### PR TITLE
speedup circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,14 +24,16 @@ jobs:
       TEST_DB_USER: test
       TEST_DB_USER_PASSWORD: test
       TEST_DB_NAME: test
+      GOPATH_FOLDER: gopath
     steps:
     # prepare
       - run: sudo apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get -y install libssl-dev python python-setuptools python3 python3-setuptools python3-pip git rsync psmisc
       - run: cd $HOME && git clone https://github.com/cossacklabs/themis && cd themis && sudo make install
       - run: cd $HOME && for version in $VERSIONS; do mkdir go_root_$version; cd go_root_$version; wget https://storage.googleapis.com/golang/go$version.linux-amd64.tar.gz; tar xf go$version.linux-amd64.tar.gz; cd -; done
+      - run: mkdir $HOME/$GOPATH_FOLDER
       - checkout
-      - run: cd $HOME && for version in $VERSIONS; do mkdir -p go_path_$version/src/github.com/cossacklabs/themis/gothemis; mkdir -p go_path_$version/src/github.com/cossacklabs/acra; rsync -auv $HOME/themis/gothemis/ go_path_$version/src/github.com/cossacklabs/themis/gothemis; rsync -auv $HOME/project/ go_path_$version/src/github.com/cossacklabs/acra; done
-      - run: cd $HOME && for version in $VERSIONS; do GOROOT=$HOME/go_root_$version/go PATH=$GOROOT/bin/:$PATH GOPATH=$HOME/go_path_$version go get -d github.com/cossacklabs/acra/...; done
+      - run: cd $HOME && mkdir -p $HOME/$GOPATH_FOLDER/src/github.com/cossacklabs/themis/gothemis; mkdir -p $HOME/$GOPATH_FOLDER/src/github.com/cossacklabs/acra; rsync -auv $HOME/themis/gothemis/ $HOME/$GOPATH_FOLDER/src/github.com/cossacklabs/themis/gothemis; rsync -auv $HOME/project/ $HOME/$GOPATH_FOLDER/src/github.com/cossacklabs/acra
+      - run: cd $HOME && GOPATH=$HOME/$GOPATH_FOLDER go get -d github.com/cossacklabs/acra/...
       - run: pip3 install -r $HOME/project/tests/requirements.txt
       # install from sources because pip install git+https://github.com/mysql/mysql-connector-python not support recursive submodules
       - run: git clone https://github.com/Lagovas/mysql-connector-python; cd mysql-connector-python; sudo python3 setup.py clean build_py install_lib
@@ -40,7 +42,7 @@ jobs:
       # delete file if exists
       - run: if [ -f $FILEPATH_ERROR_FLAG ]; then rm "$FILEPATH_ERROR_FLAG"; fi
       # run test in each go environment and create $FILEPATH_ERROR_FLAG file if was any error. But all tests should
-      - run: cd $HOME && for version in $VERSIONS; do export GOROOT=$HOME/go_root_$version/go; export PATH=$GOROOT/bin/:$PATH; export GOPATH=$HOME/go_path_$version; go test -v github.com/cossacklabs/acra/...; if [ "$?" != "0" ]; then echo "$version" >> "$FILEPATH_ERROR_FLAG"; fi done
+      - run: cd $HOME && for version in $VERSIONS; do export GOROOT=$HOME/go_root_$version/go; export PATH=$GOROOT/bin/:$PATH; export GOPATH=$HOME/$GOPATH_FOLDER; rm -rf $HOME/$GOPATH_FOLDER/bin; rm -r f$HOME/$GOPATH_FOLDER/pkg; go test -v github.com/cossacklabs/acra/...; if [ "$?" != "0" ]; then echo "$version" >> "$FILEPATH_ERROR_FLAG"; fi done
       # if file exists (exit code of stat == 0 ) then something was wrong. cat file with versions of environments where was error and return exit 1
       - run: if [ -f  $FILEPATH_ERROR_FLAG ]; then cat "$FILEPATH_ERROR_FLAG"; rm "$FILEPATH_ERROR_FLAG"; exit 1; fi
       # each iteration pass to test different ports for forks to avoid problems with TCP TIME WAIT between tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
       - run: cd $HOME && for version in $VERSIONS; do mkdir go_root_$version; cd go_root_$version; wget https://storage.googleapis.com/golang/go$version.linux-amd64.tar.gz; tar xf go$version.linux-amd64.tar.gz; cd -; done
       - run: mkdir $HOME/$GOPATH_FOLDER
       - checkout
-      - run: cd $HOME && mkdir -p $HOME/$GOPATH_FOLDER/src/github.com/cossacklabs/themis/gothemis; mkdir -p $HOME/$GOPATH_FOLDER/src/github.com/cossacklabs/acra; ln -s $HOME/themis/gothemis $HOME/$GOPATH_FOLDER/src/github.com/cossacklabs/themis/gothemis; ln -s $HOME/project/ $HOME/$GOPATH_FOLDER/src/github.com/cossacklabs/acra
+      - run: cd $HOME && mkdir -p $HOME/$GOPATH_FOLDER/src/github.com/cossacklabs/themis; mkdir -p $HOME/$GOPATH_FOLDER/src/github.com/cossacklabs/acra; ln -s $HOME/themis/gothemis $HOME/$GOPATH_FOLDER/src/github.com/cossacklabs/themis/gothemis; cp -r $HOME/project/* $HOME/$GOPATH_FOLDER/src/github.com/cossacklabs/acra/
       - run: cd $HOME && GOPATH=$HOME/$GOPATH_FOLDER go get -d github.com/cossacklabs/acra/...
       - run: pip3 install -r $HOME/project/tests/requirements.txt
       # install from sources because pip install git+https://github.com/mysql/mysql-connector-python not support recursive submodules

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
       - run: cd $HOME && for version in $VERSIONS; do mkdir go_root_$version; cd go_root_$version; wget https://storage.googleapis.com/golang/go$version.linux-amd64.tar.gz; tar xf go$version.linux-amd64.tar.gz; cd -; done
       - run: mkdir $HOME/$GOPATH_FOLDER
       - checkout
-      - run: cd $HOME && mkdir -p $HOME/$GOPATH_FOLDER/src/github.com/cossacklabs/themis/gothemis; mkdir -p $HOME/$GOPATH_FOLDER/src/github.com/cossacklabs/acra; rsync -auv $HOME/themis/gothemis/ $HOME/$GOPATH_FOLDER/src/github.com/cossacklabs/themis/gothemis; rsync -auv $HOME/project/ $HOME/$GOPATH_FOLDER/src/github.com/cossacklabs/acra
+      - run: cd $HOME && mkdir -p $HOME/$GOPATH_FOLDER/src/github.com/cossacklabs/themis/gothemis; mkdir -p $HOME/$GOPATH_FOLDER/src/github.com/cossacklabs/acra; ln -s $HOME/themis/gothemis $HOME/$GOPATH_FOLDER/src/github.com/cossacklabs/themis/gothemis; ln -s $HOME/project/ $HOME/$GOPATH_FOLDER/src/github.com/cossacklabs/acra
       - run: cd $HOME && GOPATH=$HOME/$GOPATH_FOLDER go get -d github.com/cossacklabs/acra/...
       - run: pip3 install -r $HOME/project/tests/requirements.txt
       # install from sources because pip install git+https://github.com/mysql/mysql-connector-python not support recursive submodules
@@ -42,7 +42,7 @@ jobs:
       # delete file if exists
       - run: if [ -f $FILEPATH_ERROR_FLAG ]; then rm "$FILEPATH_ERROR_FLAG"; fi
       # run test in each go environment and create $FILEPATH_ERROR_FLAG file if was any error. But all tests should
-      - run: cd $HOME && for version in $VERSIONS; do export GOROOT=$HOME/go_root_$version/go; export PATH=$GOROOT/bin/:$PATH; export GOPATH=$HOME/$GOPATH_FOLDER; rm -rf $HOME/$GOPATH_FOLDER/bin; rm -r f$HOME/$GOPATH_FOLDER/pkg; go test -v github.com/cossacklabs/acra/...; if [ "$?" != "0" ]; then echo "$version" >> "$FILEPATH_ERROR_FLAG"; fi done
+      - run: cd $HOME && for version in $VERSIONS; do export GOROOT=$HOME/go_root_$version/go; export PATH=$GOROOT/bin/:$PATH; export GOPATH=$HOME/$GOPATH_FOLDER; rm -rf $HOME/$GOPATH_FOLDER/bin; rm -rf $HOME/$GOPATH_FOLDER/pkg; go test -v github.com/cossacklabs/acra/...; if [ "$?" != "0" ]; then echo "$version" >> "$FILEPATH_ERROR_FLAG"; fi done
       # if file exists (exit code of stat == 0 ) then something was wrong. cat file with versions of environments where was error and return exit 1
       - run: if [ -f  $FILEPATH_ERROR_FLAG ]; then cat "$FILEPATH_ERROR_FLAG"; rm "$FILEPATH_ERROR_FLAG"; exit 1; fi
       # each iteration pass to test different ports for forks to avoid problems with TCP TIME WAIT between tests

--- a/.circleci/integration.sh
+++ b/.circleci/integration.sh
@@ -12,7 +12,7 @@ for version in $VERSIONS; do
     export TEST_CONNECTOR_COMMAND_PORT=$(expr ${TEST_CONNECTOR_COMMAND_PORT} + 1);
     export GOROOT=$HOME/go_root_$version/go;
     export PATH=$GOROOT/bin/:$PATH;
-    export GOPATH=$HOME/go_path_$version;
+    export GOPATH=$HOME/$GOPATH_FOLDER;
 
     # setup postgresql credentials
     #export TEST_DB_USER=${POSTGRES_USER}


### PR DESCRIPTION
use one gopath for all versions of golang and download sources of dependencies once
p.s. actually, it decreases duration of this operations from ~1.5-2 minutes to 0.7-1 min ... Depends on network