### PR TITLE
rename 'logger' to 'query_capture' for AcraCensor

### DIFF
--- a/acra-censor/acra-censor_configuration_provider.go
+++ b/acra-censor/acra-censor_configuration_provider.go
@@ -8,14 +8,14 @@ import (
 
 const BlacklistConfigStr = "blacklist"
 const WhitelistConfigStr = "whitelist"
-const LoggerConfigStr = "logger"
+const LoggerConfigStr = "query_capture"
 
 type AcraCensorConfig struct {
 	Handlers []struct {
-		Handler string
-		Queries []string
-		Tables  []string
-		Rules   []string
+		Handler  string
+		Queries  []string
+		Tables   []string
+		Rules    []string
 		Filepath string
 	}
 }

--- a/configs/acra-censor.example.yaml
+++ b/configs/acra-censor.example.yaml
@@ -1,5 +1,5 @@
 handlers:
-  - handler: logger
+  - handler: query_capture
     filepath: censor_log
   - handler: blacklist
     queries:


### PR DESCRIPTION
for sanity sake! :D

and because `query_capture` is name of the  [`querycapture_handler`](https://github.com/cossacklabs/acra/blob/master/acra-censor/handlers/querycapture_handler.go) itself