### PR TITLE
ignore parse errors

### DIFF
--- a/acra-censor/acra-censor_configuration_provider.go
+++ b/acra-censor/acra-censor_configuration_provider.go
@@ -19,6 +19,7 @@ type AcraCensorConfig struct {
 		Rules    []string
 		Filepath string
 	}
+	IgnoreParseError bool `yaml:"ignore_parse_error"`
 }
 
 func (acraCensor *AcraCensor) LoadConfiguration(configuration []byte) error {
@@ -27,6 +28,7 @@ func (acraCensor *AcraCensor) LoadConfiguration(configuration []byte) error {
 	if err != nil {
 		return err
 	}
+	acraCensor.ignoreParseError = censorConfiguration.IgnoreParseError
 	for _, handlerConfiguration := range censorConfiguration.Handlers {
 		switch handlerConfiguration.Handler {
 		case WhitelistConfigStr:

--- a/acra-censor/acra-censor_implementation.go
+++ b/acra-censor/acra-censor_implementation.go
@@ -1,11 +1,13 @@
 package acracensor
 
 import (
+	"github.com/cossacklabs/acra/acra-censor/handlers"
 	log "github.com/sirupsen/logrus"
 )
 
 type AcraCensor struct {
-	handlers []QueryHandlerInterface
+	handlers         []QueryHandlerInterface
+	ignoreParseError bool
 }
 
 func (acraCensor *AcraCensor) AddHandler(handler QueryHandlerInterface) {
@@ -30,6 +32,10 @@ func (acraCensor *AcraCensor) HandleQuery(query string) error {
 	for _, handler := range acraCensor.handlers {
 		continueHandling, err := handler.CheckQuery(query)
 		if err != nil {
+			if err == handlers.ErrQuerySyntaxError && acraCensor.ignoreParseError {
+				log.WithError(err).Infof("parsing error on query (first %v symbols): %s", handlers.LogQueryLength, handlers.TrimStringToN(query, handlers.LogQueryLength))
+				continue
+			}
 			log.Errorf("Forbidden query: '%s'", query)
 			return err
 		} else {

--- a/acra-censor/acra-censor_test.go
+++ b/acra-censor/acra-censor_test.go
@@ -758,6 +758,10 @@ func TestConfigurationProvider(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	if acraCensor.ignoreParseError {
+		t.Fatal("ignore_parse_error must be 'false' as default")
+	}
+
 	if len(acraCensor.handlers) != 3 {
 		t.Fatal("Unexpected amount of handlers: ", len(acraCensor.handlers))
 	}
@@ -846,7 +850,7 @@ func testSyntax(t *testing.T) {
       - SELECT * ROM EMPLOYEE WHERE CITY='Seattle';`
 
 	err = acraCensor.LoadConfiguration([]byte(configuration))
-	if err != handlers.ErrStructureSyntaxError {
+	if err != handlers.ErrQuerySyntaxError {
 		t.Fatal(err)
 	}
 }
@@ -886,4 +890,43 @@ func TestDifferentTablesParsing(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestIgnoringQueryParseErrors(t *testing.T) {
+	queriesWithSyntaxErrors := []string{
+		"Insert into something",
+	}
+	acraCensor := &AcraCensor{}
+	defer acraCensor.ReleaseAll()
+	whitelistHandler := &handlers.WhitelistHandler{}
+	whitelistHandler.AddTables([]string{"some table"})
+	blacklistHandler := &handlers.BlacklistHandler{}
+	blacklistHandler.AddTables([]string{"some table"})
+
+	checkHandler := func(queryHandlers []QueryHandlerInterface, expectedError error) {
+		for _, handler := range queryHandlers {
+			acraCensor.AddHandler(handler)
+		}
+		for _, query := range queriesWithSyntaxErrors {
+			err := acraCensor.HandleQuery(query)
+			if err != expectedError {
+				t.Fatalf("unexpected error value - %v", err)
+			}
+		}
+		for _, handler := range queryHandlers {
+			acraCensor.RemoveHandler(handler)
+		}
+	}
+
+	checkHandler([]QueryHandlerInterface{whitelistHandler}, handlers.ErrQuerySyntaxError)
+	checkHandler([]QueryHandlerInterface{blacklistHandler}, handlers.ErrQuerySyntaxError)
+	// check when censor with two handlers and each one will return query parse error
+	checkHandler([]QueryHandlerInterface{whitelistHandler, blacklistHandler}, handlers.ErrQuerySyntaxError)
+
+	acraCensor.ignoreParseError = true
+
+	checkHandler([]QueryHandlerInterface{whitelistHandler}, nil)
+	checkHandler([]QueryHandlerInterface{blacklistHandler}, nil)
+	// check when censor with two handlers and each one will return query parse error
+	checkHandler([]QueryHandlerInterface{whitelistHandler, blacklistHandler}, nil)
 }

--- a/acra-censor/handlers/blacklist_handler.go
+++ b/acra-censor/handlers/blacklist_handler.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"errors"
+	"github.com/cossacklabs/acra/logging"
 	"github.com/xwb1989/sqlparser"
 	"reflect"
 	"strings"
@@ -28,7 +29,7 @@ func (handler *BlacklistHandler) CheckQuery(query string) (bool, error) {
 	if len(handler.tables) != 0 {
 		parsedQuery, err := sqlparser.Parse(query)
 		if err != nil {
-			log.WithError(err).Errorln("Can't parse query in blacklist handler for check")
+			log.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCensorQueryParseError).WithError(err).Errorln("Can't parse query in blacklist handler for check")
 			return false, ErrQuerySyntaxError
 		}
 		switch parsedQuery := parsedQuery.(type) {
@@ -196,7 +197,7 @@ func (handler *BlacklistHandler) AddRules(rules []string) error {
 		handler.rules = append(handler.rules, rule)
 		_, err := sqlparser.Parse(rule)
 		if err != nil {
-			log.WithError(err).Errorln("Can't parse query to add rule to blacklist handler")
+			log.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCensorQueryParseError).WithError(err).Errorln("Can't parse query to add rule to blacklist handler")
 			return ErrQuerySyntaxError
 		}
 	}
@@ -225,7 +226,7 @@ func (handler *BlacklistHandler) testRulesViolation(query string) (bool, error) 
 	for _, rule := range handler.rules {
 		parsedRule, err := sqlparser.Parse(rule)
 		if err != nil {
-			log.WithError(err).Errorln("Can't parse rule in blacklist handler for test")
+			log.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCensorQueryParseError).WithError(err).Errorln("Can't parse rule in blacklist handler for test")
 			return true, ErrQuerySyntaxError
 		}
 		switch parsedRule := parsedRule.(type) {
@@ -255,7 +256,7 @@ func (handler *BlacklistHandler) testRulesViolation(query string) (bool, error) 
 func (handler *BlacklistHandler) isDangerousSelect(selectQuery string, forbiddenWhere sqlparser.SQLNode, forbiddenTables sqlparser.TableExprs, forbiddenColumns sqlparser.SelectExprs) (bool, error) {
 	parsedSelectQuery, err := sqlparser.Parse(selectQuery)
 	if err != nil {
-		log.WithError(err).Errorln("Can't parse query in blacklist handler to check is it dangerous select")
+		log.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCensorQueryParseError).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCensorQueryParseError).WithError(err).Errorln("Can't parse query in blacklist handler to check is it dangerous select")
 		return true, ErrQuerySyntaxError
 	}
 	evaluatedStmt := parsedSelectQuery.(*sqlparser.Select)

--- a/acra-censor/handlers/handlers_util.go
+++ b/acra-censor/handlers/handlers_util.go
@@ -14,16 +14,13 @@ var ErrAccessToForbiddenTableWhitelist = errors.New("query tries to access forbi
 var ErrForbiddenSqlStructureBlacklist = errors.New("query's structure is forbidden")
 var ErrForbiddenSqlStructureWhitelist = errors.New("query's structure is forbidden")
 
-var ErrParseTablesBlacklist = errors.New("parsing tables error")
 var ErrParseSqlRuleBlacklist = errors.New("parsing security rules error")
 
-var ErrParseTablesWhitelist = errors.New("parsing tables error")
 var ErrParseSqlRuleWhitelist = errors.New("parsing security rules error")
 
 var ErrNotImplemented = errors.New("not implemented yet")
 
 var ErrQuerySyntaxError = errors.New("fail to parse specified query")
-var ErrStructureSyntaxError = errors.New("fail to parse specified structure")
 
 var ErrComplexSerializationError = errors.New("can't perform complex serialization of queries")
 var ErrSingleQueryCaptureError = errors.New("can't capture single query")

--- a/acra-censor/handlers/handlers_util.go
+++ b/acra-censor/handlers/handlers_util.go
@@ -51,3 +51,9 @@ func contains(queries []string, query string) (bool, int) {
 	}
 	return false, 0
 }
+func TrimStringToN(query string, n int) string {
+	if len(query) <= n {
+		return query
+	}
+	return query[:n]
+}

--- a/acra-censor/handlers/querycapture_handler.go
+++ b/acra-censor/handlers/querycapture_handler.go
@@ -17,13 +17,6 @@ const MaxQueriesInChannel = 10
 const DefaultSerializationTimeout = time.Second
 const LogQueryLength = 100
 
-func trimToN(query string, n int) string {
-	if len(query) <= n {
-		return query
-	}
-	return query[:n]
-}
-
 type QueryCaptureHandler struct {
 	Queries              []QueryInfo
 	filePath             string
@@ -156,7 +149,7 @@ func (handler *QueryCaptureHandler) CheckQuery(query string) (bool, error) {
 	select {
 	case handler.logChannel <- *queryInfo: // channel is ok
 	default: //channel is full
-		log.Errorf("Can't process too many queries. Skip query: %s", trimToN(query, LogQueryLength))
+		log.Errorf("Can't process too many queries. Skip query: %s", TrimStringToN(query, LogQueryLength))
 	}
 
 	return true, nil

--- a/acra-censor/handlers/whitelist_handler.go
+++ b/acra-censor/handlers/whitelist_handler.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"errors"
+	"github.com/cossacklabs/acra/logging"
 	"github.com/xwb1989/sqlparser"
 	"reflect"
 	"strings"
@@ -27,7 +28,7 @@ func (handler *WhitelistHandler) CheckQuery(query string) (bool, error) {
 	if len(handler.tables) != 0 {
 		parsedQuery, err := sqlparser.Parse(query)
 		if err != nil {
-			log.WithError(err).Errorln("Can't parse query in whitelist handler for check")
+			log.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCensorQueryParseError).WithError(err).Errorln("Can't parse query in whitelist handler for check")
 			return false, ErrQuerySyntaxError
 		}
 		switch parsedQuery := parsedQuery.(type) {
@@ -228,7 +229,7 @@ func (handler *WhitelistHandler) AddRules(rules []string) error {
 		handler.rules = append(handler.rules, rule)
 		_, err := sqlparser.Parse(rule)
 		if err != nil {
-			log.WithError(err).Errorln("Can't parse query to add rule to whitelist handler")
+			log.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCensorQueryParseError).WithError(err).Errorln("Can't parse query to add rule to whitelist handler")
 			return ErrQuerySyntaxError
 		}
 	}
@@ -257,7 +258,7 @@ func (handler *WhitelistHandler) testRulesViolation(query string) (bool, error) 
 	for _, rule := range handler.rules {
 		parsedRule, err := sqlparser.Parse(rule)
 		if err != nil {
-			log.WithError(err).Errorln("Can't parse rule in whitelist handler for test")
+			log.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCensorQueryParseError).WithError(err).Errorln("Can't parse rule in whitelist handler for test")
 			return true, ErrQuerySyntaxError
 		}
 		switch parsedRule := parsedRule.(type) {
@@ -287,7 +288,7 @@ func (handler *WhitelistHandler) testRulesViolation(query string) (bool, error) 
 func (handler *WhitelistHandler) isDangerousSelect(selectQuery string, allowedWhere sqlparser.SQLNode, allowedTables sqlparser.TableExprs, allowedColumns sqlparser.SelectExprs) (bool, error) {
 	parsedSelectQuery, err := sqlparser.Parse(selectQuery)
 	if err != nil {
-		log.WithError(err).Errorln("Can't parse query in whitelist handler to check is it dangerous select")
+		log.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCensorQueryParseError).WithError(err).Errorln("Can't parse query in whitelist handler to check is it dangerous select")
 		return true, ErrQuerySyntaxError
 	}
 	evaluatedStmt := parsedSelectQuery.(*sqlparser.Select)

--- a/configs/acra-censor.example.yaml
+++ b/configs/acra-censor.example.yaml
@@ -1,3 +1,4 @@
+ignore_parse_error: false
 handlers:
   - handler: query_capture
     priority: 1


### PR DESCRIPTION
now user can configure to not block queries that censor can't parse via parameter in censor config `ignore_parse_error` that default `false` (parsing with errors will block queries as default)