### PR TITLE
support mysql in python examples (T633)

### DIFF
--- a/examples/python/example_with_zone.py
+++ b/examples/python/example_with_zone.py
@@ -25,7 +25,8 @@ except ImportError:
     # Fall back to Python 2's urllib2
     from urllib2 import urlopen
 
-from sqlalchemy import Table, Column, Integer, String, MetaData, create_engine, select, Binary
+from sqlalchemy import (Table, Column, Integer, MetaData, create_engine,
+    select, Binary, Text)
 from sqlalchemy import cast
 from sqlalchemy.dialects.postgresql import BYTEA
 
@@ -50,18 +51,25 @@ if __name__ == '__main__':
     parser.add_argument('--data', type=str, help='data to save in ascii. default random data')
     parser.add_argument('--print', action='store_true', help='just print data', default=False)
     parser.add_argument('-v', '--verbose', dest='verbose', action='store_true', help='verbose', default=False)
+    parser.add_argument('--postgresql', action='store_true', help="use postgresql driver (default if nothing else   set)")
+    parser.add_argument('--mysql', action='store_true', help="use mysql driver")
     args = parser.parse_args()
+
+    # default driver
+    driver = 'postgresql'
+    if args.mysql:
+        driver = 'mysql+pymysql'
 
     metadata = MetaData()
     test = Table('test_example_with_zone', metadata,
         Column('id', Integer, primary_key=True),
         Column('data', Binary),
-        Column('raw_data', String),
+        Column('raw_data', Text),
     )
     if args.verbose:
-        proxy_engine = create_engine('postgresql://{}:{}@{}:{}/{}'.format(args.db_user, args.db_password, args.host, args.port, args.db_name), echo=True)
+        proxy_engine = create_engine('{}://{}:{}@{}:{}/{}'.format(driver, args.db_user, args.db_password, args.host, args.port, args.db_name), echo=True)
     else:
-        proxy_engine = create_engine('postgresql://{}:{}@{}:{}/{}'.format(args.db_user, args.db_password, args.host, args.port, args.db_name))
+        proxy_engine = create_engine('{}://{}:{}@{}:{}/{}'.format(driver, args.db_user, args.db_password, args.host, args.port, args.db_name))
     proxy_connection = proxy_engine.connect()
     metadata.create_all(proxy_engine)
 

--- a/examples/python/example_without_zone.py
+++ b/examples/python/example_without_zone.py
@@ -16,7 +16,8 @@ import argparse
 import string
 from random import randint, choice
 
-from sqlalchemy import Table, Column, Integer, String, MetaData, types, create_engine, select
+from sqlalchemy import (Table, Column, Integer, MetaData, types,
+    create_engine, select, Text)
 
 from acrawriter import create_acrastruct
 
@@ -60,7 +61,14 @@ if __name__ == '__main__':
     parser.add_argument('--host', type=str, default='localhost', help='host of acra-connector to connect')
     parser.add_argument('--data', type=str, help='data to save in ascii. default random data')
     parser.add_argument('--print', action='store_true', help='just print data', default=False)
+    parser.add_argument('--postgresql', action='store_true', help="use postgresql driver (default if nothing else   set)")
+    parser.add_argument('--mysql', action='store_true', help="use mysql driver")
     args = parser.parse_args()
+
+    # default driver
+    driver = 'postgresql'
+    if args.mysql:
+        driver = 'mysql+pymysql'
 
     metadata = MetaData()
     with open(args.public_key, 'rb') as f:
@@ -68,10 +76,10 @@ if __name__ == '__main__':
     test = Table('test_example_without_zone', metadata,
         Column('id', Integer, primary_key=True),
         Column('data', AcraBinary(key)),
-        Column('raw_data', String),
+        Column('raw_data', Text),
     )
 
-    proxy_engine = create_engine('postgresql://{}:{}@{}:{}/{}'.format(args.db_user, args.db_password, args.host, args.port, args.db_name))
+    proxy_engine = create_engine('{}://{}:{}@{}:{}/{}'.format(driver, args.db_user, args.db_password, args.host, args.port, args.db_name))
     proxy_connection = proxy_engine.connect()
     metadata.create_all(proxy_engine)
     if getattr(args, 'print', False):

--- a/examples/python/requirements.txt
+++ b/examples/python/requirements.txt
@@ -1,4 +1,3 @@
-sqlalchemy
-psycopg2
-pythemis
-acrawriter
+-r requirements/base.txt
+-r requirements/postgresql.txt
+-r requirements/mysql.txt

--- a/examples/python/requirements/base.txt
+++ b/examples/python/requirements/base.txt
@@ -1,0 +1,3 @@
+sqlalchemy
+pythemis
+acrawriter

--- a/examples/python/requirements/mysql.txt
+++ b/examples/python/requirements/mysql.txt
@@ -1,0 +1,2 @@
+-r base.txt
+PyMySQL

--- a/examples/python/requirements/postgresql.txt
+++ b/examples/python/requirements/postgresql.txt
@@ -1,0 +1,2 @@
+-r base.txt
+psycopg2


### PR DESCRIPTION
* use mysql driver too
* add argument to switch to mysql
* separate requirement files for pip, to install them both or separately
* postgresql driver set as default to leave backward compatibility all examples and docs that exists now