### PR TITLE
Lagovas/poison key isolation

### DIFF
--- a/cmd/acra_genkeys/acra_genkeys.go
+++ b/cmd/acra_genkeys/acra_genkeys.go
@@ -19,8 +19,9 @@ import (
 	"github.com/cossacklabs/acra/cmd"
 	"github.com/cossacklabs/acra/keystore"
 	"github.com/cossacklabs/acra/utils"
-	"github.com/cossacklabs/themis/gothemis/keys"
 	"os"
+	"path/filepath"
+	"strings"
 )
 
 var DEFAULT_CONFIG_PATH = utils.GetConfigPathByName("acra_genkeys")
@@ -37,7 +38,10 @@ func main() {
 		fmt.Printf("Error: %v\n", utils.ErrorMessage("Can't parse args", err))
 		os.Exit(1)
 	}
-
+	if strings.Contains(*client_id, string(filepath.Separator)) {
+		fmt.Println("Error: client id can't contain directory separator")
+		os.Exit(1)
+	}
 	store, err := keystore.NewFilesystemKeyStore(*output_dir)
 	if err != nil {
 		panic(err)

--- a/keystore/filesystem_store.go
+++ b/keystore/filesystem_store.go
@@ -23,6 +23,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"path/filepath"
 	"runtime"
 	"sync"
 )
@@ -35,13 +36,13 @@ type FilesystemKeyStore struct {
 }
 
 const (
-	POISON_KEY_FILENAME = "poison_key"
+	POISON_KEY_FILENAME = ".poison_key/poison_key"
 )
 
 func NewFilesystemKeyStore(directory string) (*FilesystemKeyStore, error) {
 	fi, err := os.Stat(directory)
 	if nil == err && runtime.GOOS == "linux" && fi.Mode().Perm().String() != "-rwx------" {
-		log.Printf("Error: key store folder has an incorrect permissions")
+		log.Println("Error: key store folder has an incorrect permissions")
 		return nil, errors.New("key store folder has an incorrect permissions")
 	}
 	return &FilesystemKeyStore{directory: directory, keys: make(map[string][]byte)}, nil
@@ -72,7 +73,8 @@ func (store *FilesystemKeyStore) generate_key_pair(filename string) (*keys.Keypa
 	if err != nil {
 		return nil, err
 	}
-	err = os.MkdirAll(store.directory, 0700)
+	dirpath := filepath.Dir(store.get_file_path(filename))
+	err = os.MkdirAll(dirpath, 0700)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
store poison key in separate folder in keys dir to avoid collision if client id will be <poison_key>
anyway now can't be created key with name ".poison_key" as it's directory name for poison key. i think it's would be enough