### PR TITLE
[WIP] AcraReader: basic HTTP API /decrypt handling

### DIFF
--- a/logging/event_codes.go
+++ b/logging/event_codes.go
@@ -82,4 +82,15 @@ const (
 
 	// mysql processing
 	EventCodeErrorProtocolProcessing = 600
+
+	// AcraReader
+	EventCodeErrorReaderCantHandleHTTPRequest           = 700
+	EventCodeErrorReaderMethodNotAllowed                = 701
+	EventCodeErrorReaderMalformedURL                    = 702
+	EventCodeErrorReaderVersionNotSupported             = 703
+	EventCodeErrorReaderEndpointNotSupported            = 704
+	EventCodeErrorReaderCantParseRequestBody            = 705
+	EventCodeErrorReaderCantReadPrivateKeyForDecryption = 706
+	EventCodeErrorReaderCantDecryptAcraStruct           = 707
+	EventCodeErrorReaderCantReturnResponse              = 708
 )


### PR DESCRIPTION
Initial version of AcraReader HTTP API handling.

API format:

Request
```
POST `<host>/v1/decrypt?zone_id=<zone_id_string>`
Content-Type: application/octet-stream
Content-Length: [NUMBER_OF_BYTES_IN_FILE]

[ACRASTRUCT]
```

Response:
```
HTTP/1.1 200 OK
Content-Length: 88
Content-Type: application/octet-stream
Connection: Closed

[DECRYPTED ACRASTRUCT]
```