### PR TITLE
mysql prepared statements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,8 @@ jobs:
       - run: cd $HOME && for version in $VERSIONS; do mkdir -p go_path_$version/src/github.com/cossacklabs/themis/gothemis; mkdir -p go_path_$version/src/github.com/cossacklabs/acra; rsync -auv $HOME/themis/gothemis/ go_path_$version/src/github.com/cossacklabs/themis/gothemis; rsync -auv $HOME/project/ go_path_$version/src/github.com/cossacklabs/acra; done
       - run: cd $HOME && for version in $VERSIONS; do GOROOT=$HOME/go_root_$version/go PATH=$GOROOT/bin/:$PATH GOPATH=$HOME/go_path_$version go get -d github.com/cossacklabs/acra/...; done
       - run: pip3 install -r $HOME/project/tests/requirements.txt
+      # install from sources because pip install git+https://github.com/mysql/mysql-connector-python not support recursive submodules
+      - run: git clone https://github.com/Lagovas/mysql-connector-python; cd mysql-connector-python; sudo python3 setup.py clean build_py install_lib
       - run: sudo ldconfig
     # testing
       # delete file if exists

--- a/acra-censor/acra-censor_test.go
+++ b/acra-censor/acra-censor_test.go
@@ -210,7 +210,6 @@ func testWhitelistRules(t *testing.T, acraCensor *AcraCensor, whitelistHandler *
 
 func TestBlacklistQueries(t *testing.T) {
 	sqlSelectQueries := []string{
-		"SELECT * FROM Schema.Tables;",
 		"SELECT Student_ID FROM STUDENT;",
 		"SELECT * FROM STUDENT;",
 		"SELECT EMP_ID, NAME FROM EMPLOYEE_TBL WHERE EMP_ID = '0000';",
@@ -429,7 +428,6 @@ func testBlacklistRules(t *testing.T, acraCensor *AcraCensor, blacklistHandler *
 
 func TestQueryIgnoring(t *testing.T) {
 	testQueries := []string{
-		"SELECT * FROM Schema.Tables;",
 		"SELECT Student_ID FROM STUDENT;",
 		"SELECT * FROM STUDENT;",
 		"SELECT * FROM STUDENT;",
@@ -461,14 +459,12 @@ func TestQueryIgnoring(t *testing.T) {
 	ignoreQueryHandler.AddQueries(testQueries)
 	acraCensor.AddHandler(ignoreQueryHandler)
 
-
 	blacklist := &handlers.BlacklistHandler{}
 	err := blacklist.AddQueries(testQueries)
 	if err != nil {
 		t.Fatal(err)
 	}
 	acraCensor.AddHandler(blacklist)
-
 
 	//should not block
 	for _, query := range testQueries {
@@ -491,7 +487,6 @@ func TestQueryIgnoring(t *testing.T) {
 
 func TestSerialization(t *testing.T) {
 	testQueries := []string{
-		"SELECT * FROM Schema.Tables;",
 		"SELECT Student_ID FROM STUDENT;",
 		"SELECT * FROM STUDENT;",
 		"SELECT * FROM X;",
@@ -688,7 +683,6 @@ func TestQueryCapture(t *testing.T) {
 	defer handler.Release()
 
 	testQueries := []string{
-		"SELECT * FROM Schema.Tables;",
 		"SELECT Student_ID FROM STUDENT;",
 		"SELECT * FROM STUDENT;",
 		"SELECT * FROM X;",
@@ -702,7 +696,7 @@ func TestQueryCapture(t *testing.T) {
 		}
 	}
 
-	expected := "[{\"RawQuery\":\"SELECT * FROM Schema.Tables;\",\"IsForbidden\":false},{\"RawQuery\":\"SELECT Student_ID FROM STUDENT;\",\"IsForbidden\":false},{\"RawQuery\":\"SELECT * FROM STUDENT;\",\"IsForbidden\":false},{\"RawQuery\":\"SELECT * FROM X;\",\"IsForbidden\":false},{\"RawQuery\":\"SELECT * FROM Y;\",\"IsForbidden\":false}]"
+	expected := "[{\"RawQuery\":\"SELECT Student_ID FROM STUDENT;\",\"IsForbidden\":false},{\"RawQuery\":\"SELECT * FROM STUDENT;\",\"IsForbidden\":false},{\"RawQuery\":\"SELECT * FROM X;\",\"IsForbidden\":false},{\"RawQuery\":\"SELECT * FROM Y;\",\"IsForbidden\":false}]"
 
 	defaultTimeout := handler.GetSerializationTimeout()
 	handler.SetSerializationTimeout(50 * time.Millisecond)
@@ -724,7 +718,7 @@ func TestQueryCapture(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expected = "[{\"RawQuery\":\"SELECT * FROM Schema.Tables;\",\"IsForbidden\":false},{\"RawQuery\":\"SELECT Student_ID FROM STUDENT;\",\"IsForbidden\":false},{\"RawQuery\":\"SELECT * FROM STUDENT;\",\"IsForbidden\":false},{\"RawQuery\":\"SELECT * FROM X;\",\"IsForbidden\":false},{\"RawQuery\":\"SELECT * FROM Y;\",\"IsForbidden\":false},{\"RawQuery\":\"SELECT * FROM Z;\",\"IsForbidden\":false}]"
+	expected = "[{\"RawQuery\":\"SELECT Student_ID FROM STUDENT;\",\"IsForbidden\":false},{\"RawQuery\":\"SELECT * FROM STUDENT;\",\"IsForbidden\":false},{\"RawQuery\":\"SELECT * FROM X;\",\"IsForbidden\":false},{\"RawQuery\":\"SELECT * FROM Y;\",\"IsForbidden\":false},{\"RawQuery\":\"SELECT * FROM Z;\",\"IsForbidden\":false}]"
 	time.Sleep(handler.GetSerializationTimeout() + 10*time.Millisecond)
 
 	result, err = ioutil.ReadFile(tmpFile.Name())

--- a/acra-censor/acra-censor_test.go
+++ b/acra-censor/acra-censor_test.go
@@ -665,7 +665,8 @@ func TestLogging(t *testing.T) {
 	}
 }
 func TestQueryCapture(t *testing.T) {
-
+	// extraWaitTime provide extra time to serialize in background goroutine before check
+	const extraWaitTime = 100 * time.Millisecond
 	tmpFile, err := ioutil.TempFile("", "censor_log")
 	if err != nil {
 		t.Fatal(err)
@@ -701,7 +702,7 @@ func TestQueryCapture(t *testing.T) {
 	defaultTimeout := handler.GetSerializationTimeout()
 	handler.SetSerializationTimeout(50 * time.Millisecond)
 	//wait until goroutine handles complex serialization
-	time.Sleep(defaultTimeout + handler.GetSerializationTimeout() + 10*time.Millisecond)
+	time.Sleep(defaultTimeout + handler.GetSerializationTimeout() + extraWaitTime)
 
 	result, err := ioutil.ReadFile(tmpFile.Name())
 	if err != nil {
@@ -719,7 +720,7 @@ func TestQueryCapture(t *testing.T) {
 	}
 
 	expected = "[{\"RawQuery\":\"SELECT Student_ID FROM STUDENT;\",\"IsForbidden\":false},{\"RawQuery\":\"SELECT * FROM STUDENT;\",\"IsForbidden\":false},{\"RawQuery\":\"SELECT * FROM X;\",\"IsForbidden\":false},{\"RawQuery\":\"SELECT * FROM Y;\",\"IsForbidden\":false},{\"RawQuery\":\"SELECT * FROM Z;\",\"IsForbidden\":false}]"
-	time.Sleep(handler.GetSerializationTimeout() + 10*time.Millisecond)
+	time.Sleep(handler.GetSerializationTimeout() + extraWaitTime)
 
 	result, err = ioutil.ReadFile(tmpFile.Name())
 	if err != nil {

--- a/acra-censor/handlers/querycapture_handler.go
+++ b/acra-censor/handlers/querycapture_handler.go
@@ -2,18 +2,27 @@ package handlers
 
 import (
 	"encoding/json"
-	"github.com/cossacklabs/acra/logging"
-	log "github.com/sirupsen/logrus"
 	"io/ioutil"
 	"os"
 	"os/signal"
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/cossacklabs/acra/logging"
+	log "github.com/sirupsen/logrus"
 )
 
 const MaxQueriesInChannel = 10
 const DefaultSerializationTimeout = time.Second
+const LogQueryLength = 100
+
+func trimToN(query string, n int) string {
+	if len(query) <= n {
+		return query
+	}
+	return query[:n]
+}
 
 type QueryCaptureHandler struct {
 	Queries              []QueryInfo
@@ -147,7 +156,7 @@ func (handler *QueryCaptureHandler) CheckQuery(query string) (bool, error) {
 	select {
 	case handler.logChannel <- *queryInfo: // channel is ok
 	default: //channel is full
-		log.Errorf("Can't process too many queries")
+		log.Errorf("Can't process too many queries. Skip query: %s", trimToN(query, LogQueryLength))
 	}
 
 	return true, nil

--- a/cmd/acra-connector/acra-connector.go
+++ b/cmd/acra-connector/acra-connector.go
@@ -108,8 +108,8 @@ func handleClientConnection(config *Config, connection net.Conn) {
 	acraConn.SetDeadline(time.Time{})
 	defer acraConnWrapped.Close()
 
-	toAcraErrCh := make(chan error)
-	fromAcraErrCh := make(chan error)
+	toAcraErrCh := make(chan error, 1)
+	fromAcraErrCh := make(chan error, 1)
 	go network.Proxy(connection, acraConnWrapped, toAcraErrCh)
 	go network.Proxy(acraConnWrapped, connection, fromAcraErrCh)
 	select {

--- a/cmd/acra-server/listener.go
+++ b/cmd/acra-server/listener.go
@@ -205,7 +205,7 @@ func (server *SServer) Start() {
 func (server *SServer) StartFromFileDescriptor(fd uintptr) {
 	file := os.NewFile(fd, "/tmp/acra-server")
 	if file == nil {
-		log.Errorln("can't create new file from descriptor for acra listener")
+		log.Errorln("Can't create new file from descriptor for acra listener")
 		server.errorSignalChannel <- syscall.SIGTERM
 		return
 	}
@@ -411,7 +411,7 @@ func (server *SServer) StartCommandsFromFileDescriptor(fd uintptr) {
 	var connection net.Conn
 	file := os.NewFile(fd, "/tmp/acra-server_http_api")
 	if file == nil {
-		log.Errorln("can't create new file from descriptor for api listener")
+		log.Errorln("Can't create new file from descriptor for api listener")
 		server.errorSignalChannel <- syscall.SIGTERM
 		return
 	}

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -58,10 +58,10 @@ func (handler *SignalHandler) AddCallback(callback SignalCallback) {
 
 // Register should be called as goroutine
 func (handler *SignalHandler) Register() {
-	for _, osSignal := range handler.signals {
-		signal.Notify(handler.ch, osSignal)
-	}
+	signal.Notify(handler.ch, handler.signals...)
+
 	<-handler.ch
+
 	for _, listener := range handler.listeners {
 		listener.Close()
 	}

--- a/decryptor/mysql/response_proxy.go
+++ b/decryptor/mysql/response_proxy.go
@@ -337,6 +337,9 @@ func (handler *MysqlHandler) processBinaryDataRow(rowData []byte, fields []*Colu
 		return nil, ErrMalformPacket
 	}
 
+	// https://dev.mysql.com/doc/internals/en/binary-protocol-resultset-row.html
+	// 1 - packet header
+	// 7 + 2 offset from docs
 	pos = 1 + ((len(fields) + 7 + 2) >> 3)
 	nullBitmap := rowData[1:pos]
 	output = append(output, rowData[:pos]...)

--- a/decryptor/postgresql/pg_decryptor.go
+++ b/decryptor/postgresql/pg_decryptor.go
@@ -264,12 +264,11 @@ func (row *DataRow) Marshal() ([]byte, error) {
 type PgProxy struct {
 	clientConnection net.Conn
 	dbConnection     net.Conn
-	errCh            chan<- error
 	TlsCh            chan bool
 }
 
-func NewPgProxy(clientConnection, dbConnection net.Conn, errCh chan<- error) (*PgProxy, error) {
-	return &PgProxy{clientConnection: clientConnection, dbConnection: dbConnection, errCh: errCh, TlsCh: make(chan bool)}, nil
+func NewPgProxy(clientConnection, dbConnection net.Conn) (*PgProxy, error) {
+	return &PgProxy{clientConnection: clientConnection, dbConnection: dbConnection, TlsCh: make(chan bool)}, nil
 }
 
 func NewClientSideDataRow(reader *acra_io.ExtendedBufferedReader, writer *bufio.Writer) (*DataRow, error) {
@@ -433,7 +432,7 @@ func (proxy *PgProxy) PgDecryptStream(censor acracensor.AcraCensorInterface, dec
 					break
 				case <-time.NewTimer(TLS_TIMEOUT).C:
 					log.Errorln("can't stop background goroutine to start tls handshake")
-					proxy.errCh <- errors.New("can't stop background goroutine")
+					errCh <- errors.New("can't stop background goroutine")
 					return
 				}
 				log.Debugln("stop client connection")

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,3 +4,5 @@ sqlalchemy
 PyMySQL==0.8.0
 semver==2.7.9
 requests
+# driver with binary prepared statements support
+#mysql-connector-python==8.0.11

--- a/tests/test.py
+++ b/tests/test.py
@@ -1445,7 +1445,7 @@ class TestKeyStorageClearing(BaseTestCase):
         except:
             pass
 
-        for engine in self.engines:
+        for engine in getattr(self, 'engines', []):
             engine.dispose()
 
     def test_clearing(self):


### PR DESCRIPTION
* support prepared statements with [binary](https://dev.mysql.com/doc/internals/en/binary-protocol-resultset.html) and [text](https://dev.mysql.com/doc/internals/en/com-query-response.html#packet-ProtocolText::Resultset) formats of response
* test support of prepared statements with postgresql/mysql (two formats)
* fix race condition (when one goroutine close connection with secure session and second try to write/encrypt)
* increase wait time in acra-censor tests for correct running on slow machines (need refactoring in a future)
* small refactoring 