### PR TITLE
Created AcraTranslator examples

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,8 +1,9 @@
 # docker
   * `acra-authmanager.dockerfile` - resulting image with AcraAuthmanager tool
   * `acra-build.dockerfile` - intermediate image for compile all acra components
-  * `acra-connector.dockerfile` - resulting image with AcraConnector
   * `acra-server.dockerfile` - resulting image with AcraServer
+  * `acra-connector.dockerfile` - resulting image with AcraConnector
+  * `acra-translator.dockerfile` - resulting image with AcraTranslator
   * `acra-keymaker.dockerfile` - resulting image with AcraKeymaker tool
   * `acra-webconfig.dockerfile` - resulting image with AcraWebconfig component
   * `mysql-nossl.dockerfile` - MySQL server container with disabled SSL
@@ -68,6 +69,11 @@ included into composes and is given only to indicate its position):
   * `docker/docker-compose.pgsql-ssl-server-ssl_zonemode.yml`
     PostgreSQL <-SSL-> AcraServer <-SSL-> client in zone mode
 
+  * `docker/docker-compose.translator-ssession-connector-http.yml`
+    AcraTranslator <-SecureSession-> AcraConnector <-HTTP-> client
+  * `docker/docker-compose.translator-ssession-connector-grpc.yml`
+    AcraTranslator <-SecureSession-> AcraConnector <-gRPC-> client
+
 
 ## Quick launch
 
@@ -78,7 +84,7 @@ docker-compose -f docker/<compose_file_name>.yml up
 This will create `docker/.acrakeys` directory structure, generate all key pairs,
 put them to appropriate services' directories and launch all components.
 
-Now you can connect to:
+Now you can connect to (depending on selected example):
 
 |   Port   |          Component           |     In docker-compose examples with     |
 |----------|------------------------------|-----------------------------------------|

--- a/docker/docker-compose.translator-ssession-connector-grpc.yml
+++ b/docker/docker-compose.translator-ssession-connector-grpc.yml
@@ -1,0 +1,110 @@
+version: "3"
+
+services:
+    # Create keys:
+    # - ./.acrakeys/acra-connector/${ACRA_CLIENT_ID}
+    # - ./.acrakeys/acra-translator/${ACRA_CLIENT_ID}.pub
+    acra-keymaker_connector:
+        # You can specify docker image tag in the environment
+        # variable ACRA_DOCKER_IMAGE_TAG or run by default with 'latest' images
+        image: "cossacklabs/acra-keymaker:${ACRA_DOCKER_IMAGE_TAG:-latest}"
+        # We do not need network for keys' generation at all
+        network_mode: "none"
+        environment:
+            # INSECURE!!! You MUST define your own ACRA_MASTER_KEY
+            # The default is only for testing purposes
+            ACRA_MASTER_KEY: ${ACRA_MASTER_KEY:-UHZ3VUNNeTJ0SEFhbWVjNkt4eDdVYkc2WnNpUTlYa0E=}
+        volumes:
+            - ./.acrakeys:/keys
+        command: >-
+            --client_id=${ACRA_CLIENT_ID:-testclientid}
+            --generate_acraconnector_keys
+            --keys_output_dir=/keys/acra-connector
+            --keys_public_output_dir=/keys/acra-translator
+    # Create keys:
+    # - ./.acrakeys/acra-connector/${ACRA_CLIENT_ID}_translator.pub
+    # - ./.acrakeys/acra-translator/${ACRA_CLIENT_ID}_translator
+    acra-keymaker_translator:
+        image: "cossacklabs/acra-keymaker:${ACRA_DOCKER_IMAGE_TAG:-latest}"
+        network_mode: "none"
+        environment:
+            ACRA_MASTER_KEY: ${ACRA_MASTER_KEY:-UHZ3VUNNeTJ0SEFhbWVjNkt4eDdVYkc2WnNpUTlYa0E=}
+        volumes:
+            - ./.acrakeys:/keys
+        command: >-
+            --client_id=${ACRA_CLIENT_ID:-testclientid}
+            --generate_acratranslator_keys
+            --keys_output_dir=/keys/acra-translator
+            --keys_public_output_dir=/keys/acra-connector
+    # Create keys:
+    # - ./.acrakeys/acra-translator/${ACRA_CLIENT_ID}_storage
+    # - ./.acrakeys/acra-writer/${ACRA_CLIENT_ID}_storage.pub
+    acra-keymaker_writer:
+        image: "cossacklabs/acra-keymaker:${ACRA_DOCKER_IMAGE_TAG:-latest}"
+        network_mode: "none"
+        environment:
+            ACRA_MASTER_KEY: ${ACRA_MASTER_KEY:-UHZ3VUNNeTJ0SEFhbWVjNkt4eDdVYkc2WnNpUTlYa0E=}
+        volumes:
+            - ./.acrakeys:/keys
+        command: >-
+            --client_id=${ACRA_CLIENT_ID:-testclientid}
+            --generate_acrawriter_keys
+            --keys_output_dir=/keys/acra-translator
+            --keys_public_output_dir=/keys/acra-writer
+
+    acra-translator:
+        image: "cossacklabs/acra-translator:${ACRA_DOCKER_IMAGE_TAG:-latest}"
+        restart: always
+        depends_on:
+            - acra-keymaker_translator
+            - acra-keymaker_connector
+            - acra-keymaker_writer
+        environment:
+            ACRA_MASTER_KEY: ${ACRA_MASTER_KEY:-UHZ3VUNNeTJ0SEFhbWVjNkt4eDdVYkc2WnNpUTlYa0E=}
+        # We use internal networks:
+        # - 'translator-connector' - for interconnection with AcraConnector
+        networks:
+            - translator-connector
+        volumes:
+            # Mount the directory with only the keys for this service
+            - ./.acrakeys/acra-translator:/keys:ro
+        command: >-
+            --incoming_connection_grpc_string=http://0.0.0.0:9696
+            --keys_dir=/keys
+            --keystore_cache_size=100
+            -v
+
+    acra-connector:
+        image: "cossacklabs/acra-connector:${ACRA_DOCKER_IMAGE_TAG:-latest}"
+        restart: always
+        depends_on:
+            - acra-keymaker_translator
+            - acra-keymaker_connector
+            - acra-translator
+        # Open the port outside for client application
+        ports:
+            - "9494:9494"
+        environment:
+            ACRA_MASTER_KEY: ${ACRA_MASTER_KEY:-UHZ3VUNNeTJ0SEFhbWVjNkt4eDdVYkc2WnNpUTlYa0E=}
+        # We use internal networks:
+        # - 'translator-connector' - for interconnection with AcraConnector
+        # and external network 'world' for port exposing
+        networks:
+            - translator-connector
+            - world
+        volumes:
+            # Mount the directory with only the keys for this service
+            - ./.acrakeys/acra-connector:/keys:ro
+        command: >-
+            --mode=AcraTranslator
+            --acratranslator_connection_host=acra-translator
+            --acratranslator_connection_port=9696
+            --client_id=${ACRA_CLIENT_ID:-testclientid}
+            --incoming_connection_string=tcp://0.0.0.0:9494
+            --keys_dir=/keys
+            -v
+
+networks:
+    world:
+    translator-connector:
+        internal: true

--- a/docker/docker-compose.translator-ssession-connector-http.yml
+++ b/docker/docker-compose.translator-ssession-connector-http.yml
@@ -1,0 +1,110 @@
+version: "3"
+
+services:
+    # Create keys:
+    # - ./.acrakeys/acra-connector/${ACRA_CLIENT_ID}
+    # - ./.acrakeys/acra-translator/${ACRA_CLIENT_ID}.pub
+    acra-keymaker_connector:
+        # You can specify docker image tag in the environment
+        # variable ACRA_DOCKER_IMAGE_TAG or run by default with 'latest' images
+        image: "cossacklabs/acra-keymaker:${ACRA_DOCKER_IMAGE_TAG:-latest}"
+        # We do not need network for keys' generation at all
+        network_mode: "none"
+        environment:
+            # INSECURE!!! You MUST define your own ACRA_MASTER_KEY
+            # The default is only for testing purposes
+            ACRA_MASTER_KEY: ${ACRA_MASTER_KEY:-UHZ3VUNNeTJ0SEFhbWVjNkt4eDdVYkc2WnNpUTlYa0E=}
+        volumes:
+            - ./.acrakeys:/keys
+        command: >-
+            --client_id=${ACRA_CLIENT_ID:-testclientid}
+            --generate_acraconnector_keys
+            --keys_output_dir=/keys/acra-connector
+            --keys_public_output_dir=/keys/acra-translator
+    # Create keys:
+    # - ./.acrakeys/acra-connector/${ACRA_CLIENT_ID}_translator.pub
+    # - ./.acrakeys/acra-translator/${ACRA_CLIENT_ID}_translator
+    acra-keymaker_translator:
+        image: "cossacklabs/acra-keymaker:${ACRA_DOCKER_IMAGE_TAG:-latest}"
+        network_mode: "none"
+        environment:
+            ACRA_MASTER_KEY: ${ACRA_MASTER_KEY:-UHZ3VUNNeTJ0SEFhbWVjNkt4eDdVYkc2WnNpUTlYa0E=}
+        volumes:
+            - ./.acrakeys:/keys
+        command: >-
+            --client_id=${ACRA_CLIENT_ID:-testclientid}
+            --generate_acratranslator_keys
+            --keys_output_dir=/keys/acra-translator
+            --keys_public_output_dir=/keys/acra-connector
+    # Create keys:
+    # - ./.acrakeys/acra-translator/${ACRA_CLIENT_ID}_storage
+    # - ./.acrakeys/acra-writer/${ACRA_CLIENT_ID}_storage.pub
+    acra-keymaker_writer:
+        image: "cossacklabs/acra-keymaker:${ACRA_DOCKER_IMAGE_TAG:-latest}"
+        network_mode: "none"
+        environment:
+            ACRA_MASTER_KEY: ${ACRA_MASTER_KEY:-UHZ3VUNNeTJ0SEFhbWVjNkt4eDdVYkc2WnNpUTlYa0E=}
+        volumes:
+            - ./.acrakeys:/keys
+        command: >-
+            --client_id=${ACRA_CLIENT_ID:-testclientid}
+            --generate_acrawriter_keys
+            --keys_output_dir=/keys/acra-translator
+            --keys_public_output_dir=/keys/acra-writer
+
+    acra-translator:
+        image: "cossacklabs/acra-translator:${ACRA_DOCKER_IMAGE_TAG:-latest}"
+        restart: always
+        depends_on:
+            - acra-keymaker_translator
+            - acra-keymaker_connector
+            - acra-keymaker_writer
+        environment:
+            ACRA_MASTER_KEY: ${ACRA_MASTER_KEY:-UHZ3VUNNeTJ0SEFhbWVjNkt4eDdVYkc2WnNpUTlYa0E=}
+        # We use internal networks:
+        # - 'translator-connector' - for interconnection with AcraConnector
+        networks:
+            - translator-connector
+        volumes:
+            # Mount the directory with only the keys for this service
+            - ./.acrakeys/acra-translator:/keys:ro
+        command: >-
+            --incoming_connection_http_string=http://0.0.0.0:9595
+            --keys_dir=/keys
+            --keystore_cache_size=100
+            -v
+
+    acra-connector:
+        image: "cossacklabs/acra-connector:${ACRA_DOCKER_IMAGE_TAG:-latest}"
+        restart: always
+        depends_on:
+            - acra-keymaker_translator
+            - acra-keymaker_connector
+            - acra-translator
+        # Open the port outside for client application
+        ports:
+            - "9494:9494"
+        environment:
+            ACRA_MASTER_KEY: ${ACRA_MASTER_KEY:-UHZ3VUNNeTJ0SEFhbWVjNkt4eDdVYkc2WnNpUTlYa0E=}
+        # We use internal networks:
+        # - 'translator-connector' - for interconnection with AcraConnector
+        # and external network 'world' for port exposing
+        networks:
+            - translator-connector
+            - world
+        volumes:
+            # Mount the directory with only the keys for this service
+            - ./.acrakeys/acra-connector:/keys:ro
+        command: >-
+            --mode=AcraTranslator
+            --acratranslator_connection_host=acra-translator
+            --acratranslator_connection_port=9595
+            --client_id=${ACRA_CLIENT_ID:-testclientid}
+            --incoming_connection_string=tcp://0.0.0.0:9494
+            --keys_dir=/keys
+            -v
+
+networks:
+    world:
+    translator-connector:
+        internal: true

--- a/tests/generate_acrastruct.py
+++ b/tests/generate_acrastruct.py
@@ -19,10 +19,17 @@ parser.add_argument(
 parser.add_argument(
     '--data', nargs='?', default='Plain text.',
     help='Plain text to encode (default: "Plain text.")')
+parser.add_argument(
+    '--out_file', nargs='?', default='',
+    help='Save AcraStruct to filename (default: "<client_id>.acrastruct")')
 args = parser.parse_args()
+
+as_out_file = args.out_file
+if as_out_file == '':
+    as_out_file = '{}.acrastruct'.format(args.client_id)
 
 encryption_key = read_storage_public_key(args.client_id, args.keys_dir)
 acrastruct = create_acrastruct(args.data, encryption_key)
 
-with open('testclientid_testmessage.acrastruct', 'wb') as f:
+with open(as_out_file, 'wb') as f:
     f.write(acrastruct)

--- a/tests/generate_acrastruct.py
+++ b/tests/generate_acrastruct.py
@@ -1,0 +1,28 @@
+import argparse
+import os
+import sys
+from utils import read_storage_public_key
+# add to path our wrapper until not published to PYPI
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)),
+                                                'wrappers/python'))
+from acrawriter import create_acrastruct
+
+
+parser = argparse.ArgumentParser(
+    description='This small script generate AcraStruct for testing purposes.')
+parser.add_argument(
+    '--client_id', nargs='?', default='testclientid',
+    help='Client ID (default: testclientid)')
+parser.add_argument(
+    '--keys_dir', nargs='?', default='docker/.acrakeys/acra-writer',
+    help='Directory where keys placed (default: docker/.acrakeys/acra-writer)')
+parser.add_argument(
+    '--data', nargs='?', default='Plain text.',
+    help='Plain text to encode (default: "Plain text.")')
+args = parser.parse_args()
+
+encryption_key = read_storage_public_key(args.client_id, args.keys_dir)
+acrastruct = create_acrastruct(args.data, encryption_key)
+
+with open('testclientid_testmessage.acrastruct', 'wb') as f:
+    f.write(acrastruct)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -7,6 +7,6 @@ def load_default_config(service_name):
         return yaml.safe_load(f)
 
 
-def read_storage_public_key(client_id):
-    with open('.acrakeys/{}_storage.pub'.format(client_id), 'rb') as f:
+def read_storage_public_key(client_id, keys_dir='.acrakeys'):
+    with open('{}/{}_storage.pub'.format(keys_dir, client_id), 'rb') as f:
             return f.read()


### PR DESCRIPTION
* created docker-compose examples:
  - `docker/docker-compose.translator-ssession-connector-grpc.yml`
  - `docker/docker-compose.translator-ssession-connector-grpc.yml`
* written small script `tests/generate_acrastruct.py`
* added optional argument `keys_dir` to `read_storage_public_key` method