### PR TITLE
logging in CEF format

### DIFF
--- a/cmd/acraproxy/acraproxy.go
+++ b/cmd/acraproxy/acraproxy.go
@@ -153,7 +153,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	logging.CustomizeLogger(*loggingFormat, SERVICE_NAME)
+	logging.CustomizeLogging(*loggingFormat, SERVICE_NAME)
 
 	if *port != cmd.DEFAULT_PROXY_PORT {
 		*connectionString = network.BuildConnectionString(cmd.DEFAULT_PROXY_CONNECTION_PROTOCOL, cmd.DEFAULT_PROXY_HOST, *port, "")

--- a/cmd/acraserver/acraserver.go
+++ b/cmd/acraserver/acraserver.go
@@ -77,7 +77,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	logging.CustomizeLogger(*loggingFormat, SERVICE_NAME)
+	logging.CustomizeLogging(*loggingFormat, SERVICE_NAME)
 	cmd.ValidateClientId(*serverId)
 
 	if *host != cmd.DEFAULT_ACRA_HOST || *port != cmd.DEFAULT_ACRA_PORT {

--- a/logging/cef_formatter.go
+++ b/logging/cef_formatter.go
@@ -1,0 +1,212 @@
+package logging
+
+import (
+	"bytes"
+	"fmt"
+	"time"
+	"sync"
+	"github.com/sirupsen/logrus"
+	"strings"
+)
+
+// Almost compatible with CEF doc
+// https://kc.mcafee.com/resources/sites/MCAFEE/content/live/CORP_KNOWLEDGEBASE/78000/KB78712/en_US/CEF_White_Paper_20100722.pdf
+//
+// Current implementation allows using any extension keys
+//
+
+const defaultTimestampFormat = time.RFC3339
+const defaultCEFLogStart = "CEF:0"
+const defaultHostName = "host"
+const defaultMessageDivider = "|"
+
+// Default key names for the default fields
+const (
+	FieldKeyUnixTime = "unixTime"
+	FieldKeyProduct  = "product"
+	FieldKeyVersion  = "version"
+	FieldKeySeverity = "severity"
+	FieldKeyVendor   = "vendor"
+	FieldKeyCode     = "code"
+)
+
+// CEFTextFormatter formats logs into text
+type CEFTextFormatter struct {
+	// Enable logging the full timestamp when a TTY is attached instead of just
+	// the time passed since beginning of execution.
+	FullTimestamp bool
+
+	// TimestampFormat to use for display when a full timestamp is printed
+	TimestampFormat string
+
+	// QuoteEmptyFields will wrap empty fields in quotes if true
+	QuoteEmptyFields bool
+
+	// By default 'CEF:0'
+	CEFPrefixString string
+
+	// By default 'host'
+	HostName string
+
+	// start log with syslog prefix automatically
+	ShouldAddSyslogPrefix bool
+
+	sync.Once
+}
+
+func (f *CEFTextFormatter) init(entry *logrus.Entry) {
+	f.ShouldAddSyslogPrefix = false
+}
+
+// Format renders a single log entry
+func (f *CEFTextFormatter) Format(entry *logrus.Entry) ([]byte, error) {
+	var b *bytes.Buffer
+
+	if entry.Buffer != nil {
+		b = entry.Buffer
+	} else {
+		b = &bytes.Buffer{}
+	}
+
+	f.Do(func() { f.init(entry) })
+
+	timestampFormat := f.TimestampFormat
+	if timestampFormat == "" {
+		timestampFormat = defaultTimestampFormat
+	}
+
+	hostname := f.HostName
+	if hostname == "" {
+		hostname = defaultHostName
+	}
+
+	logPrefix := f.CEFPrefixString
+	if logPrefix == "" {
+		logPrefix = defaultCEFLogStart
+	}
+
+	// timestamp host CEF:0
+	if f.ShouldAddSyslogPrefix {
+		b.WriteString(entry.Time.Format(timestampFormat))
+		b.WriteByte(' ')
+		b.WriteString(hostname)
+		b.WriteByte(' ')
+	}
+	b.WriteString(defaultCEFLogStart)
+
+	// |Device Vendor|Device Product|Device Version|Signature ID|Name|Severity|
+	f.appendCEFLogPiece(b, entry.Data[FieldKeyVendor])
+	f.appendCEFLogPiece(b, entry.Data[FieldKeyProduct])
+	f.appendCEFLogPiece(b, entry.Data[FieldKeyVersion])
+	f.appendCEFLogPiece(b, entry.Data[FieldKeyCode])
+
+	f.appendCEFLogPiece(b, entry.Message)
+	f.appendCEFLogPiece(b, severityByLevel(entry.Level))
+
+	b.WriteString(defaultMessageDivider)
+
+	// Extension
+
+	// actually, these fields should have only designated names according to the Extension Dictionary of CEF
+	extensionKeys := otherExtensionKeys(entry.Data)
+	for _, key := range extensionKeys {
+		f.appendKeyValue(b, key, entry.Data[key])
+	}
+
+	b.WriteByte('\n')
+	return b.Bytes(), nil
+}
+
+func otherExtensionKeys(data logrus.Fields) []string {
+	extensionKeys := make([]string, 0, len(data))
+	for k := range data {
+
+		if k != FieldKeyVendor && k != FieldKeyProduct && k != FieldKeyVersion &&
+			k != FieldKeyCode && k != FieldKeySeverity {
+
+			extensionKeys = append(extensionKeys, k)
+		}
+	}
+	return extensionKeys
+}
+
+func (f *CEFTextFormatter) appendCEFLogPiece(b *bytes.Buffer, value interface{}) {
+	b.WriteString(defaultMessageDivider)
+	f.appendValue(b, value)
+}
+
+func (f *CEFTextFormatter) appendKeyValue(b *bytes.Buffer, key string, value interface{}) {
+	preparedKey := prepareString(key)
+
+	if f.needsQuoting(preparedKey) {
+		preparedKey = fmt.Sprintf("%q", preparedKey)
+	}
+
+	b.WriteString(preparedKey)
+	b.WriteByte('=')
+	f.appendValue(b, value)
+	b.WriteByte(' ')
+}
+
+func (f *CEFTextFormatter) appendValue(b *bytes.Buffer, value interface{}) {
+	stringVal, ok := value.(string)
+	if !ok {
+		stringVal = fmt.Sprint(value)
+	}
+
+	stringVal = prepareString(stringVal)
+
+	// CEF doesn't define using quotes
+	if len(stringVal) == 0 {
+		b.WriteString(" ")
+	} else {
+		b.WriteString(stringVal)
+	}
+}
+
+func prepareString(value string) string {
+	stringVal := fmt.Sprint(value)
+
+	// is it a valid way to remove any \t\n even inside line?
+	stringVal = strings.TrimSpace(stringVal)
+	stringVal = strings.Replace(stringVal, "\n", " ", -1)
+	stringVal = strings.Replace(stringVal, "\t", " ", -1)
+	stringVal = strings.Replace(stringVal, `\`, `\\`, -1)
+	stringVal = strings.Replace(stringVal, "|", `\|`, -1)
+	stringVal = strings.Replace(stringVal, `=`, `\=`, -1)
+	return stringVal
+}
+
+func severityByLevel(level logrus.Level) int {
+	switch level {
+	case logrus.DebugLevel:
+		return 0
+	case logrus.InfoLevel:
+		return 0
+	case logrus.WarnLevel:
+		return 3
+	case logrus.ErrorLevel:
+		return 6
+	case logrus.FatalLevel:
+		return 8
+	case logrus.PanicLevel:
+		return 10
+	}
+
+	return 0
+}
+
+func (f *CEFTextFormatter) needsQuoting(text string) bool {
+	if f.QuoteEmptyFields && len(text) == 0 {
+		return true
+	}
+	for _, ch := range text {
+		if !((ch >= 'a' && ch <= 'z') ||
+			(ch >= 'A' && ch <= 'Z') ||
+			(ch >= '0' && ch <= '9') ||
+			ch == '-' || ch == '.' || ch == '_' || ch == '/' || ch == '@' || ch == '^' || ch == '+') {
+			return true
+		}
+	}
+	return false
+}

--- a/logging/cef_formatter.go
+++ b/logging/cef_formatter.go
@@ -22,12 +22,12 @@ const defaultMessageDivider = "|"
 
 // Default key names for the default fields
 const (
-	FieldKeyUnixTime = "unixTime"
-	FieldKeyProduct  = "product"
-	FieldKeyVersion  = "version"
-	FieldKeySeverity = "severity"
-	FieldKeyVendor   = "vendor"
-	FieldKeyCode     = "code"
+	FieldKeyUnixTime  = "unixTime"
+	FieldKeyProduct   = "product"
+	FieldKeyVersion   = "version"
+	FieldKeySeverity  = "severity"
+	FieldKeyVendor    = "vendor"
+	FieldKeyEventCode = "code"
 )
 
 // CEFTextFormatter formats logs into text
@@ -98,7 +98,7 @@ func (f *CEFTextFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 	f.appendCEFLogPiece(b, entry.Data[FieldKeyVendor])
 	f.appendCEFLogPiece(b, entry.Data[FieldKeyProduct])
 	f.appendCEFLogPiece(b, entry.Data[FieldKeyVersion])
-	f.appendCEFLogPiece(b, entry.Data[FieldKeyCode])
+	f.appendCEFLogPiece(b, entry.Data[FieldKeyEventCode])
 
 	f.appendCEFLogPiece(b, entry.Message)
 	f.appendCEFLogPiece(b, severityByLevel(entry.Level))
@@ -122,7 +122,7 @@ func otherExtensionKeys(data logrus.Fields) []string {
 	for k := range data {
 
 		if k != FieldKeyVendor && k != FieldKeyProduct && k != FieldKeyVersion &&
-			k != FieldKeyCode && k != FieldKeySeverity {
+			k != FieldKeyEventCode && k != FieldKeySeverity {
 
 			extensionKeys = append(extensionKeys, k)
 		}

--- a/logging/cef_formatter.go
+++ b/logging/cef_formatter.go
@@ -52,7 +52,7 @@ type CEFTextFormatter struct {
 }
 
 func (f *CEFTextFormatter) init(entry *logrus.Entry) {
-	f.ShouldAddSyslogPrefix = true
+	f.ShouldAddSyslogPrefix = false
 	f.QuoteEmptyFields = true
 }
 

--- a/logging/cef_formatter_test.go
+++ b/logging/cef_formatter_test.go
@@ -1,0 +1,28 @@
+package logging
+
+import (
+	"testing"
+)
+
+func TestStringEscape(t *testing.T) {
+	testString := "small string"
+	modifiedString := prepareString(testString)
+
+	if modifiedString != testString {
+		t.Errorf("Incorrect CEF string escaping <%s>", modifiedString)
+	}
+
+	testString = "small | = string"
+	modifiedString = prepareString(testString)
+
+	if modifiedString != "small \\| \\= string" {
+		t.Errorf("Incorrect CEF string escaping <%s>", modifiedString)
+	}
+
+	testString = "small \t \n string"
+	modifiedString = prepareString(testString)
+
+	if modifiedString != "small     string" {
+		t.Errorf("Incorrect CEF string escaping <%s>", modifiedString)
+	}
+}

--- a/logging/log_formatters.go
+++ b/logging/log_formatters.go
@@ -5,6 +5,7 @@ import (
 	"time"
 	"sync"
 	"github.com/cossacklabs/acra/utils"
+	"fmt"
 )
 
 
@@ -124,8 +125,8 @@ var (
 
 	// to be re-defined
 	extraCEFFields = logrus.Fields{
-		FieldKeyVendor:   "cossacklabs",
-		FieldKeyCode:     0,
+		FieldKeyVendor:    "cossacklabs",
+		FieldKeyEventCode: 0,
 	}
 
 	JSONFieldMap = logrus.FieldMap{
@@ -140,7 +141,7 @@ var (
 // Note: the given entry is copied and not changed during the formatting process.
 func (f AcraJSONFormatter) Format(e *logrus.Entry) ([]byte, error) {
 	// unix time
-	f.Fields[FieldKeyUnixTime] = e.Time.Unix()
+	f.Fields[FieldKeyUnixTime] = unixTimeWithMilliseconds(e)
 
 	ne := copyEntry(e, f.Fields)
 	dataBytes, err := f.Formatter.Format(ne)
@@ -154,10 +155,20 @@ func (f AcraJSONFormatter) Format(e *logrus.Entry) ([]byte, error) {
 // Note: the given entry is copied and not changed during the formatting process.
 func (f AcraCEFFormatter) Format(e *logrus.Entry) ([]byte, error) {
 	// unix time
-	f.Fields[FieldKeyUnixTime] = e.Time.Unix()
+	f.Fields[FieldKeyUnixTime] = unixTimeWithMilliseconds(e)
 
 	ne := copyEntry(e, f.Fields)
 	dataBytes, err := f.CEFTextFormatter.Format(ne)
 	releaseEntry(ne)
 	return dataBytes, err
+}
+
+
+func unixTimeWithMilliseconds(e *logrus.Entry) string {
+	//secs := e.Time.Unix()
+	nanos := e.Time.UnixNano()
+	millis := nanos / 1000000
+	millisf := float64(millis) / 1000.0
+
+	return fmt.Sprintf("%.3f", millisf)
 }

--- a/logging/log_formatters.go
+++ b/logging/log_formatters.go
@@ -13,16 +13,17 @@ import (
 // ----------
 
 
+
 // TextFormatter returns a default logrus.TextFormatter with specific settings
 func TextFormatter() logrus.Formatter {
 	return &logrus.TextFormatter{
 		FullTimestamp:    true,
-		TimestampFormat:  time.RFC3339Nano,
+		TimestampFormat:  time.RFC3339,
 		QuoteEmptyFields: true}
 }
 
 
-// JSONFormatter returns a AcraJSON formatter
+// JSONFormatter returns a AcraJSONFormatter
 func JSONFormatter(fields logrus.Fields) logrus.Formatter {
 	for k, v := range extraJSONFields {
 		if _, ok := fields[k]; !ok {
@@ -33,25 +34,31 @@ func JSONFormatter(fields logrus.Fields) logrus.Formatter {
 	return AcraJSONFormatter{
 		Formatter: &logrus.JSONFormatter{
 			FieldMap:        JSONFieldMap,
-			TimestampFormat: time.RFC3339Nano,
+			TimestampFormat: time.RFC3339,
 		},
 		Fields: fields,
 	}
 }
 
 
-// CustomCEFFormatter returns a AcraCEF formatter
-func CustomCEFFormatter(fields logrus.Fields) logrus.Formatter {
+// CEFFormatter returns a AcraCEFFormatter
+func CEFFormatter(fields logrus.Fields) logrus.Formatter {
 	for k, v := range extraJSONFields {
 		if _, ok := fields[k]; !ok {
 			fields[k] = v
 		}
 	}
 
+	for k, v := range extraCEFFields {
+		if _, ok := fields[k]; !ok {
+			fields[k] = v
+		}
+	}
+
 	return AcraCEFFormatter{
-		Formatter: &logrus.TextFormatter {
-			FullTimestamp:    true,
-			TimestampFormat: time.RFC3339Nano,
+		CEFTextFormatter: CEFTextFormatter{
+			FullTimestamp:   true,
+			TimestampFormat: time.RFC3339,
 		},
 		Fields: fields,
 	}
@@ -91,6 +98,7 @@ func releaseEntry(e *logrus.Entry) {
 	entryPool.Put(e)
 }
 
+
 // AcraCustomFormatter represents a format with specific fields.
 // It has logrus.Formatter which formats the entry and logrus.Fields which
 // are added to the JSON/CEF message if not given in the entry data.
@@ -102,16 +110,28 @@ type AcraJSONFormatter struct {
 }
 
 type AcraCEFFormatter struct {
-	logrus.Formatter
+	CEFTextFormatter
 	logrus.Fields
 }
 
 var (
-	extraJSONFields = logrus.Fields{"product": "acra", "version": utils.VERSION} // to be re-defined
-	JSONFieldMap    = logrus.FieldMap{
+	// to be re-defined
+	extraJSONFields = logrus.Fields{
+		FieldKeyProduct:  "acra",
+		FieldKeyUnixTime: 0,
+		FieldKeyVersion:  utils.VERSION,
+	}
+
+	// to be re-defined
+	extraCEFFields = logrus.Fields{
+		FieldKeyVendor:   "cossacklabs",
+		FieldKeyCode:     0,
+	}
+
+	JSONFieldMap = logrus.FieldMap{
 		logrus.FieldKeyTime:  "timestamp",
 		logrus.FieldKeyMsg:   "msg",
-		logrus.FieldKeyLevel: "severity",
+		logrus.FieldKeyLevel: "level",
 	}
 )
 
@@ -119,6 +139,9 @@ var (
 //
 // Note: the given entry is copied and not changed during the formatting process.
 func (f AcraJSONFormatter) Format(e *logrus.Entry) ([]byte, error) {
+	// unix time
+	f.Fields[FieldKeyUnixTime] = e.Time.Unix()
+
 	ne := copyEntry(e, f.Fields)
 	dataBytes, err := f.Formatter.Format(ne)
 	releaseEntry(ne)
@@ -126,15 +149,15 @@ func (f AcraJSONFormatter) Format(e *logrus.Entry) ([]byte, error) {
 }
 
 
-// TODO: change how we format strings
-// TODO: handle severity levels
 // Format formats an entry to a AcraCEF format according to the given Formatter and Fields.
 //
 // Note: the given entry is copied and not changed during the formatting process.
 func (f AcraCEFFormatter) Format(e *logrus.Entry) ([]byte, error) {
+	// unix time
+	f.Fields[FieldKeyUnixTime] = e.Time.Unix()
+
 	ne := copyEntry(e, f.Fields)
-	dataBytes, err := f.Formatter.Format(ne)
+	dataBytes, err := f.CEFTextFormatter.Format(ne)
 	releaseEntry(ne)
 	return dataBytes, err
 }
-

--- a/logging/log_formatters.go
+++ b/logging/log_formatters.go
@@ -58,7 +58,6 @@ func CEFFormatter(fields logrus.Fields) logrus.Formatter {
 
 	return AcraCEFFormatter{
 		CEFTextFormatter: CEFTextFormatter{
-			FullTimestamp:   true,
 			TimestampFormat: time.RFC3339,
 		},
 		Fields: fields,

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -39,21 +39,21 @@ func SetLogLevel(level int) {
 	}
 }
 
-func CustomizeLogger(loggingFormat string, serviceName string) {
+func CustomizeLogging(loggingFormat string, serviceName string) {
 	log.SetOutput(os.Stderr)
-	log.SetFormatter(LogFormatterFor(loggingFormat, serviceName))
+	log.SetFormatter(logFormatterFor(loggingFormat, serviceName))
 
 	log.Infof("changed logging format to %s", loggingFormat)
 }
 
-func LogFormatterFor(loggingFormat string, serviceName string) log.Formatter {
+func logFormatterFor(loggingFormat string, serviceName string) log.Formatter {
 	loggingFormat = strings.ToLower(loggingFormat)
 
 	if loggingFormat == "json" {
-		return JSONFormatter(log.Fields{"product": serviceName})
+		return JSONFormatter(log.Fields{FieldKeyProduct: serviceName})
 
 	} else if loggingFormat == "cef" {
-		return CustomCEFFormatter(log.Fields{"product": serviceName})
+		return CEFFormatter(log.Fields{FieldKeyProduct: serviceName})
 	}
 
 	return TextFormatter()


### PR DESCRIPTION
## Updated CEF formatter.

1. Is compliant to [CEF spec](https://kc.mcafee.com/resources/sites/MCAFEE/content/live/CORP_KNOWLEDGEBASE/78000/KB78712/en_US/CEF_White_Paper_20100722.pdf), except extension dictionary fields. Currently we allow using any extension field names.

2. Added `unixTime` field to every CEF log, time in millis.

3. Escaped `\t`, `\n`, `\`, `|`, `=` characters in messages.

4. Default `Signature ID` (aka `EventCode`) is `0`. Change event code by:
	
```
log.WithField(logging.FieldKeyEventCode, "124").Infof("log with code")
```

to get log:

```
CEF:0|cossacklabs|acraserver|0.76|124|log with code|0|unixTime=1521217206.193 
```

5. Log levels are casted to `severity` field as described in [`severityByLevel`](https://github.com/cossacklabs/acra/compare/vixentael/T496-logging-cef?expand=1#diff-4c8beb689181dfcc6993e1ed14ece891R180)


## Example output
```
CEF:0|cossacklabs|acraserver|0.76|0|changed logging format to cef|0|unixTime=1521217200.337 
CEF:0|cossacklabs|acraserver|0.76|124|log with code|0|unixTime=1521217206.193 
CEF:0|cossacklabs|acraserver|0.76|0|log with extra field|0|"extra field"=13343 unixTime=1521217206.193 
CEF:0|cossacklabs|acraserver|0.76|0|i'm tiny log here\|, using logging \\format cef|0|unixTime=1521217206.193 
CEF:0|cossacklabs|acraserver|0.76|0|use Secure Session transport wrapper|0|unixTime=1521217206.193 
CEF:0|cossacklabs|acraserver|0.76|0|start listening tcp://0.0.0.0:9393/|0|unixTime=1521217206.195 
```