### PR TITLE
Remove obsolete libssl1.0.2 dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,13 +68,8 @@ MAINTAINER = "Cossack Labs Limited <dev@cossacklabs.com>"
 LICENSE_NAME = "Apache License Version 2.0"
 
 DEBIAN_CODENAME := $(shell lsb_release -cs 2> /dev/null)
-DEBIAN_STRETCH_VERSION := libssl1.0.2
 DEBIAN_ARCHITECTURE = `dpkg --print-architecture 2>/dev/null`
-ifeq ($(DEBIAN_CODENAME),stretch)
-        DEBIAN_DEPENDENCIES := --depends $(DEBIAN_STRETCH_VERSION) --depends libthemis
-else
-        DEBIAN_DEPENDENCIES := --depends openssl --depends libthemis
-endif
+DEBIAN_DEPENDENCIES := --depends openssl --depends libthemis
 RPM_DEPENDENCIES = --depends openssl --depends libthemis
 
 ifeq ($(shell lsb_release -is 2> /dev/null),Debian)


### PR DESCRIPTION
Remove obsolete dependency libssl1.0.2 for debian stretch which was required by libthemis < 0.10.0.