### PR TITLE
Fix AcraCensor tests

### DIFF
--- a/acra-censor/acra-censor_test.go
+++ b/acra-censor/acra-censor_test.go
@@ -655,7 +655,13 @@ func TestConfigurationProvider(t *testing.T) {
 		t.Fatal(err)
 	}
 	acraCensor := &AcraCensor{}
-	defer acraCensor.ReleaseAll()
+	defer func() {
+		acraCensor.ReleaseAll()
+		err = os.Remove("censor_log")
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
 	err = acraCensor.LoadConfiguration(configuration)
 	if err != nil {
 		t.Fatal(err)
@@ -709,10 +715,6 @@ func TestConfigurationProvider(t *testing.T) {
 		}
 	}
 	testSyntax(t)
-	err = os.Remove("censor_log")
-	if err != nil {
-		t.Fatal(err)
-	}
 }
 func testSyntax(t *testing.T) {
 	acraCensor := &AcraCensor{}

--- a/acra-censor/handlers/querycapture_handler.go
+++ b/acra-censor/handlers/querycapture_handler.go
@@ -117,8 +117,8 @@ func (handler *QueryCaptureHandler) Reset() {
 }
 
 func (handler *QueryCaptureHandler) Release() {
-	handler.Reset()
 	handler.signalBackgroundExit <- true
+	handler.Reset()
 }
 
 func (handler *QueryCaptureHandler) FinishAndCloseFile(openedFile *os.File) error {


### PR DESCRIPTION
Clean up "ghost" censor_log file that appears after AcraCensor unit tests.