### PR TITLE
fix panic error when adding TLS cert

### DIFF
--- a/cmd/acraserver/acraserver.go
+++ b/cmd/acraserver/acraserver.go
@@ -139,12 +139,12 @@ func main() {
 
 	if err := config.SetMySQL(*useMysql); err != nil {
 		log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorWrongConfiguration).
-			Errorln("can't set MySQL support")
+			Errorln("Can't set MySQL support")
 		os.Exit(1)
 	}
 	if err := config.SetPostgresql(*usePostgresql); err != nil {
 		log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorWrongConfiguration).
-			Errorln("can't set PostgreSQL support")
+			Errorln("Can't set PostgreSQL support")
 		os.Exit(1)
 	}
 
@@ -202,12 +202,12 @@ func main() {
 		// need for testing with mysql docker container that always generate new certificates
 		if TestOnly == TEST_MODE {
 			tlsConfig.InsecureSkipVerify = true
-			log.Warningln("only for tests!")
+			log.Warningln("Skip verifying TLS certificate, use for tests only!")
 		}
 	}
 	config.SetTLSConfig(tlsConfig)
 	if *useTls {
-		log.Println("use TLS transport wrapper")
+		log.Println("Using TLS transport wrapper")
 		config.ConnectionWrapper, err = network.NewTLSConnectionWrapper([]byte(*clientId), tlsConfig)
 		if err != nil {
 			log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorTransportConfiguration).

--- a/network/tls_wrapper.go
+++ b/network/tls_wrapper.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/cossacklabs/acra/logging"
 	log "github.com/sirupsen/logrus"
+	"errors"
 )
 
 type TLSConnectionWrapper struct {
@@ -41,13 +42,13 @@ func NewTLSConfig(serverName string, caPath, keyPath, crtPath string) (*tls.Conf
 	if caPath != "" {
 		caPem, err := ioutil.ReadFile(caPath)
 		if err != nil {
-			log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorGeneral).Errorln("can't read root CA certificate")
+			log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorGeneral).Errorln("Can't read root CA certificate")
 			return nil, err
 		}
-		log.Debugln("add CA root certificate")
+		log.Debugln("Adding CA root certificate")
 		if ok := roots.AppendCertsFromPEM(caPem); !ok {
-			log.Errorln("can't add CA certificate")
-			return nil, err
+			log.Errorln("Can't add CA certificate from PEM")
+			return nil, errors.New("can't add CA certificate")
 		}
 	}
 	cer, err := tls.LoadX509KeyPair(crtPath, keyPath)


### PR DESCRIPTION
Fix error on adding TLS config and improve some logs

log:

```
time="2018-04-03T14:25:01Z" level=info msg="Starting service"
time="2018-04-03T14:25:01Z" level=info msg="Validating service configuration"
time="2018-04-03T14:25:01Z" level=error msg="can't add CA certificate"
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x487028]
goroutine 8 [running]:
panic(0x802020, 0xc420018050)
	/home/buildbot/go_1.7.6/src/runtime/panic.go:500 +0x1a1
crypto/tls.(*Conn).serverHandshake(0xc42012f880, 0x8bc3b0, 0xc42012f988)
	/home/buildbot/go_1.7.6/src/crypto/tls/handshake_server.go:44 +0x58
crypto/tls.(*Conn).Handshake(0xc42012f880, 0x0, 0x0)
	/home/buildbot/go_1.7.6/src/crypto/tls/conn.go:1262 +0x2c3
github.com/cossacklabs/acra/decryptor/postgresql.PgDecryptStream(0xc75f40, 0xc4200f7810, 0x0, 0xc746e0, 0xc42002a050, 0xc746e0, 0xc42002a040, 0xc420064240)
	/home/buildbot/go_path_1.7.6/src/github.com/cossacklabs/acra/decryptor/postgresql/pg_decryptor.go:213 +0x267f
created by main.(*ClientSession).HandleSecureSession
	/home/buildbot/go_path_1.7.6/src/github.com/cossacklabs/acra/cmd/acraserver/client_session.go:105 +0xd3d
```