### PR TITLE
check block size in secure session initialization

### DIFF
--- a/cmd/acraproxy/acraproxy.go
+++ b/cmd/acraproxy/acraproxy.go
@@ -74,7 +74,7 @@ func NewClientSession(config *Config) (*session.SecureSession, error) {
 }
 
 func initializeSecureSession(config *Config, connection net.Conn) (*session.SecureSession, error) {
-	err := SendData(config.ClientId, connection)
+	err := SendSessionData(config.ClientId, connection)
 	if err != nil {
 		return nil, err
 	}
@@ -87,12 +87,12 @@ func initializeSecureSession(config *Config, connection net.Conn) (*session.Secu
 	if err != nil {
 		return nil, err
 	}
-	err = SendData(connect_request, connection)
+	err = SendSessionData(connect_request, connection)
 	if err != nil {
 		return nil, err
 	}
 	for {
-		data, err := ReadData(connection)
+		data, err := ReadSessionData(connection)
 		if err != nil {
 			return nil, err
 		}
@@ -106,7 +106,7 @@ func initializeSecureSession(config *Config, connection net.Conn) (*session.Secu
 			return ssession, nil
 		}
 
-		err = SendData(buf, connection)
+		err = SendSessionData(buf, connection)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/acraserver/listener.go
+++ b/cmd/acraserver/listener.go
@@ -49,7 +49,7 @@ func NewServer(config *Config) (server *SServer, err error) {
  read client_id, load public key for this client and initialize Secure Session
 */
 func (server *SServer) initSSession(connection net.Conn) ([]byte, *ClientSession, error) {
-	client_id, err := ReadData(connection)
+	client_id, err := ReadSessionData(connection)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -67,7 +67,7 @@ func (server *SServer) initSSession(connection net.Conn) ([]byte, *ClientSession
 	}
 	client_session.session = ssession
 	for {
-		data, err := ReadData(connection)
+		data, err := ReadSessionData(connection)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -79,7 +79,7 @@ func (server *SServer) initSSession(connection net.Conn) ([]byte, *ClientSession
 			return client_id, client_session, nil
 		}
 
-		err = SendData(buf, connection)
+		err = SendSessionData(buf, connection)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -129,7 +129,10 @@ func (server *SServer) handleConnection(connection net.Conn) {
 	client_id, client_session, err := server.initSSession(connection)
 	if err != nil {
 		log.Printf("Warning: %v\n", ErrorMessage("can't initialize secure session with acraproxy", err))
-		connection.Close()
+		err = connection.Close()
+		if err != nil {
+			log.Printf("Warning: %v\n", ErrorMessage("can't close connection", err))
+		}
 		return
 	}
 	defer client_session.session.Close()
@@ -165,7 +168,7 @@ func (server *SServer) Start() {
  read client_id, load public key for this client and initialize Secure Session
 */
 func (server *SServer) initCommandsSSession(connection net.Conn) (*ClientCommandsSession, error) {
-	client_id, err := ReadData(connection)
+	client_id, err := ReadSessionData(connection)
 	if err != nil {
 		return nil, err
 	}
@@ -186,7 +189,7 @@ func (server *SServer) initCommandsSSession(connection net.Conn) (*ClientCommand
 		return nil, err
 	}
 	for {
-		data, err := ReadData(connection)
+		data, err := ReadSessionData(connection)
 		if err != nil {
 			return nil, err
 		}
@@ -198,7 +201,7 @@ func (server *SServer) initCommandsSSession(connection net.Conn) (*ClientCommand
 			return client_session, nil
 		}
 
-		err = SendData(buf, connection)
+		err = SendSessionData(buf, connection)
 		if err != nil {
 			return nil, err
 		}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -30,6 +30,13 @@ import (
 	"strings"
 )
 
+const (
+	SESSION_DATA_LIMIT = 8 * 1024 // 8 kb
+)
+
+var ErrBigDataBlockSize = errors.New(
+	fmt.Sprintf("Block size greater than %v", SESSION_DATA_LIMIT))
+
 func WriteFull(data []byte, wr io.Writer) (int, error) {
 	/* write data to io.Writer. if wr.Write will return n <= len(data) will
 	sent the rest of data until error or total sent byte count == len(data)
@@ -63,6 +70,24 @@ func SendData(data []byte, conn io.Writer) error {
 	return nil
 }
 
+func SendSessionData(data []byte, conn io.Writer) error {
+	// as SendData but check that data block less than SESSION_DATA_LIMIT
+	if len(data) > SESSION_DATA_LIMIT {
+		return ErrBigDataBlockSize
+	}
+	var buf [4]byte
+	binary.LittleEndian.PutUint32(buf[:], uint32(len(data)))
+	_, err := WriteFull(buf[:], conn)
+	if err != nil {
+		return err
+	}
+	_, err = WriteFull(data, conn)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func ReadData(reader io.Reader) ([]byte, error) {
 	var length [4]byte
 	_, err := io.ReadFull(reader, length[:])
@@ -70,6 +95,25 @@ func ReadData(reader io.Reader) ([]byte, error) {
 		return nil, err
 	}
 	data_size := int(binary.LittleEndian.Uint32(length[:]))
+	buf := make([]byte, data_size)
+	_, err = io.ReadFull(reader, buf)
+	if err != nil {
+		return nil, err
+	}
+	return buf, nil
+}
+
+func ReadSessionData(reader io.Reader) ([]byte, error) {
+	// as ReadData but check that data block less than SESSION_DATA_LIMIT
+	var length [4]byte
+	_, err := io.ReadFull(reader, length[:])
+	if err != nil {
+		return nil, err
+	}
+	data_size := int(binary.LittleEndian.Uint32(length[:]))
+	if data_size > SESSION_DATA_LIMIT {
+		return nil, ErrBigDataBlockSize
+	}
 	buf := make([]byte, data_size)
 	_, err = io.ReadFull(reader, buf)
 	if err != nil {


### PR DESCRIPTION
check block size in secure session initialization and close connections if too big sizes
Fixes #73
Fixes #74