### PR TITLE
use one global keystore

### DIFF
--- a/cmd/acraserver/acraserver.go
+++ b/cmd/acraserver/acraserver.go
@@ -143,7 +143,7 @@ func main() {
 		}
 	}
 
-	server, err := NewServer(config)
+	server, err := NewServer(config, keyStore)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/acraserver/client_commands_session.go
+++ b/cmd/acraserver/client_commands_session.go
@@ -28,7 +28,6 @@ import (
 
 type ClientCommandsSession struct {
 	ClientSession
-	//	keystorage keystore.KeyStore
 }
 
 func NewClientCommandsSession(keystorage keystore.KeyStore, config *Config, connection net.Conn) (*ClientCommandsSession, error) {

--- a/cmd/acraserver/client_session.go
+++ b/cmd/acraserver/client_session.go
@@ -23,12 +23,10 @@ import (
 	"github.com/cossacklabs/acra/decryptor/postgresql"
 	"github.com/cossacklabs/acra/keystore"
 	"github.com/cossacklabs/acra/utils"
-	"github.com/cossacklabs/themis/gothemis/session"
 	"io"
 )
 
 type ClientSession struct {
-	session        *session.SecureSession
 	config         *Config
 	keystorage     keystore.KeyStore
 	connection     net.Conn


### PR DESCRIPTION
* drop creation new keystore in server constructor
* drop redundant session fields. now session implemented via connection wrappers