### PR TITLE
custom logging 101

### DIFF
--- a/cmd/acra_addzone/acra_addzone.go
+++ b/cmd/acra_addzone/acra_addzone.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cossacklabs/themis/gothemis/keys"
 	log "github.com/sirupsen/logrus"
 	"os"
+	"github.com/cossacklabs/acra/logging"
 )
 
 // DEFAULT_CONFIG_PATH relative path to config which will be parsed as default
@@ -32,7 +33,7 @@ func main() {
 	outputDir := flag.String("output_dir", keystore.DEFAULT_KEY_DIR_SHORT, "Folder where will be saved generated zone keys")
 	fsKeystore := flag.Bool("fs", true, "Use filesystem key store")
 
-	cmd.SetLogLevel(cmd.LOG_VERBOSE)
+	logging.SetLogLevel(logging.LOG_VERBOSE)
 
 	err := cmd.Parse(DEFAULT_CONFIG_PATH)
 	if err != nil {

--- a/cmd/acra_configui/acra_configui.go
+++ b/cmd/acra_configui/acra_configui.go
@@ -15,7 +15,7 @@ import (
 	"flag"
 	log "github.com/sirupsen/logrus"
 	"github.com/cossacklabs/acra/utils"
-	"github.com/cossacklabs/acra/cmd"
+	"github.com/cossacklabs/acra/logging"
 )
 
 var acraHost *string
@@ -168,9 +168,9 @@ func main() {
 	flag.Parse()
 
 	if *debug {
-		cmd.SetLogLevel(cmd.LOG_DEBUG)
+		logging.SetLogLevel(logging.LOG_DEBUG)
 	} else {
-		cmd.SetLogLevel(cmd.LOG_VERBOSE)
+		logging.SetLogLevel(logging.LOG_VERBOSE)
 	}
 
 	http.HandleFunc("/index.html", index)

--- a/cmd/acra_genkeys/acra_genkeys.go
+++ b/cmd/acra_genkeys/acra_genkeys.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cossacklabs/acra/utils"
 	log "github.com/sirupsen/logrus"
 	"os"
+	"github.com/cossacklabs/acra/logging"
 )
 
 // DEFAULT_CONFIG_PATH relative path to config which will be parsed as default
@@ -32,7 +33,7 @@ func main() {
 	dataKeys := flag.Bool("storage", false, "Create keypair for data encryption/decryption")
 	outputDir := flag.String("output", keystore.DEFAULT_KEY_DIR_SHORT, "Folder where will be saved keys")
 
-	cmd.SetLogLevel(cmd.LOG_VERBOSE)
+	logging.SetLogLevel(logging.LOG_VERBOSE)
 
 	err := cmd.Parse(DEFAULT_CONFIG_PATH)
 	if err != nil {

--- a/cmd/acra_genpoisonrecord/acra_genpoisonrecord.go
+++ b/cmd/acra_genpoisonrecord/acra_genpoisonrecord.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cossacklabs/acra/utils"
 	log "github.com/sirupsen/logrus"
 	"os"
+	"github.com/cossacklabs/acra/logging"
 )
 
 // DEFAULT_CONFIG_PATH relative path to config which will be parsed as default
@@ -32,7 +33,7 @@ func main() {
 	keysDir := flag.String("keys_dir", keystore.DEFAULT_KEY_DIR_SHORT, "Folder from which will be loaded keys")
 	dataLength := flag.Int("data_length", poison.DEFAULT_DATA_LENGTH, fmt.Sprintf("Length of random data for data block in acrastruct. -1 is random in range 1..%v", poison.MAX_DATA_LENGTH))
 
-	cmd.SetLogLevel(cmd.LOG_DISCARD)
+	logging.SetLogLevel(logging.LOG_DISCARD)
 
 	err := cmd.Parse(DEFAULT_CONFIG_PATH)
 	if err != nil {

--- a/cmd/acra_rollback/acra_rollback.go
+++ b/cmd/acra_rollback/acra_rollback.go
@@ -30,6 +30,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"os"
 	"strings"
+	"github.com/cossacklabs/acra/logging"
 )
 
 // DEFAULT_CONFIG_PATH relative path to config which will be parsed as default
@@ -150,7 +151,7 @@ func main() {
 	execute := flag.Bool("execute", false, "Execute inserts")
 	escapeFormat := flag.Bool("escape", false, "Escape bytea format")
 
-	cmd.SetLogLevel(cmd.LOG_VERBOSE)
+	logging.SetLogLevel(logging.LOG_VERBOSE)
 
 	err := cmd.Parse(DEFAULT_CONFIG_PATH)
 	if err != nil {

--- a/cmd/acraproxy/acraproxy.go
+++ b/cmd/acraproxy/acraproxy.go
@@ -33,10 +33,12 @@ import (
 	"github.com/cossacklabs/acra/keystore"
 	"github.com/cossacklabs/acra/network"
 	"github.com/cossacklabs/acra/utils"
+	"github.com/cossacklabs/acra/logging"
 )
 
 // DEFAULT_CONFIG_PATH relative path to config which will be parsed as default
-var DEFAULT_CONFIG_PATH = utils.GetConfigPathByName("acraproxy")
+var SERVICE_NAME = "acraproxy"
+var DEFAULT_CONFIG_PATH = utils.GetConfigPathByName(SERVICE_NAME)
 
 func handleClientConnection(config *Config, connection net.Conn) {
 	defer connection.Close()
@@ -143,12 +145,15 @@ func main() {
 	connectionAPIString := flag.String("connection_api_string", network.BuildConnectionString(cmd.DEFAULT_PROXY_CONNECTION_PROTOCOL, cmd.DEFAULT_PROXY_HOST, cmd.DEFAULT_PROXY_API_PORT, ""), "Connection string like tcp://x.x.x.x:yyyy or unix:///path/to/socket")
 	acraConnectionString := flag.String("acra_connection_string", "", "Connection string to Acra server like tcp://x.x.x.x:yyyy or unix:///path/to/socket")
 	acraApiConnectionString := flag.String("acra_api_connection_string", "", "Connection string to Acra's API like tcp://x.x.x.x:yyyy or unix:///path/to/socket")
+	loggingFormat := flag.String("logging_format", "", "Logging format: plaintext, json or CEF")
 
 	err := cmd.Parse(DEFAULT_CONFIG_PATH)
 	if err != nil {
 		log.WithError(err).Errorln("can't parse args")
 		os.Exit(1)
 	}
+
+	logging.CustomizeLogger(*loggingFormat, SERVICE_NAME)
 
 	if *port != cmd.DEFAULT_PROXY_PORT {
 		*connectionString = network.BuildConnectionString(cmd.DEFAULT_PROXY_CONNECTION_PROTOCOL, cmd.DEFAULT_PROXY_HOST, *port, "")
@@ -198,9 +203,9 @@ func main() {
 	}
 
 	if *verbose {
-		cmd.SetLogLevel(cmd.LOG_VERBOSE)
+		logging.SetLogLevel(logging.LOG_VERBOSE)
 	} else {
-		cmd.SetLogLevel(cmd.LOG_DISCARD)
+		logging.SetLogLevel(logging.LOG_DISCARD)
 	}
 	if runtime.GOOS != "linux" {
 		*disableUserCheck = true

--- a/cmd/acraserver/acraserver.go
+++ b/cmd/acraserver/acraserver.go
@@ -24,11 +24,13 @@ import (
 	"github.com/cossacklabs/acra/keystore"
 	"github.com/cossacklabs/acra/network"
 	"github.com/cossacklabs/acra/utils"
+	"github.com/cossacklabs/acra/logging"
 	log "github.com/sirupsen/logrus"
 )
 
 // DEFAULT_CONFIG_PATH relative path to config which will be parsed as default
-var DEFAULT_CONFIG_PATH = utils.GetConfigPathByName("acraserver")
+var SERVICE_NAME = "acraserver"
+var DEFAULT_CONFIG_PATH = utils.GetConfigPathByName(SERVICE_NAME)
 
 func main() {
 	dbHost := flag.String("db_host", "", "Host to db")
@@ -67,6 +69,7 @@ func main() {
 	clientId := flag.String("client_id", "", "Expected client id of acraproxy in mode without encryption")
 	acraConnectionString := flag.String("connection_string", network.BuildConnectionString(cmd.DEFAULT_ACRA_CONNECTION_PROTOCOL, cmd.DEFAULT_ACRA_HOST, cmd.DEFAULT_ACRA_PORT, ""), "Connection string like tcp://x.x.x.x:yyyy or unix:///path/to/socket")
 	acraAPIConnectionString := flag.String("connection_api_string", network.BuildConnectionString(cmd.DEFAULT_ACRA_CONNECTION_PROTOCOL, cmd.DEFAULT_ACRA_HOST, cmd.DEFAULT_ACRA_API_PORT, ""), "Connection string for api like tcp://x.x.x.x:yyyy or unix:///path/to/socket")
+	loggingFormat := flag.String("logging_format", "", "Logging format: plaintext, json or CEF")
 
 	err := cmd.Parse(DEFAULT_CONFIG_PATH)
 	if err != nil {
@@ -74,6 +77,7 @@ func main() {
 		os.Exit(1)
 	}
 
+	logging.CustomizeLogger(*loggingFormat, SERVICE_NAME)
 	cmd.ValidateClientId(*serverId)
 
 	if *host != cmd.DEFAULT_ACRA_HOST || *port != cmd.DEFAULT_ACRA_PORT {
@@ -84,11 +88,11 @@ func main() {
 	}
 
 	if *debug {
-		cmd.SetLogLevel(cmd.LOG_DEBUG)
+		logging.SetLogLevel(logging.LOG_DEBUG)
 	} else if *verbose {
-		cmd.SetLogLevel(cmd.LOG_VERBOSE)
+		logging.SetLogLevel(logging.LOG_VERBOSE)
 	} else {
-		cmd.SetLogLevel(cmd.LOG_DISCARD)
+		logging.SetLogLevel(logging.LOG_DISCARD)
 	}
 	if *dbHost == "" {
 		log.Errorln("you must specify db_host")

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -22,12 +22,6 @@ var (
 	dumpconfig = flag_.Bool("dumpconfig", false, "dump config")
 )
 
-const (
-	LOG_DEBUG = iota
-	LOG_VERBOSE
-	LOG_DISCARD
-)
-
 func init() {
 	// override default usage message by ours
 	flag_.CommandLine.Usage = PrintDefaults
@@ -236,14 +230,3 @@ func Parse(configPath string) error {
 	return nil
 }
 
-func SetLogLevel(level int) {
-	if level == LOG_DEBUG {
-		log.SetLevel(log.DebugLevel)
-	} else if level == LOG_VERBOSE {
-		log.SetLevel(log.InfoLevel)
-	} else if level == LOG_DISCARD {
-		log.SetLevel(log.WarnLevel)
-	} else {
-		panic(fmt.Sprintf("Incorrect log level - %v", level))
-	}
-}

--- a/configs/acraproxy.yaml
+++ b/configs/acraproxy.yaml
@@ -67,3 +67,5 @@ v: false
 # Turn on zone mode
 zonemode: false
 
+# Logging format (plaintext, json, CEF)
+logging_format: plaintext

--- a/configs/acraserver.yaml
+++ b/configs/acraserver.yaml
@@ -85,3 +85,6 @@ wholecell: true
 # Turn on zone mode
 zonemode: false
 
+# Logging format (plaintext, json, CEF)
+logging_format: plaintext
+

--- a/logging/log_formatters.go
+++ b/logging/log_formatters.go
@@ -1,0 +1,141 @@
+package logging
+
+import (
+	"github.com/sirupsen/logrus"
+	"time"
+	"sync"
+	"github.com/cossacklabs/acra/utils"
+)
+
+
+// ---------- custom Loggers
+// inspired by "github.com/bshuster-repo/logrus-logstash-hook"
+// ----------
+
+
+// CustomTextFormatter returns a default logrus.TextFormatter with specific settings
+func CustomTextFormatter() logrus.Formatter {
+	return &logrus.TextFormatter{
+		FullTimestamp:    true,
+		TimestampFormat:  time.RFC3339Nano,
+		QuoteEmptyFields: true,
+		ForceColors:      true}
+}
+
+
+// CustomJSONFormatter returns a AcraJSON formatter
+func CustomJSONFormatter(fields logrus.Fields) logrus.Formatter {
+	for k, v := range extraJSONFields {
+		if _, ok := fields[k]; !ok {
+			fields[k] = v
+		}
+	}
+
+	return AcraCustomJSONFormatter{
+		Formatter: &logrus.JSONFormatter{
+			FieldMap:        JSONFieldMap,
+			TimestampFormat: time.RFC3339Nano,
+		},
+		Fields: fields,
+	}
+}
+
+
+// CustomCEFFormatter returns a AcraCEF formatter
+func CustomCEFFormatter(fields logrus.Fields) logrus.Formatter {
+	for k, v := range extraJSONFields {
+		if _, ok := fields[k]; !ok {
+			fields[k] = v
+		}
+	}
+
+	return AcraCustomCEFFormatter{
+		Formatter: &logrus.TextFormatter {
+			FullTimestamp:    true,
+			TimestampFormat: time.RFC3339Nano,
+		},
+		Fields: fields,
+	}
+}
+
+
+
+// ---------------------------
+
+// Using a pool to re-use of old entries when formatting Logstash messages.
+// It is used in the Fire function.
+var entryPool = sync.Pool{
+	New: func() interface{} {
+		return &logrus.Entry{}
+	},
+}
+
+// copyEntry copies the entry `e` to a new entry and then adds all the fields in `fields` that are missing in the new entry data.
+// It uses `entryPool` to re-use allocated entries.
+func copyEntry(e *logrus.Entry, fields logrus.Fields) *logrus.Entry {
+	ne := entryPool.Get().(*logrus.Entry)
+	ne.Message = e.Message
+	ne.Level = e.Level
+	ne.Time = e.Time
+	ne.Data = logrus.Fields{}
+	for k, v := range fields {
+		ne.Data[k] = v
+	}
+	for k, v := range e.Data {
+		ne.Data[k] = v
+	}
+	return ne
+}
+
+// releaseEntry puts the given entry back to `entryPool`. It must be called if copyEntry is called.
+func releaseEntry(e *logrus.Entry) {
+	entryPool.Put(e)
+}
+
+// AcraCustomFormatter represents a format with specific fields.
+// It has logrus.Formatter which formats the entry and logrus.Fields which
+// are added to the JSON/CEF message if not given in the entry data.
+//
+// Note: use the `CustomJSONFormatter` function to set a default AcraJSON formatter.
+type AcraCustomJSONFormatter struct {
+	logrus.Formatter
+	logrus.Fields
+}
+
+type AcraCustomCEFFormatter struct {
+	logrus.Formatter
+	logrus.Fields
+}
+
+var (
+	extraJSONFields = logrus.Fields{"product": "acra", "version": utils.VERSION} // to be re-defined
+	JSONFieldMap    = logrus.FieldMap{
+		logrus.FieldKeyTime:  "timestamp",
+		logrus.FieldKeyMsg:   "msg",
+		logrus.FieldKeyLevel: "severity",
+	}
+)
+
+
+// Format formats an entry to a AcraJSON format according to the given Formatter and Fields.
+//
+// Note: the given entry is copied and not changed during the formatting process.
+func (f AcraCustomJSONFormatter) Format(e *logrus.Entry) ([]byte, error) {
+	ne := copyEntry(e, f.Fields)
+	dataBytes, err := f.Formatter.Format(ne)
+	releaseEntry(ne)
+	return dataBytes, err
+}
+
+
+// TODO: change how we format strings
+// Format formats an entry to a AcraCEF format according to the given Formatter and Fields.
+//
+// Note: the given entry is copied and not changed during the formatting process.
+func (f AcraCustomCEFFormatter) Format(e *logrus.Entry) ([]byte, error) {
+	ne := copyEntry(e, f.Fields)
+	dataBytes, err := f.Formatter.Format(ne)
+	releaseEntry(ne)
+	return dataBytes, err
+}
+

--- a/logging/log_formatters.go
+++ b/logging/log_formatters.go
@@ -30,7 +30,7 @@ func JSONFormatter(fields logrus.Fields) logrus.Formatter {
 		}
 	}
 
-	return JSONFormatter{
+	return AcraJSONFormatter{
 		Formatter: &logrus.JSONFormatter{
 			FieldMap:        JSONFieldMap,
 			TimestampFormat: time.RFC3339Nano,
@@ -48,7 +48,7 @@ func CustomCEFFormatter(fields logrus.Fields) logrus.Formatter {
 		}
 	}
 
-	return CEFFormatter{
+	return AcraCEFFormatter{
 		Formatter: &logrus.TextFormatter {
 			FullTimestamp:    true,
 			TimestampFormat: time.RFC3339Nano,

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -1,0 +1,60 @@
+// Copyright 2016, Cossack Labs Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package logging
+
+import (
+	"fmt"
+	log "github.com/sirupsen/logrus"
+	"strings"
+	"os"
+)
+
+
+const (
+	LOG_DEBUG = iota
+	LOG_VERBOSE
+	LOG_DISCARD
+)
+
+func SetLogLevel(level int) {
+	if level == LOG_DEBUG {
+		log.SetLevel(log.DebugLevel)
+	} else if level == LOG_VERBOSE {
+		log.SetLevel(log.InfoLevel)
+	} else if level == LOG_DISCARD {
+		log.SetLevel(log.WarnLevel)
+	} else {
+		panic(fmt.Sprintf("Incorrect log level - %v", level))
+	}
+}
+
+func CustomizeLogger(loggingFormat string, serviceName string) {
+	log.SetOutput(os.Stderr)
+	log.SetFormatter(LogFormatterFor(loggingFormat, serviceName))
+
+	log.Infof("changed logging format to %s", loggingFormat)
+}
+
+func LogFormatterFor(loggingFormat string, serviceName string) log.Formatter {
+	loggingFormat = strings.ToLower(loggingFormat)
+
+	if loggingFormat == "json" {
+		return CustomJSONFormatter(log.Fields{"product": serviceName})
+
+	} else if loggingFormat == "cef" {
+		return CustomCEFFormatter(log.Fields{"product": serviceName})
+	}
+
+	return CustomTextFormatter()
+}

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -50,11 +50,11 @@ func LogFormatterFor(loggingFormat string, serviceName string) log.Formatter {
 	loggingFormat = strings.ToLower(loggingFormat)
 
 	if loggingFormat == "json" {
-		return CustomJSONFormatter(log.Fields{"product": serviceName})
+		return JSONFormatter(log.Fields{"product": serviceName})
 
 	} else if loggingFormat == "cef" {
 		return CustomCEFFormatter(log.Fields{"product": serviceName})
 	}
 
-	return CustomTextFormatter()
+	return TextFormatter()
 }

--- a/utils/logging.go
+++ b/utils/logging.go
@@ -15,6 +15,9 @@ package utils
 
 import "fmt"
 
+
+// TODO: move to /logging and refactor everything
+
 // function for standartizing custom messages with messages from error
 func ErrorMessage(msg string, err error) string {
 	return fmt.Sprintf("%v (error message - %v)", msg, err)

--- a/utils/version.go
+++ b/utils/version.go
@@ -2,4 +2,3 @@ package utils
 
 
 var VERSION string = "0.76" // change on current during build
-func main(){}

--- a/utils/version.go
+++ b/utils/version.go
@@ -1,0 +1,5 @@
+package utils
+
+
+var VERSION string = "0.76" // change on current during build
+func main(){}


### PR DESCRIPTION
First changes in new logging.

## `acraserver` and `acraproxy` changes:

1.  now have new config variable that allows to customize log format
`logging_format: plaintext` | `logging_format: json` | `logging_format: cef`

2. on `main()` customize Logger according to `logging_format`

3. CEF format is not well-implemented yet, I've added interface that works similar to TextFormatter

4. Each log contains required fields (as discussed in T376): msg, severity, timestamp, product, version.

## refactoring

1. new `logging` package created
2. `SetLogLevel` moved to `logging` from `cmd`
3. `version.go` file created

## Logs examples

JSON:

```
API server listening at: 127.0.0.1:60083
{"msg":"changed logging format to json","product":"acraserver","severity":"info","timestamp":"2018-03-14T18:02:09.495669863+02:00","version":"0.76"}
{"code":"123","msg":"log with code","product":"acraserver","severity":"info","timestamp":"2018-03-14T18:02:09.495870084+02:00","version":"0.76"}
{"msg":"i'm tiny log here, using logging format json","product":"acraserver","severity":"info","timestamp":"2018-03-14T18:02:09.495905957+02:00","version":"0.76"}
{"msg":"use Secure Session transport wrapper","product":"acraserver","severity":"info","timestamp":"2018-03-14T18:02:09.495960067+02:00","version":"0.76"}
{"msg":"start listening tcp://0.0.0.0:9393/","product":"acraserver","severity":"info","timestamp":"2018-03-14T18:02:09.496306267+02:00","version":"0.76"}
```


Plaintext:

```
API server listening at: 127.0.0.1:60115
INFO[2018-03-14T18:04:18.900221018+02:00] changed logging format to plaintext          
INFO[2018-03-14T18:04:18.900363409+02:00] log with code                                 code=123
INFO[2018-03-14T18:04:18.900379439+02:00] i'm tiny log here, using logging format plaintext 
INFO[2018-03-14T18:04:18.900402328+02:00] use Secure Session transport wrapper         
INFO[2018-03-14T18:04:18.900748933+02:00] start listening tcp://0.0.0.0:9393/          
```


CEF (correct formatting is not implemented yet):
```
API server listening at: 127.0.0.1:60095
time="2018-03-14T18:02:50.821499407+02:00" level=info msg="changed logging format to cef" product=acraserver version=0.76
time="2018-03-14T18:02:50.821641325+02:00" level=info msg="log with code" code=123 product=acraserver version=0.76
time="2018-03-14T18:02:50.82171267+02:00" level=info msg="i'm tiny log here, using logging format cef" product=acraserver version=0.76
time="2018-03-14T18:02:50.821764261+02:00" level=info msg="use Secure Session transport wrapper" product=acraserver version=0.76
time="2018-03-14T18:02:50.822050098+02:00" level=info msg="start listening tcp://0.0.0.0:9393/" product=acraserver version=0.76
```


# Next steps:

CEF formatter, change `severity` level regarding to CEF (0..10)