### PR TITLE
avoid free server struct until end of program [T707]

### DIFF
--- a/cmd/acra-server/acra-server.go
+++ b/cmd/acra-server/acra-server.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cossacklabs/acra/network"
 	"github.com/cossacklabs/acra/utils"
 	log "github.com/sirupsen/logrus"
+	"runtime"
 )
 
 var restartSignalsChannel chan os.Signal
@@ -373,4 +374,5 @@ func main() {
 
 	// todo: any reason why it's so far from adding callback?
 	sigHandlerSIGHUP.Register()
+	runtime.KeepAlive(server)
 }


### PR DESCRIPTION
I think we get mysterious panics in tests because after `go server.Start()` golang runtime can free server struct in some cases because in main function it doesn't used after this function call and to be sure I want to try explicitly say to keep alive this struct