### PR TITLE
Decrease amount of connection errors during tests

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -874,8 +874,9 @@ class TestConnectionClosing(BaseTestCase):
         # try create new connection
         connection2 = self.get_connection()
         self.check_count(cursor, current_connection_count + 1)
-
+        connection2.cursor().close()
         connection2.close()
+
         self.check_count(cursor, current_connection_count)
         cursor.close()
         connection.close()

--- a/tests/test.py
+++ b/tests/test.py
@@ -65,6 +65,7 @@ FORK_FAIL_SLEEP = 0.1
 CONNECTION_FAIL_SLEEP = 0.1
 SOCKET_CONNECT_TIMEOUT = 10
 KILL_WAIT_TIMEOUT = 10
+BETWEEN_TESTS_SLEEP = 0.5
 
 TEST_WITH_TLS = os.environ.get('TEST_TLS', 'off').lower() == 'on'
 
@@ -518,7 +519,9 @@ class BaseTestCase(unittest.TestCase):
         except:
             pass
         for engine in getattr(self, 'engines', []):
-            engine.dispose()
+            engine.dispose()     
+        # sleep before next test
+        time.sleep(BETWEEN_TESTS_SLEEP)
 
     def get_random_data(self):
         size = random.randint(100, DATA_MAX_SIZE)
@@ -763,6 +766,8 @@ class TestConnectionClosing(BaseTestCase):
         if not self.EXTERNAL_ACRA and hasattr(self, 'acra'):
             procs.append(self.acra)
         stop_process(procs)
+        # sleep before next test
+        time.sleep(BETWEEN_TESTS_SLEEP)
 
     def getActiveConnectionCount(self, cursor):
         if TEST_MYSQL:
@@ -901,6 +906,8 @@ class TestKeyNonExistence(BaseTestCase):
     def tearDown(self):
         if hasattr(self, 'acra'):
             stop_process(self.acra)
+        # sleep before next test
+        time.sleep(BETWEEN_TESTS_SLEEP)
 
     def delete_key(self, filename):
         os.remove('.acrakeys{sep}{name}'.format(sep=os.path.sep, name=filename))
@@ -1254,6 +1261,9 @@ class TestKeyStorageClearing(BaseTestCase):
         for engine in self.engines:
             engine.dispose()
 
+        # sleep before next test
+        time.sleep(BETWEEN_TESTS_SLEEP)
+
     def test_clearing(self):
         # execute any query for loading key by acra
         result = self.engine1.execute(sa.select([1]).limit(1))
@@ -1336,6 +1346,8 @@ class TestAcraRollback(BaseTestCase):
         self.engine_raw.dispose()
         if os.path.exists(self.output_filename):
             os.remove(self.output_filename)
+        # sleep before next test
+        time.sleep(BETWEEN_TESTS_SLEEP)
 
     def run_rollback(self, extra_args):
         args = ['./acra_rollback'] + self.default_rollback_args + extra_args
@@ -1558,6 +1570,8 @@ class SSLPostgresqlConnectionTest(HexFormatTest):
                 engine.dispose()
         except:
             pass
+        # sleep before next test
+        time.sleep(BETWEEN_TESTS_SLEEP)
 
 
 class SSLPostgresqlConnectionWithZoneTest(ZoneHexFormatTest,
@@ -1662,6 +1676,8 @@ class SSLMysqlConnectionTest(HexFormatTest):
                 engine.dispose()
         except:
             pass
+        # sleep before next test
+        time.sleep(BETWEEN_TESTS_SLEEP)
 
 
 class SSLMysqlConnectionWithZoneTest(ZoneHexFormatTest,

--- a/tests/test.py
+++ b/tests/test.py
@@ -140,7 +140,7 @@ def create_client_keypair(name, only_server=False, only_client=False):
     return subprocess.call(args, cwd=os.getcwd(), timeout=PROCESS_CALL_TIMEOUT)
 
 
-def wait_connection(port, count=10, sleep=0.1):
+def wait_connection(port, count=10, sleep=0.3):
     """try connect to 127.0.0.1:port and close connection
     if can't then sleep on and try again (<count> times)
     if <count> times is failed than raise Exception
@@ -158,7 +158,7 @@ def wait_connection(port, count=10, sleep=0.1):
     raise Exception("can't wait connection")
 
 
-def wait_unix_socket(socket_path, count=10, sleep=0.1):
+def wait_unix_socket(socket_path, count=10, sleep=0.3):
     while count:
         try:
             connection = socket.socket(socket.AF_UNIX)
@@ -866,6 +866,7 @@ class TestConnectionClosing(BaseTestCase):
         created_connections = self.checkConnectionLimit(connection_limit)
 
         for conn in connections + created_connections:
+            conn.cursor().close()
             conn.close()
 
         self.check_count(cursor, current_connection_count)


### PR DESCRIPTION
This workaround possibly decreases amount of unstable connection errors during integration tests.

I can't be sure that it will help to eliminate all connection issues, but according to my last N tests, it reduces connection errors on CircleCI significantly (I got no connection errors during testing in my branch).

However, due to delay between tests, overall time for testing increases in ~1.5x.

I think we should merge this workaround to master branch. However, if we won't get positive results, just put `0` as value of `BETWEEN_TESTS_SLEEP` to remove extra delays.