### PR TITLE
check that insert query contain placeholder

### DIFF
--- a/cmd/acra-rollback/acra-rollback.go
+++ b/cmd/acra-rollback/acra-rollback.go
@@ -183,6 +183,11 @@ func main() {
 		PLACEHOLDER = "?"
 	}
 
+	if !strings.Contains(*sqlInsert, PLACEHOLDER) {
+		log.Errorln("SQL INSERT statement doesn't contain any placeholders")
+		os.Exit(1)
+	}
+
 	dbDriverName := "postgres"
 	if *useMysql {
 		// https://github.com/ziutek/mymysql

--- a/tests/test.py
+++ b/tests/test.py
@@ -1685,6 +1685,26 @@ class TestAcraRollback(BaseTestCase):
         for data in result:
             self.assertIn(data[0], source_data)
 
+    def test_without_placeholder(self):
+        args = ['./acra-rollback',
+            '--execute=true',
+            '--select=select data from {};'.format(test_table.name),
+            '--insert=query without placeholders;',
+            '--postgresql_enable'
+        ]
+
+        log_file = tempfile.NamedTemporaryFile('w+', encoding='utf-8')
+        popen_args = {
+            'stderr': subprocess.PIPE,
+            'stdout': subprocess.PIPE,
+            'close_fds': True
+        }
+        process = subprocess.Popen(args, **popen_args)
+        _, err = process.communicate(timeout=5)
+        stop_process(process)
+
+        self.assertIn(b"SQL INSERT statement doesn't contain any placeholders", err)
+
 
 class TestAcraKeyMakers(unittest.TestCase):
     def test_only_alpha_client_id(self):


### PR DESCRIPTION
after recent acra-rollback usage met case when it was helpful if acra-rollback check that query contains expected placeholder for example if user run from bash like: 
``` 
acra-rollback arg1 arg1 --insert="some query $1" 
``` 
he will be surprised to see that output will not contain any decrypted data but `select` queries and decryption was executed. Because bash use `$n` as placeholders too :)

acra-rollback will take query with replaced value by bash (empty for example and placeholder will not placed in query)