### PR TITLE
fix initializing cert pool

### DIFF
--- a/network/tls_wrapper.go
+++ b/network/tls_wrapper.go
@@ -44,6 +44,8 @@ func NewTLSConfig(serverName string, caPath, keyPath, crtPath string) (*tls.Conf
 	if roots, err = x509.SystemCertPool(); err != nil {
 		log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorGeneral).
 			Errorln("Can't load system ca certificates")
+	}
+	if roots == nil {
 		roots = x509.NewCertPool()
 	}
 	if caPath != "" {


### PR DESCRIPTION
SystemCertPool has next code:
```
func loadSystemRoots() (*CertPool, error) {
	roots := NewCertPool()
	var firstErr error
	for _, file := range certFiles {
		data, err := ioutil.ReadFile(file)
		if err == nil {
			roots.AppendCertsFromPEM(data)
			return roots, nil
		}
		if firstErr == nil && !os.IsNotExist(err) {
			firstErr = err
		}
	}

	for _, directory := range certDirectories {
		fis, err := ioutil.ReadDir(directory)
		if err != nil {
			if firstErr == nil && !os.IsNotExist(err) {
				firstErr = err
			}
			continue
		}
		rootsAdded := false
		for _, fi := range fis {
			data, err := ioutil.ReadFile(directory + "/" + fi.Name())
			if err == nil && roots.AppendCertsFromPEM(data) {
				rootsAdded = true
			}
		}
		if rootsAdded {
			return roots, nil
		}
	}

	return nil, firstErr
}
```
and has one case when no certs was added and 0 errors then it `return nil, firstErr` where firstErr may be nil too
Added check on nil and create empty pool if so