### PR TITLE
More logs for acra_proxy, acra_server, acra_configui

### DIFF
--- a/.circleci/integration.sh
+++ b/.circleci/integration.sh
@@ -25,14 +25,14 @@ for version in $VERSIONS; do
     
     echo "--------------------  Testing POSTGRES with TEST_TLS=on"
 
-    python3 tests/test.py;
+    python3 tests/test.py -v;
     if [ "$?" != "0" ]; then echo "pgsql-$version" >> "$FILEPATH_ERROR_FLAG";
     fi
 
     export TEST_TLS=off
 
     echo "--------------------  Testing POSTGRES with TEST_TLS=off"
-    python3 tests/test.py;
+    python3 tests/test.py -v;
     if [ "$?" != "0" ]; then echo "pgsql-$version" >> "$FILEPATH_ERROR_FLAG";
     fi
 
@@ -45,7 +45,7 @@ for version in $VERSIONS; do
     export TEST_TLS=off
 
     echo "--------------------  Testing TEST_MYSQL with TEST_TLS=off"
-    python3 tests/test.py;
+    python3 tests/test.py -v;
     if [ "$?" != "0" ]; then echo "mysql-$version" >> "$FILEPATH_ERROR_FLAG";
     fi
 

--- a/.circleci/integration.sh
+++ b/.circleci/integration.sh
@@ -5,6 +5,8 @@ export TEST_PROXY_PORT=7000
 export TEST_PROXY_COMMAND_PORT=8000
 cd $HOME/project
 for version in $VERSIONS; do
+    echo "-------------------- Testing Go version $version"
+
     export TEST_ACRA_PORT=$(expr ${TEST_ACRA_PORT} + 1);
     export TEST_PROXY_PORT=$(expr ${TEST_PROXY_PORT} + 1);
     export TEST_PROXY_COMMAND_PORT=$(expr ${TEST_PROXY_COMMAND_PORT} + 1);
@@ -20,11 +22,16 @@ for version in $VERSIONS; do
     unset TEST_MYSQL
 
     export TEST_TLS=on
+    
+    echo "--------------------  Testing POSTGRES with TEST_TLS=on"
+
     python3 tests/test.py;
     if [ "$?" != "0" ]; then echo "pgsql-$version" >> "$FILEPATH_ERROR_FLAG";
     fi
 
     export TEST_TLS=off
+
+    echo "--------------------  Testing POSTGRES with TEST_TLS=off"
     python3 tests/test.py;
     if [ "$?" != "0" ]; then echo "pgsql-$version" >> "$FILEPATH_ERROR_FLAG";
     fi
@@ -37,6 +44,7 @@ for version in $VERSIONS; do
     export TEST_MYSQL=true
     export TEST_TLS=off
 
+    echo "--------------------  Testing TEST_MYSQL with TEST_TLS=off"
     python3 tests/test.py;
     if [ "$?" != "0" ]; then echo "mysql-$version" >> "$FILEPATH_ERROR_FLAG";
     fi

--- a/cmd/acra_configui/acra_configui.go
+++ b/cmd/acra_configui/acra_configui.go
@@ -200,7 +200,7 @@ func index(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
-	loggingFormat := flag.String("logging_format", "json", "Logging format: plaintext, json or CEF")
+	loggingFormat := flag.String("logging_format", "cef", "Logging format: plaintext, json or CEF")
 	logging.CustomizeLogging(*loggingFormat, SERVICE_NAME)
 	log.Infof("Starting service")
 

--- a/cmd/acra_configui/acra_configui.go
+++ b/cmd/acra_configui/acra_configui.go
@@ -200,7 +200,7 @@ func index(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
-	loggingFormat := flag.String("logging_format", "cef", "Logging format: plaintext, json or CEF")
+	loggingFormat := flag.String("logging_format", "plaintext", "Logging format: plaintext, json or CEF")
 	logging.CustomizeLogging(*loggingFormat, SERVICE_NAME)
 	log.Infof("Starting service")
 

--- a/cmd/acraproxy/acraproxy.go
+++ b/cmd/acraproxy/acraproxy.go
@@ -124,13 +124,16 @@ type Config struct {
 }
 
 func main() {
+	loggingFormat := flag.String("logging_format", "json", "Logging format: plaintext, json or CEF")
+	logging.CustomizeLogging(*loggingFormat, SERVICE_NAME)
+
 	keysDir := flag.String("keys_dir", keystore.DEFAULT_KEY_DIR_SHORT, "Folder from which will be loaded keys")
 	clientId := flag.String("client_id", "", "Client id")
 	acraHost := flag.String("acra_host", "", "IP or domain to acra daemon")
 	acraCommandsPort := flag.Int("acra_commands_port", cmd.DEFAULT_ACRA_API_PORT, "Port of acra http api")
 	acraPort := flag.Int("acra_port", cmd.DEFAULT_ACRA_PORT, "Port of acra daemon")
 	acraId := flag.String("acra_id", "acra_server", "Expected id from acraserver for Secure Session")
-	verbose := flag.Bool("v", false, "Log to stdout")
+	verbose := flag.Bool("v", false, "Log to stderr")
 	port := flag.Int("port", cmd.DEFAULT_PROXY_PORT, "Port fo acraproxy")
 	commandsPort := flag.Int("command_port", cmd.DEFAULT_PROXY_API_PORT, "Port for acraproxy http api")
 	enableHTTPApi := flag.Bool("enable_http_api", false, "Enable HTTP API")
@@ -145,7 +148,6 @@ func main() {
 	connectionAPIString := flag.String("connection_api_string", network.BuildConnectionString(cmd.DEFAULT_PROXY_CONNECTION_PROTOCOL, cmd.DEFAULT_PROXY_HOST, cmd.DEFAULT_PROXY_API_PORT, ""), "Connection string like tcp://x.x.x.x:yyyy or unix:///path/to/socket")
 	acraConnectionString := flag.String("acra_connection_string", "", "Connection string to Acra server like tcp://x.x.x.x:yyyy or unix:///path/to/socket")
 	acraApiConnectionString := flag.String("acra_api_connection_string", "", "Connection string to Acra's API like tcp://x.x.x.x:yyyy or unix:///path/to/socket")
-	loggingFormat := flag.String("logging_format", "", "Logging format: plaintext, json or CEF")
 
 	err := cmd.Parse(DEFAULT_CONFIG_PATH)
 	if err != nil {
@@ -153,6 +155,7 @@ func main() {
 		os.Exit(1)
 	}
 
+	// if log format was overridden
 	logging.CustomizeLogging(*loggingFormat, SERVICE_NAME)
 
 	if *port != cmd.DEFAULT_PROXY_PORT {

--- a/cmd/acraproxy/acraproxy.go
+++ b/cmd/acraproxy/acraproxy.go
@@ -91,7 +91,7 @@ func handleClientConnection(config *Config, connection net.Conn) {
 	acraConn.SetDeadline(time.Now().Add(time.Second * 2))
 	acraConnWrapped, err := config.ConnectionWrapper.WrapClient(config.ClientId, acraConn)
 	if err != nil {
-		log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantStartConnection).
+		log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantWrapConnection).
 			Errorln("Can't wrap connection")
 		return
 	}
@@ -104,9 +104,9 @@ func handleClientConnection(config *Config, connection net.Conn) {
 	go network.Proxy(acraConnWrapped, connection, fromAcraErrCh)
 	select {
 	case err = <-toAcraErrCh:
-		log.Debugln("Error from connection with client")
+		log.Errorln("Error from connection with client")
 	case err = <-fromAcraErrCh:
-		log.Debugln("Error from connection with acra")
+		log.Errorln("Error from connection with acra")
 	}
 	if err != nil {
 		if err == io.EOF {

--- a/cmd/acraproxy/acraproxy.go
+++ b/cmd/acraproxy/acraproxy.go
@@ -104,10 +104,10 @@ func handleClientConnection(config *Config, connection net.Conn) {
 	go network.Proxy(acraConnWrapped, connection, fromAcraErrCh)
 	select {
 	case err = <-toAcraErrCh:
-		log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantStartConnection).
+		log.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantStartConnection).
 			Errorln("Error from connection with client")
 	case err = <-fromAcraErrCh:
-		log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantStartConnection).
+		log.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantStartConnection).
 			Errorln("Error from connection with acra")
 	}
 	if err != nil {

--- a/cmd/acraproxy/acraproxy.go
+++ b/cmd/acraproxy/acraproxy.go
@@ -46,20 +46,23 @@ func handleClientConnection(config *Config, connection net.Conn) {
 	if !(config.disableUserCheck) {
 		host, port, err := net.SplitHostPort(connection.RemoteAddr().String())
 		if nil != err {
-			log.WithError(err).Errorln("can't parse client remote address")
+			log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantStartConnection).
+				Errorln("Can't parse client remote address")
 			return
 		}
 		if host == "127.0.0.1" {
 			netstat, err := exec.Command("sh", "-c", "netstat -atlnpe | awk '/:"+port+" */ {print $7}'").Output()
 			if nil != err {
-				log.WithError(err).Errorln("can't get owner UID of localhost client connection")
+				log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantStartConnection).
+					Errorln("Can't get owner UID of localhost client connection")
 				return
 			}
 			parsedNetstat := strings.Split(string(netstat), "\n")
 			correctPeer := false
 			userId, err := user.Current()
 			if nil != err {
-				log.WithError(err).Errorln("can't get current user UID")
+				log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantStartConnection).
+					Errorln("Can't get current user UID")
 				return
 			}
 			log.Infof("%v\ncur_user=%v", parsedNetstat, userId.Uid)
@@ -70,7 +73,8 @@ func handleClientConnection(config *Config, connection net.Conn) {
 				}
 			}
 			if !correctPeer {
-				log.Errorln("client application and ssproxy need to be start from different users")
+				log.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantStartConnection).
+					Errorln("Client application and ssproxy need to be start from different users")
 				return
 			}
 		}
@@ -78,7 +82,8 @@ func handleClientConnection(config *Config, connection net.Conn) {
 
 	acraConn, err := network.Dial(config.AcraConnectionString)
 	if err != nil {
-		log.WithError(err).Errorln("can't connect to acra")
+		log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantStartConnection).
+			Errorln("Can't connect to acra")
 		return
 	}
 	defer acraConn.Close()
@@ -86,7 +91,8 @@ func handleClientConnection(config *Config, connection net.Conn) {
 	acraConn.SetDeadline(time.Now().Add(time.Second * 2))
 	acraConnWrapped, err := config.ConnectionWrapper.WrapClient(config.ClientId, acraConn)
 	if err != nil {
-		log.WithError(err).Errorln("can't wrap connection")
+		log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantStartConnection).
+			Errorln("Can't wrap connection")
 		return
 	}
 	acraConn.SetDeadline(time.Time{})
@@ -98,15 +104,16 @@ func handleClientConnection(config *Config, connection net.Conn) {
 	go network.Proxy(acraConnWrapped, connection, fromAcraErrCh)
 	select {
 	case err = <-toAcraErrCh:
-		log.Debugln("error from connection with client")
+		log.Debugln("Error from connection with client")
 	case err = <-fromAcraErrCh:
-		log.Debugln("error from connection with acra")
+		log.Debugln("Error from connection with acra")
 	}
 	if err != nil {
 		if err == io.EOF {
-			log.Debugln("connection closed")
+			log.Debugln("Connection closed")
 		} else {
-			log.WithError(err).Errorln("proxy error")
+			log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantStartConnection).
+				Errorln("Proxy error")
 		}
 		return
 	}
@@ -126,6 +133,7 @@ type Config struct {
 func main() {
 	loggingFormat := flag.String("logging_format", "json", "Logging format: plaintext, json or CEF")
 	logging.CustomizeLogging(*loggingFormat, SERVICE_NAME)
+	log.Infof("Starting service")
 
 	keysDir := flag.String("keys_dir", keystore.DEFAULT_KEY_DIR_SHORT, "Folder from which will be loaded keys")
 	clientId := flag.String("client_id", "", "Client id")
@@ -151,12 +159,14 @@ func main() {
 
 	err := cmd.Parse(DEFAULT_CONFIG_PATH)
 	if err != nil {
-		log.WithError(err).Errorln("can't parse args")
+		log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantReadServiceConfig).
+			Errorln("Can't parse args")
 		os.Exit(1)
 	}
 
 	// if log format was overridden
 	logging.CustomizeLogging(*loggingFormat, SERVICE_NAME)
+	log.Infof("Validating service configuration")
 
 	if *port != cmd.DEFAULT_PROXY_PORT {
 		*connectionString = network.BuildConnectionString(cmd.DEFAULT_PROXY_CONNECTION_PROTOCOL, cmd.DEFAULT_PROXY_HOST, *port, "")
@@ -166,7 +176,8 @@ func main() {
 	}
 
 	if *acraHost == "" && *acraConnectionString == "" {
-		log.Errorln("you must pass acra_host or acra_connection_string parameter")
+		log.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorWrongConfiguration).
+			Errorln("Configuration error: you must pass acra_host or acra_connection_string parameter")
 		os.Exit(1)
 	}
 	if *acraHost != "" {
@@ -174,7 +185,8 @@ func main() {
 	}
 	if *enableHTTPApi {
 		if *acraHost == "" && *acraApiConnectionString == "" {
-			log.Errorln("you must pass acra_host or acra_api_connection_string parameter")
+			log.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorWrongConfiguration).
+				Errorln("Configuration error: you must pass acra_host or acra_api_connection_string parameter")
 			os.Exit(1)
 		}
 		if *acraHost != "" {
@@ -184,24 +196,29 @@ func main() {
 
 	cmd.ValidateClientId(*clientId)
 
+	log.Infof("Reading keys")
 	clientPrivateKey := fmt.Sprintf("%v%v%v", *keysDir, string(os.PathSeparator), *clientId)
 	serverPublicKey := fmt.Sprintf("%v%v%v_server.pub", *keysDir, string(os.PathSeparator), *clientId)
 	exists, err := utils.FileExists(clientPrivateKey)
 	if !exists {
-		log.Errorf("acraproxy private key %s doesn't exists", clientPrivateKey)
+		log.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorWrongConfiguration).
+			Errorf("Configuration error: acraproxy private key %s doesn't exists", clientPrivateKey)
 		os.Exit(1)
 	}
 	if err != nil {
-		log.Errorf("can't check is exists acraproxy private key %v, got error - %v", clientPrivateKey, err)
+		log.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorWrongConfiguration).
+			Errorf("Configuration error: can't check is exists acraproxy private key %v, got error - %v", clientPrivateKey, err)
 		os.Exit(1)
 	}
 	exists, err = utils.FileExists(serverPublicKey)
 	if !exists {
-		log.Errorf("acraserver public key %s doesn't exists", serverPublicKey)
+		log.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorWrongConfiguration).
+			Errorf("Configuration error: acraserver public key %s doesn't exists", serverPublicKey)
 		os.Exit(1)
 	}
 	if err != nil {
-		log.Errorf("can't check is exists acraserver public key %v, got error - %v", serverPublicKey, err)
+		log.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorWrongConfiguration).
+			Errorf("Configuration error: can't check is exists acraserver public key %v, got error - %v", serverPublicKey, err)
 		os.Exit(1)
 	}
 
@@ -214,46 +231,58 @@ func main() {
 		*disableUserCheck = true
 	}
 
+	log.Infof("Initializing keystore")
 	keyStore, err := keystore.NewProxyFileSystemKeyStore(*keysDir, []byte(*clientId))
 	if err != nil {
-		log.WithError(err).Errorln("can't initialize keystore")
+		log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantInitKeyStore).
+			Errorln("Can't initialize keystore")
 		os.Exit(1)
 	}
+
+	log.Debugf("Start listening connections")
 	config := &Config{KeyStore: keyStore, KeysDir: *keysDir, ClientId: []byte(*clientId), AcraConnectionString: *acraConnectionString, ConnectionString: *connectionString, AcraId: []byte(*acraId), disableUserCheck: *disableUserCheck}
 	listener, err := network.Listen(*connectionString)
 	if err != nil {
-		log.WithError(err).Errorln("can't start listen connections")
+		log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantStartListenConnections).
+			Errorln("Can't start listen connections")
 		os.Exit(1)
 	}
 	defer listener.Close()
 
+	log.Debugf("Registering process signal handlers")
 	sigHandler, err := cmd.NewSignalHandler([]os.Signal{os.Interrupt, syscall.SIGTERM})
 	if err != nil {
-		log.WithError(err).Errorln("can't register SIGINT handler")
+		log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantRegisterSignalHandler).
+			Errorln("Can't register SIGINT handler")
 		os.Exit(1)
 	}
 	go sigHandler.Register()
 	sigHandler.AddListener(listener)
+
+
 	if *useTls {
-		log.Infoln("use TLS transport wrapper")
+		log.Infof("Selecting transport: use TLS transport wrapper")
 		tlsConfig, err := network.NewTLSConfig(*tlsSNI, *tlsCA, *tlsKey, *tlsCert)
 		if err != nil {
-			log.WithError(err).Errorln("can't get config for TLS")
+			log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorTransportConfiguration).
+				Errorln("Configuration error: can't get config for TLS")
 			os.Exit(1)
 		}
 		config.ConnectionWrapper, err = network.NewTLSConnectionWrapper(nil, tlsConfig)
 		if err != nil {
-			log.WithError(err).Errorln("can't initialize tls connection wrapper")
+			log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorTransportConfiguration).
+				Errorln("Configuration error: can't initialize TLS connection wrapper")
 			os.Exit(1)
 		}
 	} else if *noEncryption {
-		log.Infoln("use raw transport wrapper")
+		log.Infof("Selecting transport: use raw transport wrapper")
 		config.ConnectionWrapper = &network.RawConnectionWrapper{ClientId: []byte(*clientId)}
 	} else {
-		log.Infoln("use Secure Session transport wrapper")
+		log.Infof("Selecting transport: use Secure Session transport wrapper")
 		config.ConnectionWrapper, err = network.NewSecureSessionConnectionWrapper(keyStore)
 		if err != nil {
-			log.WithError(err).Errorln("can't initialize secure session connection wrapper")
+			log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorTransportConfiguration).
+				Errorln("Configuration error: can't initialize secure session connection wrapper")
 			os.Exit(1)
 		}
 	}
@@ -263,41 +292,45 @@ func main() {
 			commandsConfig := *config
 			commandsConfig.AcraConnectionString = *acraApiConnectionString
 
-			log.Infof("start listening http api %s", *connectionAPIString)
+			log.Infof("Start listening http API: %s", *connectionAPIString)
 			commandsListener, err := network.Listen(*connectionAPIString)
 			if err != nil {
-				log.WithError(err).Errorln("can't start listen connections to http api")
+				log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantStartListenConnections).
+				Errorln("System error: can't start listen connections to http API")
 				os.Exit(1)
 			}
 			sigHandler.AddListener(commandsListener)
 			for {
 				connection, err := commandsListener.Accept()
 				if err != nil {
-					log.WithError(err).Errorf("can't accept new connection")
+					log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantAcceptNewConnections).
+						Errorf("System error: can't accept new connection")
 					continue
 				}
 				// unix socket and value == '@'
 				if len(connection.RemoteAddr().String()) == 1 {
-					log.WithError(err).Errorf("new connection to http api: <%v>", connection.LocalAddr())
+					log.Infof("Got new connection to http API: <%v>", connection.LocalAddr())
 				} else {
-					log.WithError(err).Errorf("new connection to http api: <%v>", connection.RemoteAddr())
+					log.Infof("Got new connection to http API: <%v>", connection.RemoteAddr())
 				}
 				go handleClientConnection(&commandsConfig, connection)
 			}
 		}()
 	}
-	log.Infof("start listening %s", *connectionString)
+
+	log.Infof("Start listening connection %s", *connectionString)
 	for {
 		connection, err := listener.Accept()
 		if err != nil {
-			log.WithError(err).Errorln("can't accept new connection")
+			log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantAcceptNewConnections).
+				Errorln("System error: сan't accept new connection")
 			os.Exit(1)
 		}
 		// unix socket and value == '@'
 		if len(connection.RemoteAddr().String()) == 1 {
-			log.Infof("new connection to acraproxy: <%v>", connection.LocalAddr())
+			log.Infof("Got new connection to acraproxy: <%v>", connection.LocalAddr())
 		} else {
-			log.Infof("new connection to acraproxy: <%v>", connection.RemoteAddr())
+			log.Infof("Got new connection to acraproxy: <%v>", connection.RemoteAddr())
 		}
 		go handleClientConnection(config, connection)
 	}

--- a/cmd/acraproxy/acraproxy.go
+++ b/cmd/acraproxy/acraproxy.go
@@ -133,7 +133,7 @@ type Config struct {
 }
 
 func main() {
-	loggingFormat := flag.String("logging_format", "cef", "Logging format: plaintext, json or CEF")
+	loggingFormat := flag.String("logging_format", "plaintext", "Logging format: plaintext, json or CEF")
 	logging.CustomizeLogging(*loggingFormat, SERVICE_NAME)
 	log.Infof("Starting service")
 

--- a/cmd/acraproxy/acraproxy.go
+++ b/cmd/acraproxy/acraproxy.go
@@ -133,7 +133,7 @@ type Config struct {
 }
 
 func main() {
-	loggingFormat := flag.String("logging_format", "json", "Logging format: plaintext, json or CEF")
+	loggingFormat := flag.String("logging_format", "cef", "Logging format: plaintext, json or CEF")
 	logging.CustomizeLogging(*loggingFormat, SERVICE_NAME)
 	log.Infof("Starting service")
 

--- a/cmd/acraproxy/acraproxy.go
+++ b/cmd/acraproxy/acraproxy.go
@@ -104,9 +104,11 @@ func handleClientConnection(config *Config, connection net.Conn) {
 	go network.Proxy(acraConnWrapped, connection, fromAcraErrCh)
 	select {
 	case err = <-toAcraErrCh:
-		log.Errorln("Error from connection with client")
+		log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantStartConnection).
+			Errorln("Error from connection with client")
 	case err = <-fromAcraErrCh:
-		log.Errorln("Error from connection with acra")
+		log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantStartConnection).
+			Errorln("Error from connection with acra")
 	}
 	if err != nil {
 		if err == io.EOF {
@@ -309,9 +311,9 @@ func main() {
 				}
 				// unix socket and value == '@'
 				if len(connection.RemoteAddr().String()) == 1 {
-					log.Infof("Got new connection to http API: <%v>", connection.LocalAddr())
+					log.Infof("Got new connection to http API: %v", connection.LocalAddr())
 				} else {
-					log.Infof("Got new connection to http API: <%v>", connection.RemoteAddr())
+					log.Infof("Got new connection to http API: %v", connection.RemoteAddr())
 				}
 				go handleClientConnection(&commandsConfig, connection)
 			}
@@ -328,9 +330,9 @@ func main() {
 		}
 		// unix socket and value == '@'
 		if len(connection.RemoteAddr().String()) == 1 {
-			log.Infof("Got new connection to acraproxy: <%v>", connection.LocalAddr())
+			log.Infof("Got new connection to acraproxy: %v", connection.LocalAddr())
 		} else {
-			log.Infof("Got new connection to acraproxy: <%v>", connection.RemoteAddr())
+			log.Infof("Got new connection to acraproxy: %v", connection.RemoteAddr())
 		}
 		go handleClientConnection(config, connection)
 	}

--- a/cmd/acraserver/acraserver.go
+++ b/cmd/acraserver/acraserver.go
@@ -38,7 +38,7 @@ const (
 	GRACEFUL_ENV            = "GRACEFUL_RESTART"
 	DESCRIPTOR_ACRA         = 3
 	DESCRIPTOR_API          = 4
-	SERVICE_NAME = "acraserver"
+	SERVICE_NAME            = "acraserver"
 )
 
 // DEFAULT_CONFIG_PATH relative path to config which will be parsed as default
@@ -159,11 +159,11 @@ func main() {
 		config.SetByteaFormat(ESCAPE_BYTEA_FORMAT)
 	}
 
-	log.Infof("Initializing keystore")
+	log.Infof("Initialising keystore")
 	keyStore, err := keystore.NewFilesystemKeyStore(*keysDir)
 	if err != nil {
 		log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantInitKeyStore).
-			Errorln("Can't initialize keystore")
+			Errorln("Can't initialise keystore")
 		os.Exit(1)
 	}
 	if *useTls {
@@ -177,7 +177,7 @@ func main() {
 		config.ConnectionWrapper, err = network.NewTLSConnectionWrapper([]byte(*clientId), tlsConfig)
 		if err != nil {
 			log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorTransportConfiguration).
-				Errorln("Configuration error: can't initialize TLS connection wrapper")
+				Errorln("Configuration error: can't initialise TLS connection wrapper")
 			os.Exit(1)
 		}
 	} else if *noEncryption {
@@ -311,7 +311,7 @@ func main() {
 		os.Exit(0)
 	})
 
-	log.Infof("Current PID: %v", os.Getpid())
+	log.Infof("Start listening to connections. Current PID: %v", os.Getpid())
 
 	if os.Getenv(GRACEFUL_ENV) == "true" {
 		go server.StartFromFileDescriptor(DESCRIPTOR_ACRA)
@@ -325,5 +325,6 @@ func main() {
 		}
 	}
 
+	// todo: any reason why it's so far from adding callback?
 	sigHandlerSIGHUP.Register()
 }

--- a/cmd/acraserver/acraserver.go
+++ b/cmd/acraserver/acraserver.go
@@ -49,7 +49,7 @@ var ErrWaitTimeout = errors.New("timeout")
 
 func main() {
 	config := NewConfig()
-	loggingFormat := flag.String("logging_format", "cef", "Logging format: plaintext, json or CEF")
+	loggingFormat := flag.String("logging_format", "plaintext", "Logging format: plaintext, json or CEF")
 	logging.CustomizeLogging(*loggingFormat, SERVICE_NAME)
 	log.Infof("Starting service")
 

--- a/cmd/acraserver/acraserver.go
+++ b/cmd/acraserver/acraserver.go
@@ -49,7 +49,7 @@ var ErrWaitTimeout = errors.New("timeout")
 
 func main() {
 	config := NewConfig()
-	loggingFormat := flag.String("logging_format", "json", "Logging format: plaintext, json or CEF")
+	loggingFormat := flag.String("logging_format", "cef", "Logging format: plaintext, json or CEF")
 	logging.CustomizeLogging(*loggingFormat, SERVICE_NAME)
 	log.Infof("Starting service")
 

--- a/cmd/acraserver/client_commands_session.go
+++ b/cmd/acraserver/client_commands_session.go
@@ -21,7 +21,6 @@ import (
 
 	"errors"
 	"github.com/cossacklabs/acra/keystore"
-	"github.com/cossacklabs/acra/utils"
 	"github.com/cossacklabs/acra/zone"
 	"github.com/cossacklabs/themis/gothemis/keys"
 	"fmt"
@@ -50,19 +49,19 @@ func (clientSession *ClientCommandsSession) ConnectToDb() error {
 }
 
 func (clientSession *ClientCommandsSession) close() {
-	log.Debugln("close acraproxy connection")
+	log.Debugln("Close acraproxy connection")
 	err := clientSession.connection.Close()
 	if err != nil {
-		log.Warningf("%v", utils.ErrorMessage("error with closing connection to acraproxy", err))
+		log.WithError(err).Errorln("Error during closing connection to acraproxy")
 	}
-	log.Debugln("all connections closed")
+	log.Debugln("All connections closed")
 }
 
 func (clientSession *ClientCommandsSession) HandleSession() {
 	reader := bufio.NewReader(clientSession.connection)
 	req, err := http.ReadRequest(reader)
 	if err != nil {
-		log.Warningf("%v", utils.ErrorMessage("error reading command request from proxy", err))
+		log.WithError(err).Warningln("Got new command request, but can't read it")
 		clientSession.close()
 		return
 	}
@@ -72,32 +71,38 @@ func (clientSession *ClientCommandsSession) HandleSession() {
 
 	switch req.URL.Path {
 	case "/getNewZone":
+		log.Debugln("Got /getNewZone request")
 		id, publicKey, err := clientSession.keystorage.GenerateZoneKey()
 		if err == nil {
 			zoneData, err := zone.ZoneDataToJson(id, &keys.PublicKey{Value: publicKey})
 			if err == nil {
+				log.Debugln("Handled request correctly")
 				response = fmt.Sprintf("HTTP/1.1 200 OK Found\r\n\r\n%s\r\n\r\n", string(zoneData))
 			}
 		}
 	case "/resetKeyStorage":
-		log.Info("clear key storage cache")
+		log.Debugln("Got /resetKeyStorage request")
 		clientSession.keystorage.Reset()
 		response = "HTTP/1.1 200 OK Found\r\n\r\n"
+		log.Debugln("Cleared key storage cache")
 	case "/getConfig":
+		log.Debugln("Got /getConfig request")
 		jsonOutput, err := clientSession.config.ToJson()
 		if err != nil {
-			log.Warningf("%v\n", utils.ErrorMessage("can't convert config to JSON", err))
+			log.WithError(err).Warningln("Can't convert config to JSON")
 			response = "HTTP/1.1 500 Server error\r\n\r\n\r\n\r\n"
 		} else {
+			log.Debugln("Handled request correctly")
 			log.Debugln(string(jsonOutput))
 			response = fmt.Sprintf("HTTP/1.1 200 OK Found\r\n\r\n%s\r\n\r\n", string(jsonOutput))
 		}
 	case "/setConfig":
+		log.Debugln("Got /setConfig request")
 		decoder := json.NewDecoder(req.Body)
 		var configFromUI UIEditableConfig
 		err := decoder.Decode(&configFromUI)
 		if err != nil {
-			log.Warningf("%v\n", utils.ErrorMessage("can't convert config from incoming", err))
+			log.WithError(err).Warningln("Can't convert config from incoming")
 			response = "HTTP/1.1 500 Server error\r\n\r\n\r\n\r\n"
 			return
 		}
@@ -117,12 +122,13 @@ func (clientSession *ClientCommandsSession) HandleSession() {
 			return
 
 		}
+		log.Debugln("Handled request correctly, restarting server")
 		clientSession.Server.restartSignalsChannel <- syscall.SIGHUP
 	}
 
 	_, err = clientSession.connection.Write([]byte(response))
 	if err != nil {
-		log.Warningf("%v", utils.ErrorMessage("can't send data with secure session to acraproxy", err))
+		log.WithError(err).Errorln("Can't send data with secure session to acraproxy")
 		return
 	}
 	clientSession.close()

--- a/cmd/acraserver/client_session.go
+++ b/cmd/acraserver/client_session.go
@@ -106,7 +106,8 @@ func (clientSession *ClientSession) HandleSecureSession(decryptorImpl base.Decry
 		log.Debugln("MySQL connection")
 		handler, err := mysql.NewMysqlHandler(decryptorImpl, clientSession.config.firewall)
 		if err != nil {
-			log.WithError(err).Errorln("Can't initialize mysql handler")
+			log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantInitDecryptor).
+				Errorln("Can't initialize mysql handler")
 			return
 		}
 		go handler.ClientToDbProxy(decryptorImpl, clientSession.connectionToDb, clientSession.connection, innerErrorChannel)

--- a/cmd/acraserver/client_session.go
+++ b/cmd/acraserver/client_session.go
@@ -58,13 +58,13 @@ func (clientSession *ClientSession) close() {
 		log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantCloseConnectionToService).
 			Errorln("Error with closing connection to acraproxy")
 	}
-	log.Debugln("close db connection")
+	log.Debugln("Close db connection")
 	err = clientSession.connectionToDb.Close()
 	if err != nil {
 		log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantCloseConnectionDB).
 			Errorln("Error with closing connection to db")
 	}
-	log.Debugln("all connections closed")
+	log.Debugln("All connections closed")
 }
 
 /* proxy connections from client to db and decrypt responses from db to client
@@ -106,7 +106,7 @@ func (clientSession *ClientSession) HandleSecureSession(decryptorImpl base.Decry
 		log.Debugln("MySQL connection")
 		handler, err := mysql.NewMysqlHandler(decryptorImpl)
 		if err != nil {
-			log.WithError(err).Errorln("can't initialize mysql handler")
+			log.WithError(err).Errorln("Can't initialize mysql handler")
 			return
 		}
 		go handler.ClientToDbProxy(decryptorImpl, clientSession.connectionToDb, clientSession.connection, innerErrorChannel)
@@ -123,7 +123,7 @@ func (clientSession *ClientSession) HandleSecureSession(decryptorImpl base.Decry
 			log.Debugln("EOF connection closed")
 		} else if netErr, ok := err.(net.Error); ok {
 			if netErr.Timeout() {
-				log.Debugln("network timeout")
+				log.Debugln("Network timeout")
 				if clientSession.config.UseMySQL() {
 					break
 				} else {
@@ -133,11 +133,11 @@ func (clientSession *ClientSession) HandleSecureSession(decryptorImpl base.Decry
 				}
 			}
 			log.WithError(netErr).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantHandleSecureSession).
-				Errorln("network error")
+				Errorln("Network error")
 		} else if opErr, ok := err.(*net.OpError); ok {
-			log.WithError(opErr).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantHandleSecureSession).Errorln("network error")
+			log.WithError(opErr).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantHandleSecureSession).Errorln("Network error")
 		} else {
-			log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantHandleSecureSession).Errorln("unexpected error")
+			log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantHandleSecureSession).Errorln("Unexpected error")
 		}
 		break
 	}

--- a/cmd/acraserver/listener.go
+++ b/cmd/acraserver/listener.go
@@ -188,9 +188,9 @@ func (server *SServer) Start() {
 		}
 		// unix socket and value == '@'
 		if len(connection.RemoteAddr().String()) == 1 {
-			log.Infof("Got new connection to acraserver: <%v>", connection.LocalAddr())
+			log.Infof("Got new connection to acraserver: %v", connection.LocalAddr())
 		} else {
-			log.Infof("Got new connection to acraserver: <%v>", connection.RemoteAddr())
+			log.Infof("Got new connection to acraserver: %v", connection.RemoteAddr())
 		}
 		go func() {
 			server.cmACRA.Incr()
@@ -235,9 +235,9 @@ func (server *SServer) StartFromFileDescriptor(fd uintptr) {
 		}
 		// unix socket and value == '@'
 		if len(connection.RemoteAddr().String()) == 1 {
-			log.Infof("Got new connection to acraserver: <%v>", connection.LocalAddr())
+			log.Infof("Got new connection to acraserver: %v", connection.LocalAddr())
 		} else {
-			log.Infof("Got new connection to acraserver: <%v>", connection.RemoteAddr())
+			log.Infof("Got new connection to acraserver: %v", connection.RemoteAddr())
 		}
 		go func() {
 			server.cmACRA.Incr()
@@ -360,9 +360,9 @@ func (server *SServer) StartCommands() {
 		}
 		// unix socket and value == '@'
 		if len(connection.RemoteAddr().String()) == 1 {
-			log.Infof("Got new connection to http API: <%v>", connection.LocalAddr())
+			log.Infof("Got new connection to http API: %v", connection.LocalAddr())
 		} else {
-			log.Infof("Got new connection to http API: <%v>", connection.RemoteAddr())
+			log.Infof("Got new connection to http API: %v", connection.RemoteAddr())
 		}
 		go func() {
 			server.cmAPI.Incr()
@@ -405,9 +405,9 @@ func (server *SServer) StartCommandsFromFileDescriptor(fd uintptr) {
 		}
 		// unix socket and value == '@'
 		if len(connection.RemoteAddr().String()) == 1 {
-			log.Infof("Got new connection to http API: <%v>", connection.LocalAddr())
+			log.Infof("Got new connection to http API: %v", connection.LocalAddr())
 		} else {
-			log.Infof("Got new connection to http API: <%v>", connection.RemoteAddr())
+			log.Infof("Got new connection to http API: %v", connection.RemoteAddr())
 		}
 		go func() {
 			server.cmAPI.Incr()

--- a/cmd/acraserver/listener.go
+++ b/cmd/acraserver/listener.go
@@ -185,6 +185,7 @@ func (server *SServer) Start() {
 			}
 			log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantAcceptNewConnections).
 				Errorf("Can't accept new connection (connection=%v)", connection)
+			continue
 		}
 		// unix socket and value == '@'
 		if len(connection.RemoteAddr().String()) == 1 {
@@ -232,6 +233,7 @@ func (server *SServer) StartFromFileDescriptor(fd uintptr) {
 			}
 			log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantAcceptNewConnections).
 				Errorf("Can't accept new connection (connection=%v)", connection)
+			continue
 		}
 		// unix socket and value == '@'
 		if len(connection.RemoteAddr().String()) == 1 {
@@ -357,6 +359,7 @@ func (server *SServer) StartCommands() {
 			}
 			log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantAcceptNewConnections).
 				Errorf("Can't accept new connection (connection=%v)", connection)
+			continue
 		}
 		// unix socket and value == '@'
 		if len(connection.RemoteAddr().String()) == 1 {
@@ -402,6 +405,7 @@ func (server *SServer) StartCommandsFromFileDescriptor(fd uintptr) {
 			}
 			log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantAcceptNewConnections).
 				Errorf("System error: can't accept new connection (connection=%v)", connection)
+			continue
 		}
 		// unix socket and value == '@'
 		if len(connection.RemoteAddr().String()) == 1 {

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -186,8 +186,7 @@ func DumpConfig(configPath string, useDefault bool) error {
 
 func Parse(configPath string) error {
 	/*load from yaml config and cli. if dumpconfig option pass than generate config and exit*/
-	log.Info("Parsing config")
-	log.Infof("ConfigPath: %v", configPath)
+	log.Debugf("Parsing config from path %v", configPath)
 	// first parse using bultin flag
 	err := flag_.CommandLine.Parse(os.Args[1:])
 	if err != nil {
@@ -238,7 +237,7 @@ func Parse(configPath string) error {
 		}
 	}
 	// set options from config that wasn't set by cli
-	log.Infoln(args)
+	log.Debugln(args)
 	err = flag_.CommandLine.Parse(args)
 	if err != nil {
 		return err

--- a/configs/acra_configui.yaml
+++ b/configs/acra_configui.yaml
@@ -17,7 +17,7 @@ dumpconfig: false
 host: 127.0.0.1
 
 # Logging format: plaintext, json or CEF
-logging_format: json
+logging_format: cef
 
 # Port for configUI HTTP endpoint
 port: 8000

--- a/configs/acra_configui.yaml
+++ b/configs/acra_configui.yaml
@@ -16,6 +16,9 @@ dumpconfig: false
 # Host for configUI HTTP endpoint
 host: 127.0.0.1
 
+# Logging format: plaintext, json or CEF
+logging_format: json
+
 # Port for configUI HTTP endpoint
 port: 8000
 

--- a/configs/acra_configui.yaml
+++ b/configs/acra_configui.yaml
@@ -17,7 +17,7 @@ dumpconfig: false
 host: 127.0.0.1
 
 # Logging format: plaintext, json or CEF
-logging_format: cef
+logging_format: plaintext
 
 # Port for configUI HTTP endpoint
 port: 8000

--- a/configs/acra_configui.yaml
+++ b/configs/acra_configui.yaml
@@ -17,7 +17,7 @@ dumpconfig: false
 host: 127.0.0.1
 
 # Logging format: plaintext, json or CEF
-logging_format: plaintext
+logging_format: json
 
 # Port for configUI HTTP endpoint
 port: 8000

--- a/configs/acra_configui.yaml
+++ b/configs/acra_configui.yaml
@@ -17,7 +17,7 @@ dumpconfig: false
 host: 127.0.0.1
 
 # Logging format: plaintext, json or CEF
-logging_format: cef
+logging_format: json
 
 # Port for configUI HTTP endpoint
 port: 8000

--- a/configs/acra_configui.yaml
+++ b/configs/acra_configui.yaml
@@ -17,7 +17,7 @@ dumpconfig: false
 host: 127.0.0.1
 
 # Logging format: plaintext, json or CEF
-logging_format: json
+logging_format: plaintext
 
 # Port for configUI HTTP endpoint
 port: 8000

--- a/configs/acraproxy.yaml
+++ b/configs/acraproxy.yaml
@@ -44,7 +44,7 @@ enable_http_api: false
 keys_dir: .acrakeys
 
 # Logging format: plaintext, json or CEF
-logging_format: plaintext
+logging_format: json
 
 # Use raw transport (tcp/unix socket) between acraserver and acraproxy/client (don't use this flag if you not connect to database with ssl/tls
 no_encryption: false

--- a/configs/acraproxy.yaml
+++ b/configs/acraproxy.yaml
@@ -67,6 +67,6 @@ tls_key:
 # Expected Server Name (SNI)
 tls_sni: 
 
-# Log to stdout
+# Log to stderr
 v: false
 

--- a/configs/acraproxy.yaml
+++ b/configs/acraproxy.yaml
@@ -44,7 +44,7 @@ enable_http_api: false
 keys_dir: .acrakeys
 
 # Logging format: plaintext, json or CEF
-logging_format: json
+logging_format: plaintext
 
 # Use raw transport (tcp/unix socket) between acraserver and acraproxy/client (don't use this flag if you not connect to database with ssl/tls
 no_encryption: false

--- a/configs/acraproxy.yaml
+++ b/configs/acraproxy.yaml
@@ -44,7 +44,7 @@ enable_http_api: false
 keys_dir: .acrakeys
 
 # Logging format: plaintext, json or CEF
-logging_format: 
+logging_format: json
 
 # Use raw transport (tcp/unix socket) between acraserver and acraproxy/client (don't use this flag if you not connect to database with ssl/tls
 no_encryption: false

--- a/configs/acraproxy.yaml
+++ b/configs/acraproxy.yaml
@@ -44,7 +44,7 @@ enable_http_api: false
 keys_dir: .acrakeys
 
 # Logging format: plaintext, json or CEF
-logging_format: json
+logging_format: cef
 
 # Use raw transport (tcp/unix socket) between acraserver and acraproxy/client (don't use this flag if you not connect to database with ssl/tls
 no_encryption: false

--- a/configs/acraproxy.yaml
+++ b/configs/acraproxy.yaml
@@ -44,7 +44,7 @@ enable_http_api: false
 keys_dir: .acrakeys
 
 # Logging format: plaintext, json or CEF
-logging_format: cef
+logging_format: json
 
 # Use raw transport (tcp/unix socket) between acraserver and acraproxy/client (don't use this flag if you not connect to database with ssl/tls
 no_encryption: false

--- a/configs/acraproxy.yaml
+++ b/configs/acraproxy.yaml
@@ -44,7 +44,7 @@ enable_http_api: false
 keys_dir: .acrakeys
 
 # Logging format: plaintext, json or CEF
-logging_format: cef
+logging_format: plaintext
 
 # Use raw transport (tcp/unix socket) between acraserver and acraproxy/client (don't use this flag if you not connect to database with ssl/tls
 no_encryption: false

--- a/configs/acraserver.yaml
+++ b/configs/acraserver.yaml
@@ -85,7 +85,7 @@ tls_key:
 # Expected Server Name (SNI)
 tls_sni: 
 
-# Log to stdout
+# Log to stderr
 v: false
 
 # Acrastruct will stored in whole data cell

--- a/configs/acraserver.yaml
+++ b/configs/acraserver.yaml
@@ -47,7 +47,7 @@ injectedcell: false
 keys_dir: .acrakeys
 
 # Logging format: plaintext, json or CEF
-logging_format: plaintext
+logging_format: json
 
 # Handle MySQL connections
 mysql: false

--- a/configs/acraserver.yaml
+++ b/configs/acraserver.yaml
@@ -47,7 +47,7 @@ injectedcell: false
 keys_dir: .acrakeys
 
 # Logging format: plaintext, json or CEF
-logging_format: cef
+logging_format: json
 
 # Handle MySQL connections
 mysql: false

--- a/configs/acraserver.yaml
+++ b/configs/acraserver.yaml
@@ -47,7 +47,7 @@ injectedcell: false
 keys_dir: .acrakeys
 
 # Logging format: plaintext, json or CEF
-logging_format: json
+logging_format: plaintext
 
 # Handle MySQL connections
 mysql: false

--- a/configs/acraserver.yaml
+++ b/configs/acraserver.yaml
@@ -47,7 +47,7 @@ injectedcell: false
 keys_dir: .acrakeys
 
 # Logging format: plaintext, json or CEF
-logging_format: json
+logging_format: cef
 
 # Handle MySQL connections
 mysql: false

--- a/configs/acraserver.yaml
+++ b/configs/acraserver.yaml
@@ -47,7 +47,7 @@ injectedcell: false
 keys_dir: .acrakeys
 
 # Logging format: plaintext, json or CEF
-logging_format: 
+logging_format: json
 
 # Use raw transport (tcp/unix socket) between acraserver and acraproxy/client (don't use this flag if you not connect to database with ssl/tls
 no_encryption: false

--- a/configs/acraserver.yaml
+++ b/configs/acraserver.yaml
@@ -47,7 +47,7 @@ injectedcell: false
 keys_dir: .acrakeys
 
 # Logging format: plaintext, json or CEF
-logging_format: cef
+logging_format: plaintext
 
 # Handle MySQL connections
 mysql: false

--- a/decryptor/mysql/decryptor.go
+++ b/decryptor/mysql/decryptor.go
@@ -129,6 +129,7 @@ func (decryptor *MySQLDecryptor) checkPoisonRecord(block []byte) (bool, error) {
 	if err == nil {
 		log.Warningln("Recognized poison record")
 		if decryptor.GetPoisonCallbackStorage().HasCallbacks() {
+			log.Debugln("Check poison records")
 			if err := decryptor.GetPoisonCallbackStorage().Call(); err != nil {
 				log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorDecryptorCantHandleRecognizedPoisonRecord).
 					Errorln("Unexpected error in poison record callbacks")
@@ -142,7 +143,6 @@ func (decryptor *MySQLDecryptor) checkPoisonRecord(block []byte) (bool, error) {
 
 // poisonCheck find acrastructs in block and try to detect poison record
 func (decryptor *MySQLDecryptor) poisonCheck(block []byte) error {
-	log.Debugln("Check poison records")
 	index := 0
 	for {
 		beginTagIndex, _ := decryptor.BeginTagIndex(block[index:])

--- a/decryptor/mysql/decryptor.go
+++ b/decryptor/mysql/decryptor.go
@@ -134,8 +134,8 @@ func (decryptor *MySQLDecryptor) checkPoisonRecord(block []byte) (bool, error) {
 					Errorln("Unexpected error in poison record callbacks")
 			}
 			log.Debugln("Processed all callbacks on poison record")
-			return true, err
 		}
+		return true, err
 	}
 	return false, nil
 }

--- a/decryptor/mysql/decryptor.go
+++ b/decryptor/mysql/decryptor.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cossacklabs/acra/zone"
 	"github.com/cossacklabs/themis/gothemis/keys"
 	log "github.com/sirupsen/logrus"
+	"github.com/cossacklabs/acra/logging"
 )
 
 type decryptFunc func([]byte) ([]byte, error)
@@ -119,18 +120,20 @@ func (decryptor *MySQLDecryptor) checkPoisonRecord(block []byte) (bool, error) {
 	decryptor.Reset()
 	data, err := decryptor.SkipBeginInBlock(block)
 	if err != nil {
-		log.WithError(err).Debugln("can't skip begin tag in block")
+		log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorDecryptorCantSkipBeginInBlock).
+			Debugln("Can't skip begin tag in block")
 		return false, nil
 	}
 	if decryptor.GetPoisonCallbackStorage().HasCallbacks() {
-		log.Debugln("check block on poison")
+		log.Debugln("Check block on poison")
 		_, err := decryptor.decryptBlock(bytes.NewReader(data), nil, decryptor.getPoisonPrivateKey)
 		if err == nil {
-			log.Warningln("recognized poison record")
+			log.Warningln("Recognized poison record")
 			if err := decryptor.GetPoisonCallbackStorage().Call(); err != nil {
-				log.WithError(err).Errorln("unexpected error in poison record callbacks")
+				log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorDecryptorCantHandleRecognizedPoisonRecord).
+					Errorln("Unexpected error in poison record callbacks")
 			}
-			log.Debugln("processed all callbacks on poison record")
+			log.Debugln("Processed all callbacks on poison record")
 			return true, err
 		}
 	}
@@ -139,14 +142,14 @@ func (decryptor *MySQLDecryptor) checkPoisonRecord(block []byte) (bool, error) {
 
 // poisonCheck find acrastructs in block and try to detect poison record
 func (decryptor *MySQLDecryptor) poisonCheck(block []byte) error {
-	log.Debugln("check poison records")
+	log.Debugln("Check poison records")
 	index := 0
 	for {
 		beginTagIndex, _ := decryptor.BeginTagIndex(block[index:])
 		if beginTagIndex == utils.NOT_FOUND {
 			break
 		} else {
-			log.Debugln("found acrastruct")
+			log.Debugln("Found acrastruct")
 			poisoned, err := decryptor.checkPoisonRecord(block[index+beginTagIndex:])
 			if poisoned {
 				return base.ErrPoisonRecord
@@ -164,17 +167,17 @@ type getKeyFunc func() (*keys.PrivateKey, error)
 func (decryptor *MySQLDecryptor) decryptBlock(reader io.Reader, id []byte, keyFunc getKeyFunc) ([]byte, error) {
 	privateKey, err := keyFunc()
 	if err != nil {
-		decryptor.log.Warningln("can't read private key")
+		decryptor.log.Warningln("Can't read private key")
 		return []byte{}, err
 	}
 	key, _, err := decryptor.ReadSymmetricKey(privateKey, reader)
 	if err != nil {
-		decryptor.log.Warningf("%v", utils.ErrorMessage("can't unwrap symmetric key", err))
+		decryptor.log.WithError(err).Warningln("Can't unwrap symmetric key")
 		return []byte{}, err
 	}
 	data, err := decryptor.ReadData(key, id, reader)
 	if err != nil {
-		decryptor.log.Warningf("%v", utils.ErrorMessage("can't decrypt data with unwrapped symmetric key", err))
+		decryptor.log.WithError(err).Warningln("Can't decrypt data with unwrapped symmetric key")
 		return []byte{}, err
 	}
 	return data, nil

--- a/decryptor/mysql/response_proxy.go
+++ b/decryptor/mysql/response_proxy.go
@@ -164,7 +164,7 @@ func (handler *MysqlHandler) ClientToDbProxy(decryptor base.Decryptor, dbConnect
 		}
 		handler.clientSequenceNumber = int(packet.GetSequenceNumber())
 		clientLog = clientLog.WithField("sequence_number", handler.clientSequenceNumber)
-		clientLog.Debugln("nNw packet")
+		clientLog.Debugln("New packet")
 		inOutput := packet.Dump()
 		data := packet.GetData()
 		cmd := data[0]

--- a/decryptor/postgresql/pg_decryptor.go
+++ b/decryptor/postgresql/pg_decryptor.go
@@ -323,7 +323,7 @@ func PgDecryptStream(decryptor base.Decryptor, config *PgDecryptorConfig, dbConn
 					// poison record check
 					// check only if has any action on detection
 					if decryptor.GetPoisonCallbackStorage().HasCallbacks() {
-						log.Debugln("check poison records")
+						log.Debugln("Check poison records")
 						block, err := decryptor.SkipBeginInBlock(row.output[row.writeIndex : row.writeIndex+columnDataLength])
 						if err == nil {
 							poisoned, err := decryptor.CheckPoisonRecord(bytes.NewReader(block))
@@ -362,7 +362,7 @@ func PgDecryptStream(decryptor base.Decryptor, config *PgDecryptorConfig, dbConn
 
 					// check poison records
 					if decryptor.GetPoisonCallbackStorage().HasCallbacks() {
-						log.Debugln("check poison records")
+						log.Debugln("Check poison records")
 						for {
 							beginTagIndex, tagLength := decryptor.BeginTagIndex(row.output[currentIndex:endIndex])
 							if beginTagIndex == utils.NOT_FOUND {

--- a/decryptor/postgresql/pg_decryptor.go
+++ b/decryptor/postgresql/pg_decryptor.go
@@ -114,7 +114,7 @@ func (row *DataRow) UpdateColumnAndDataSize(oldColumnLength, newColumnLength int
 	sizeDiff := oldColumnLength - newColumnLength
 	log.Debugf("Old column size: %v; New column size: %v", oldColumnLength, newColumnLength)
 	if newColumnLength > oldColumnLength {
-		row.errCh <- errors.New("Decrypted size is more than encrypted")
+		row.errCh <- errors.New("decrypted size is more than encrypted")
 		return false
 	}
 	binary.BigEndian.PutUint32(row.columnSizePointer, uint32(newColumnLength))

--- a/decryptor/postgresql/pg_decryptor.go
+++ b/decryptor/postgresql/pg_decryptor.go
@@ -19,15 +19,17 @@ import (
 	"crypto/tls"
 	"encoding/binary"
 	"errors"
+	"io"
+	"net"
+	"time"
+
 	"github.com/cossacklabs/acra/decryptor/base"
 	acra_io "github.com/cossacklabs/acra/io"
 	"github.com/cossacklabs/acra/network"
 	"github.com/cossacklabs/acra/utils"
 	"github.com/cossacklabs/acra/zone"
 	log "github.com/sirupsen/logrus"
-	"io"
-	"net"
-	"time"
+	"github.com/cossacklabs/acra/logging"
 )
 
 type DataRow struct {
@@ -106,17 +108,17 @@ func (row *DataRow) UpdateColumnAndDataSize(oldColumnLength, newColumnLength int
 		return true
 	}
 	// something was decrypted and size should be less that was before
-	log.Debugf("modify response size: %v -> %v", oldColumnLength, newColumnLength)
+	log.Debugf("Modify response size: %v -> %v", oldColumnLength, newColumnLength)
 
 	// update column data size
 	sizeDiff := oldColumnLength - newColumnLength
-	log.Debugf("old column size: %v; New column size: %v", oldColumnLength, newColumnLength)
+	log.Debugf("Old column size: %v; New column size: %v", oldColumnLength, newColumnLength)
 	if newColumnLength > oldColumnLength {
-		row.errCh <- errors.New("decrypted size is more than encrypted")
+		row.errCh <- errors.New("Decrypted size is more than encrypted")
 		return false
 	}
 	binary.BigEndian.PutUint32(row.columnSizePointer, uint32(newColumnLength))
-	log.Debugf("old data size: %v; new data size: %v", row.dataLength, row.dataLength-sizeDiff)
+	log.Debugf("Old data size: %v; new data size: %v", row.dataLength, row.dataLength-sizeDiff)
 	// update data row size
 	row.dataLength -= sizeDiff
 	row.SetDataSize(row.dataLength)
@@ -124,7 +126,7 @@ func (row *DataRow) UpdateColumnAndDataSize(oldColumnLength, newColumnLength int
 }
 
 func (row *DataRow) ReadDataLength() bool {
-	log.Debugln("read data length")
+	log.Debugln("Read data length")
 	// read full data row length
 	n, err := row.reader.Read(row.output[:DATA_ROW_LENGTH_BUF_SIZE])
 	if !base.CheckReadWrite(n, DATA_ROW_LENGTH_BUF_SIZE, err, row.errCh) {
@@ -193,7 +195,7 @@ func PgDecryptStream(decryptor base.Decryptor, config *PgDecryptorConfig, dbConn
 				writer.Flush()
 				continue
 			} else if row.buf[0] == 'S' {
-				log.Debugln("start tls proxy")
+				log.Debugln("Start tls proxy")
 				cer, err := config.getCertificate()
 				if err != nil {
 					errCh <- err
@@ -202,7 +204,8 @@ func PgDecryptStream(decryptor base.Decryptor, config *PgDecryptorConfig, dbConn
 				}
 				// stop reading from client in goroutine
 				if err = clientConnection.SetDeadline(time.Now()); err != nil {
-					log.WithError(err).Error("can't set deadline")
+					log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorDecryptorCantSetDeadlineToClientConnection).
+						Errorln("Can't set deadline")
 					errCh <- err
 					return
 				}
@@ -210,7 +213,8 @@ func PgDecryptStream(decryptor base.Decryptor, config *PgDecryptorConfig, dbConn
 				time.Sleep(time.Millisecond)
 				// reset deadline
 				if err = clientConnection.SetDeadline(time.Time{}); err != nil {
-					log.WithError(err).Error("can't set deadline")
+					log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorDecryptorCantSetDeadlineToClientConnection).
+						Errorln("Can't set deadline")
 					errCh <- err
 					return
 				}
@@ -218,21 +222,24 @@ func PgDecryptStream(decryptor base.Decryptor, config *PgDecryptorConfig, dbConn
 				// convert to tls connection
 				tlsClientConnection := tls.Server(clientConnection, &tls.Config{Certificates: []tls.Certificate{cer}})
 				if err = writer.Flush(); err != nil {
-					log.WithError(err).Error("can't flush writer")
+					log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorDecryptorCantInitializeTLS).
+						Errorln("Can't flush writer")
 					errCh <- err
 					return
 				}
 				err = tlsClientConnection.Handshake()
 				if err != nil {
-					log.WithError(err).Error("can't initialize tls connection with client")
+					log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorDecryptorCantInitializeTLS).
+						Errorln("Can't initialize tls connection with client")
 					errCh <- err
 					return
 				}
 
-				log.Debugln("init tls with db")
+				log.Debugln("Init tls with db")
 				dbTLSConnection := tls.Client(dbConnection, &tls.Config{InsecureSkipVerify: true})
 				if err = dbTLSConnection.Handshake(); err != nil {
-					log.WithError(err).Println("can't initialize tls connection with db")
+					log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorDecryptorCantInitializeTLS).
+						Errorln("Can't initialize tls connection with db")
 					errCh <- err
 					return
 				}

--- a/logging/event_codes.go
+++ b/logging/event_codes.go
@@ -36,9 +36,15 @@ const (
 	EventCodeErrorCantWrapConnection         = 538
 	EventCodeErrorConnectionDroppedByTimeout = 539
 
-
 	// database
-	EventCodeErrorCantConnectToDB = 540
+	EventCodeErrorCantConnectToDB       = 540
 	EventCodeErrorCantCloseConnectionDB = 541
-	EventCodeErrorCantInitDecryptor = 542
+	EventCodeErrorCantInitDecryptor     = 542
+
+	// config UI
+	EventCodeErrorCantReadTemplate     = 550
+	EventCodeErrorRequestMethodNotAllowed = 551
+	EventCodeErrorCantParseRequestData = 552
+	EventCodeErrorCantGetCurrentConfig = 553
+	EventCodeErrorCantSetNewConfig     = 5543
 )

--- a/logging/event_codes.go
+++ b/logging/event_codes.go
@@ -1,0 +1,36 @@
+package logging
+
+const (
+	// 100 .. 200 some events
+	EventCodeGeneral = 100
+
+	// 500 .. 600 errors
+	EventCodeErrorGeneral                    = 500
+
+	// processes
+	EventCodeErrorCantStartService             = 505
+	EventCodeErrorCantForkProcess              = 506
+	EventCodeErrorWrongConfiguration           = 507
+	EventCodeErrorCantReadServiceConfig        = 508
+	EventCodeErrorCantCloseConnectionToService = 509
+
+	// keys
+	EventCodeErrorCantInitKeyStore           = 510
+	EventCodeErrorCantReadKeys               = 511
+
+	// system events
+	EventCodeErrorCantGetFileDescriptor      = 520
+	EventCodeErrorCantRegisterSignalHandler  = 521
+
+	// transport / networks
+	EventCodeErrorCantStartListenConnections = 530
+	EventCodeErrorTransportConfiguration     = 531
+	EventCodeErrorCantAcceptNewConnections   = 532
+	EventCodeErrorCantStartConnection        = 533
+	EventCodeErrorCantHandleSecureSession    = 534
+
+	// database
+	EventCodeErrorCantConnectToDB = 540
+	EventCodeErrorCantCloseConnectionDB = 541
+	EventCodeErrorCantInitDecryptor = 542
+)

--- a/logging/event_codes.go
+++ b/logging/event_codes.go
@@ -19,15 +19,23 @@ const (
 	EventCodeErrorCantReadKeys               = 511
 
 	// system events
-	EventCodeErrorCantGetFileDescriptor      = 520
-	EventCodeErrorCantRegisterSignalHandler  = 521
+	EventCodeErrorCantGetFileDescriptor     = 520
+	EventCodeErrorCantOpenFileByDescriptor  = 521
+	EventCodeErrorFileDescriptionIsNotValid    = 522
+	EventCodeErrorCantRegisterSignalHandler = 523
 
 	// transport / networks
 	EventCodeErrorCantStartListenConnections = 530
-	EventCodeErrorTransportConfiguration     = 531
-	EventCodeErrorCantAcceptNewConnections   = 532
-	EventCodeErrorCantStartConnection        = 533
-	EventCodeErrorCantHandleSecureSession    = 534
+	EventCodeErrorCantStopListenConnections  = 531
+	EventCodeErrorTransportConfiguration     = 532
+	EventCodeErrorCantAcceptNewConnections   = 533
+	EventCodeErrorCantStartConnection        = 534
+	EventCodeErrorCantHandleSecureSession    = 535
+	EventCodeErrorCantCloseConnection        = 536
+	EventCodeErrorCantInitClientSession      = 537
+	EventCodeErrorCantWrapConnection         = 538
+	EventCodeErrorConnectionDroppedByTimeout = 539
+
 
 	// database
 	EventCodeErrorCantConnectToDB = 540

--- a/logging/event_codes.go
+++ b/logging/event_codes.go
@@ -21,7 +21,7 @@ const (
 	// system events
 	EventCodeErrorCantGetFileDescriptor     = 520
 	EventCodeErrorCantOpenFileByDescriptor  = 521
-	EventCodeErrorFileDescriptionIsNotValid    = 522
+	EventCodeErrorFileDescriptionIsNotValid = 522
 	EventCodeErrorCantRegisterSignalHandler = 523
 
 	// transport / networks
@@ -39,12 +39,31 @@ const (
 	// database
 	EventCodeErrorCantConnectToDB       = 540
 	EventCodeErrorCantCloseConnectionDB = 541
-	EventCodeErrorCantInitDecryptor     = 542
 
 	// config UI
-	EventCodeErrorCantReadTemplate     = 550
+	EventCodeErrorCantReadTemplate        = 550
 	EventCodeErrorRequestMethodNotAllowed = 551
-	EventCodeErrorCantParseRequestData = 552
-	EventCodeErrorCantGetCurrentConfig = 553
-	EventCodeErrorCantSetNewConfig     = 5543
+	EventCodeErrorCantParseRequestData    = 552
+	EventCodeErrorCantGetCurrentConfig    = 553
+	EventCodeErrorCantSetNewConfig        = 554
+
+	// firewall
+	EventCodeErrorFirewallQueryIsNotAllowed = 560
+
+	// response proxy
+	EventCodeErrorResponseProxyCantWriteToDB      = 570
+	EventCodeErrorResponseProxyCantReadFromClient = 571
+	EventCodeErrorResponseProxyCantWriteToClient  = 572
+	EventCodeErrorResponseProxyCantReadFromServer = 573
+	EventCodeErrorResponseProxyCantWriteToServer  = 574
+	EventCodeErrorResponseProxyCantProcessColumn  = 575
+	EventCodeErrorResponseProxyCantProcessRow     = 576
+
+	// decryptor
+	EventCodeErrorCantInitDecryptor                          = 580
+	EventCodeErrorDecryptorCantDecryptBinary                 = 581
+	EventCodeErrorDecryptorCantSkipBeginInBlock              = 582
+	EventCodeErrorDecryptorCantHandleRecognizedPoisonRecord  = 583
+	EventCodeErrorDecryptorCantInitializeTLS                 = 584
+	EventCodeErrorDecryptorCantSetDeadlineToClientConnection = 585
 )

--- a/logging/log_formatters.go
+++ b/logging/log_formatters.go
@@ -125,7 +125,7 @@ var (
 	// to be re-defined
 	extraCEFFields = logrus.Fields{
 		FieldKeyVendor:    "cossacklabs",
-		FieldKeyEventCode: 0,
+		FieldKeyEventCode: EventCodeGeneral,
 	}
 
 	JSONFieldMap = logrus.FieldMap{
@@ -139,7 +139,7 @@ var (
 //
 // Note: the given entry is copied and not changed during the formatting process.
 func (f AcraJSONFormatter) Format(e *logrus.Entry) ([]byte, error) {
-	// unix time
+	// unix time in milliseconds
 	f.Fields[FieldKeyUnixTime] = unixTimeWithMilliseconds(e)
 
 	ne := copyEntry(e, f.Fields)
@@ -153,7 +153,7 @@ func (f AcraJSONFormatter) Format(e *logrus.Entry) ([]byte, error) {
 //
 // Note: the given entry is copied and not changed during the formatting process.
 func (f AcraCEFFormatter) Format(e *logrus.Entry) ([]byte, error) {
-	// unix time
+	// unix time in milliseconds
 	f.Fields[FieldKeyUnixTime] = unixTimeWithMilliseconds(e)
 
 	ne := copyEntry(e, f.Fields)
@@ -164,7 +164,6 @@ func (f AcraCEFFormatter) Format(e *logrus.Entry) ([]byte, error) {
 
 
 func unixTimeWithMilliseconds(e *logrus.Entry) string {
-	//secs := e.Time.Unix()
 	nanos := e.Time.UnixNano()
 	millis := nanos / 1000000
 	millisf := float64(millis) / 1000.0

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -43,7 +43,7 @@ func CustomizeLogging(loggingFormat string, serviceName string) {
 	log.SetOutput(os.Stderr)
 	log.SetFormatter(logFormatterFor(loggingFormat, serviceName))
 
-	log.Infof("changed logging format to %s", loggingFormat)
+	log.Debugf("Changed logging format to %s", loggingFormat)
 }
 
 func logFormatterFor(loggingFormat string, serviceName string) log.Formatter {

--- a/network/secure_session_wrapper.go
+++ b/network/secure_session_wrapper.go
@@ -29,10 +29,10 @@ type SessionCallback struct {
 }
 
 func (callback *SessionCallback) GetPublicKeyForId(ss *session.SecureSession, id []byte) *keys.PublicKey {
-	log.Infof("load public key for id <%v>", string(id))
+	log.Infof("Load public key for id %v", string(id))
 	key, err := callback.keystorage.GetPeerPublicKey(id)
 	if err != nil {
-		log.WithError(err).Errorf("can't load public key for id <%v>", string(id))
+		log.WithError(err).Errorf("Can't load public key for id %v", string(id))
 		return nil
 	}
 	return key

--- a/tests/test.py
+++ b/tests/test.py
@@ -236,6 +236,7 @@ class BaseTestCase(unittest.TestCase):
     DB_HOST = os.environ.get('TEST_DB_HOST', '127.0.0.1')
     DB_NAME = os.environ.get('TEST_DB_NAME', 'postgres')
     DB_PORT = os.environ.get('TEST_DB_PORT', 5432)
+    DEBUG_LOG = os.environ.get('DEBUG_LOG', False)
 
     PROXY_PORT_1 = int(os.environ.get('TEST_PROXY_PORT', 9595))
     PROXY_PORT_2 = PROXY_PORT_1 + 200
@@ -247,7 +248,6 @@ class BaseTestCase(unittest.TestCase):
     DB_BYTEA = 'hex'
     WHOLECELL_MODE = False
     ZONE = False
-    DEBUG_LOG = False
     TEST_DATA_LOG = False
     TLS_ON = False
     maxDiff = None

--- a/tests/test.py
+++ b/tests/test.py
@@ -1135,7 +1135,7 @@ class TestNoCheckPoisonRecord(AcraCatchLogsMixin, BasePoisonRecordTest):
             out, er_ = self.acra.communicate(timeout=1)
         except subprocess.TimeoutExpired:
             pass
-        self.assertNotIn(b'Debug: check poison records', out)
+        self.assertNotIn(b'Check poison records', out)
 
 
 class TestNoCheckPoisonRecordWithZone(TestNoCheckPoisonRecord):
@@ -1182,7 +1182,7 @@ class TestCheckLogPoisonRecord(AcraCatchLogsMixin, BasePoisonRecordTest):
             out, _ = self.acra.communicate(timeout=1)
         except subprocess.TimeoutExpired:
             pass
-        self.assertIn(b'check poison records', out)
+        self.assertIn(b'Check poison records', out)
 
 
 class TestKeyStorageClearing(BaseTestCase):


### PR DESCRIPTION
Made logging for acra_proxy, acra_server, acra_configui more user-friendly.

0. Add custom logging format for acra_configui.
1. Suggest using error codes to differentiate errors.
2. Use error codes for most logs.
3. Add more info/debug logs.
4. Unify logs language.