### PR TITLE
Using JSON line format for QueryCapture

### DIFF
--- a/acra-censor/acra-censor_interfaces.go
+++ b/acra-censor/acra-censor_interfaces.go
@@ -2,7 +2,6 @@ package acracensor
 
 type QueryHandlerInterface interface {
 	CheckQuery(sqlQuery string) (bool, error) //1st return arg specifies whether continue verification or not, 2nd specifies whether query is forbidden
-	Reset()
 	Release()
 }
 

--- a/acra-censor/acra-censor_test.go
+++ b/acra-censor/acra-censor_test.go
@@ -511,7 +511,7 @@ func TestSerialization(t *testing.T) {
 		"INSERT INTO dbo.Points (PointValue) VALUES ('1,99');",
 	}
 
-	tmpFile, err := ioutil.TempFile("", "censor_log.jsonl")
+	tmpFile, err := ioutil.TempFile("", "censor_log")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -697,7 +697,10 @@ func TestQueryCapture(t *testing.T) {
 		}
 	}
 
-	expected := "[{\"RawQuery\":\"SELECT Student_ID FROM STUDENT;\",\"IsForbidden\":false},{\"RawQuery\":\"SELECT * FROM STUDENT;\",\"IsForbidden\":false},{\"RawQuery\":\"SELECT * FROM X;\",\"IsForbidden\":false},{\"RawQuery\":\"SELECT * FROM Y;\",\"IsForbidden\":false}]"
+	expected := "{\"RawQuery\":\"SELECT Student_ID FROM STUDENT;\",\"IsForbidden\":false}\n" +
+		"{\"RawQuery\":\"SELECT * FROM STUDENT;\",\"IsForbidden\":false}\n" +
+		"{\"RawQuery\":\"SELECT * FROM X;\",\"IsForbidden\":false}\n" +
+		"{\"RawQuery\":\"SELECT * FROM Y;\",\"IsForbidden\":false}\n"
 
 	defaultTimeout := handler.GetSerializationTimeout()
 	handler.SetSerializationTimeout(50 * time.Millisecond)
@@ -719,7 +722,11 @@ func TestQueryCapture(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expected = "[{\"RawQuery\":\"SELECT Student_ID FROM STUDENT;\",\"IsForbidden\":false},{\"RawQuery\":\"SELECT * FROM STUDENT;\",\"IsForbidden\":false},{\"RawQuery\":\"SELECT * FROM X;\",\"IsForbidden\":false},{\"RawQuery\":\"SELECT * FROM Y;\",\"IsForbidden\":false},{\"RawQuery\":\"SELECT * FROM Z;\",\"IsForbidden\":false}]"
+	expected = "{\"RawQuery\":\"SELECT Student_ID FROM STUDENT;\",\"IsForbidden\":false}\n" +
+		"{\"RawQuery\":\"SELECT * FROM STUDENT;\",\"IsForbidden\":false}\n" +
+		"{\"RawQuery\":\"SELECT * FROM X;\",\"IsForbidden\":false}\n" +
+		"{\"RawQuery\":\"SELECT * FROM Y;\",\"IsForbidden\":false}\n" +
+		"{\"RawQuery\":\"SELECT * FROM Z;\",\"IsForbidden\":false}\n"
 	time.Sleep(handler.GetSerializationTimeout() + extraWaitTime)
 
 	result, err = ioutil.ReadFile(tmpFile.Name())

--- a/acra-censor/acra-censor_test.go
+++ b/acra-censor/acra-censor_test.go
@@ -511,7 +511,7 @@ func TestSerialization(t *testing.T) {
 		"INSERT INTO dbo.Points (PointValue) VALUES ('1,99');",
 	}
 
-	tmpFile, err := ioutil.TempFile("", "censor_log")
+	tmpFile, err := ioutil.TempFile("", "censor_log.jsonl")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -542,7 +542,7 @@ func TestSerialization(t *testing.T) {
 		t.Fatal("Expected: " + strings.Join(testQueries, " | ") + "\nGot: " + strings.Join(handler.GetAllInputQueries(), " | "))
 	}
 
-	err = handler.Serialize()
+	err = handler.DumpAllQueriesToFile()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -553,7 +553,7 @@ func TestSerialization(t *testing.T) {
 		t.Fatal("Expected no queries \nGot: " + strings.Join(handler.GetAllInputQueries(), " | "))
 	}
 
-	err = handler.Deserialize()
+	err = handler.ReadAllQueriesFromFile()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -630,7 +630,7 @@ func TestLogging(t *testing.T) {
 	loggingHandler.MarkQueryAsForbidden(testQueries[0])
 	loggingHandler.MarkQueryAsForbidden(testQueries[1])
 	loggingHandler.MarkQueryAsForbidden(testQueries[2])
-	loggingHandler.Serialize()
+	loggingHandler.DumpAllQueriesToFile()
 
 	err = blacklist.AddQueries(loggingHandler.GetForbiddenQueries())
 	if err != nil {

--- a/acra-censor/handlers/handlers_util.go
+++ b/acra-censor/handlers/handlers_util.go
@@ -27,6 +27,8 @@ var ErrStructureSyntaxError = errors.New("fail to parse specified structure")
 
 var ErrComplexSerializationError = errors.New("can't perform complex serialization of queries")
 var ErrSingleQueryCaptureError = errors.New("can't capture single query")
+var ErrCantOpenFileError = errors.New("can't open file to write queries")
+var ErrCantReadQueriesFromFileError = errors.New("can't read queries from file")
 var ErrUnexpectedCaptureChannelClose = errors.New("unexpected channel closing while query logging")
 
 var ErrUnexpectedTypeError = errors.New("should never appear")

--- a/acra-censor/handlers/querycapture_handler.go
+++ b/acra-censor/handlers/querycapture_handler.go
@@ -16,13 +16,6 @@ import (
 
 const DefaultSerializationTimeout = time.Second
 
-func trimToN(query string, n int) string {
-	if len(query) <= n {
-		return query
-	}
-	return query[:n]
-}
-
 type QueryCaptureHandler struct {
 	Queries              []*QueryInfo
 	BufferedQueries      []*QueryInfo

--- a/logging/event_codes.go
+++ b/logging/event_codes.go
@@ -57,6 +57,7 @@ const (
 	EventCodeErrorCensorSetupError        = 561
 	EventCodeErrorCensorSecurityError     = 562
 	EventCodeErrorCensorQueryParseError   = 563
+	EventCodeErrorCensorIOError           = 564
 
 	// response connector
 	EventCodeErrorResponseConnectorCantWriteToDB      = 570


### PR DESCRIPTION
As we discussed previously having large JSON file as Query blob might be not the best option [T605]

- format changed from large json to multiline json
- on each parsed query remember query in the buffer
- dump buffer into file once a while (instead of writing into the file on each query)