### PR TITLE
move process.kill into try/except

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -80,6 +80,9 @@ def stop_process(process):
     for p in process:
         try:
             p.wait(timeout=KILL_WAIT_TIMEOUT)
+        except:
+            pass
+        try:
             p.kill()
         except:
             pass

--- a/tests/test.py
+++ b/tests/test.py
@@ -80,9 +80,9 @@ def stop_process(process):
     for p in process:
         try:
             p.wait(timeout=KILL_WAIT_TIMEOUT)
+            p.kill()
         except:
             pass
-        p.kill()
 
 
 def get_connect_args(port=5432, sslmode='require', **kwargs):


### PR DESCRIPTION
python raise an exception on os.kill when a process with such pid not exists (it may be when process.terminate was successful) so handle this case