### PR TITLE
fix concurrent map iteration during logging

### DIFF
--- a/logging/log_formatters.go
+++ b/logging/log_formatters.go
@@ -135,12 +135,8 @@ var (
 //
 // Note: the given entry is copied and not changed during the formatting process.
 func (f AcraJSONFormatter) Format(e *logrus.Entry) ([]byte, error) {
-	// unix time in milliseconds
-	f.lock.Lock()
-	f.Fields[FieldKeyUnixTime] = unixTimeWithMilliseconds(e)
-	f.lock.Unlock()
-
 	ne := copyEntry(e, f.Fields)
+	ne.Data[FieldKeyUnixTime] = unixTimeWithMilliseconds(e)
 	dataBytes, err := f.Formatter.Format(ne)
 	releaseEntry(ne)
 	return dataBytes, err
@@ -150,12 +146,8 @@ func (f AcraJSONFormatter) Format(e *logrus.Entry) ([]byte, error) {
 //
 // Note: the given entry is copied and not changed during the formatting process.
 func (f AcraCEFFormatter) Format(e *logrus.Entry) ([]byte, error) {
-	// unix time in milliseconds
-	f.lock.Lock()
-	f.Fields[FieldKeyUnixTime] = unixTimeWithMilliseconds(e)
-	f.lock.Unlock()
-
 	ne := copyEntry(e, f.Fields)
+	ne.Data[FieldKeyUnixTime] = unixTimeWithMilliseconds(e)
 	dataBytes, err := f.CEFTextFormatter.Format(ne)
 	releaseEntry(ne)
 	return dataBytes, err

--- a/tests/test.py
+++ b/tests/test.py
@@ -539,6 +539,7 @@ class BaseTestCase(unittest.TestCase):
         args = {
             'db_host': self.DB_HOST,
             'db_port': self.DB_PORT,
+            'logging_format': 'cef',
             # we doesn't need in tests waiting closing connections
             'incoming_connection_close_timeout': 0,
             self.ACRA_BYTEA: 'true',


### PR DESCRIPTION
set unixtime to new copy of fields instead of formatter's field that is global for each `format` call. 
We had situation:
1. goroutine1 lock mutex, update time in formatter's `Fields` 
2. goroutine2 blocked after trying to lock mutex
3. goroutine1 unlock mutex, execute code and start to iterate over `Fields` and copy values (in `copyEntry` function)
4. goroutine2 unblocked and update time in formatter's `Fields` 
5. goroutine1 on next iteration see that map was changed and is not "fresh", and panic

