### PR TITLE
Fix test_rollback in integration test suit (T521)

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -1130,7 +1130,7 @@ class TestAcraRollback(BaseTestCase):
 
         self.output_filename = 'acra_rollback_output.txt'
         rollback_output_table.create(self.engine_raw, checkfirst=True)
-        if self.TLS_ON:
+        if TEST_WITH_TLS:
             self.sslmode='require'
         else:
             self.sslmode='disable'


### PR DESCRIPTION
Fix integration tests for `acra_rollback` tests in SSL enabled mode.

To manually run integration test if server is configured to use SSL:

```
TEST_TLS=on TEST_SSL_MODE=require TEST_DB_HOST=127.0.0.1 TEST_DB_USER=postgres TEST_DB_USER_PASSWORD=postgres TEST_DB_NAME=postgres TEST_DB_PORT=5432  python3 tests/test.py
```

Internal discussion, including buildbot reports:
https://ph.cossacklabs.com/T521
