### PR TITLE
More golint fixes

### DIFF
--- a/.circleci/check_golint.sh
+++ b/.circleci/check_golint.sh
@@ -3,7 +3,7 @@
 # run golint and count output lines
 # golint print issues it found in source files
 # count lines with wc and check that 0 lines was in output
-result=$(golint ./... | wc -l)
+result=$($GOPATH/bin/golint ./... | wc -l)
 if [[ $result -gt 450 ]]; then
   # too many golint issues
   echo "Too many golint issues: $result"

--- a/.circleci/check_golint.sh
+++ b/.circleci/check_golint.sh
@@ -2,9 +2,9 @@
 
 # run golint and count output lines
 # golint print issues it found in source files
-# count lines with wc and check that 0 lines was in output
+# count lines with wc and check that N lines was in output
 result=$($GOPATH/bin/golint ./... | wc -l)
-if [[ $result -gt 450 ]]; then
+if [[ $result -gt 250 ]]; then
   # too many golint issues
   echo "Too many golint issues: $result"
   exit 1;

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
       - run: pip3 install -r $HOME/project/tests/requirements.txt
       # install from sources because pip install git+https://github.com/mysql/mysql-connector-python not support recursive submodules
       - run: git clone https://github.com/Lagovas/mysql-connector-python; cd mysql-connector-python; sudo python3 setup.py clean build_py install_lib
-      - run: go install golang.org/x/lint/golint
+      - run: go get -u -v github.com/golang/lint/golint
       - run: sudo ldconfig
     # testing
       # check that code formatted with gofmt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
       GOPATH_FOLDER: gopath
     steps:
     # prepare
-      - run: sudo apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get -y install libssl-dev python python-setuptools python3 python3-setuptools python3-pip git rsync psmisc golint
+      - run: sudo apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get -y install libssl-dev python python-setuptools python3 python3-setuptools python3-pip git rsync psmisc
       - run: cd $HOME && git clone https://github.com/cossacklabs/themis && cd themis && sudo make install
       - run: cd $HOME && for version in $VERSIONS; do mkdir go_root_$version; cd go_root_$version; wget https://storage.googleapis.com/golang/go$version.linux-amd64.tar.gz; tar xf go$version.linux-amd64.tar.gz; cd -; done
       - run: mkdir $HOME/$GOPATH_FOLDER
@@ -37,12 +37,13 @@ jobs:
       - run: pip3 install -r $HOME/project/tests/requirements.txt
       # install from sources because pip install git+https://github.com/mysql/mysql-connector-python not support recursive submodules
       - run: git clone https://github.com/Lagovas/mysql-connector-python; cd mysql-connector-python; sudo python3 setup.py clean build_py install_lib
+      - run: go install golang.org/x/lint/golint
       - run: sudo ldconfig
     # testing
       # check that code formatted with gofmt
       - run: .circleci/check_gofmt.sh
       # check that code doesn't have a lot of golint issues (currently removed because golint version is very different on other planforms)
-      # - run: .circleci/check_golint.sh
+      - run: .circleci/check_golint.sh
       # delete file if exists
       - run: if [ -f $FILEPATH_ERROR_FLAG ]; then rm "$FILEPATH_ERROR_FLAG"; fi
       # run test in each go environment and create $FILEPATH_ERROR_FLAG file if was any error. But all tests should

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,13 +37,13 @@ jobs:
       - run: pip3 install -r $HOME/project/tests/requirements.txt
       # install from sources because pip install git+https://github.com/mysql/mysql-connector-python not support recursive submodules
       - run: git clone https://github.com/Lagovas/mysql-connector-python; cd mysql-connector-python; sudo python3 setup.py clean build_py install_lib
-      - run: go get -u -v github.com/golang/lint/golint
+      - run: cd $HOME && GOPATH=$HOME/$GOPATH_FOLDER go get -u -v github.com/golang/lint/golint
       - run: sudo ldconfig
     # testing
       # check that code formatted with gofmt
       - run: .circleci/check_gofmt.sh
       # check that code doesn't have a lot of golint issues (currently removed because golint version is very different on other planforms)
-      - run: .circleci/check_golint.sh
+      - run: GOPATH=$HOME/$GOPATH_FOLDER .circleci/check_golint.sh
       # delete file if exists
       - run: if [ -f $FILEPATH_ERROR_FLAG ]; then rm "$FILEPATH_ERROR_FLAG"; fi
       # run test in each go environment and create $FILEPATH_ERROR_FLAG file if was any error. But all tests should

--- a/acra-censor/handlers/blacklist_handler.go
+++ b/acra-censor/handlers/blacklist_handler.go
@@ -226,7 +226,7 @@ func (handler *BlacklistHandler) RemoveRules(rules []string) {
 
 func (handler *BlacklistHandler) testRulesViolation(query string) (bool, error) {
 	if sqlparser.Preview(query) != sqlparser.StmtSelect {
-		return true, errors.New("Non-select queries are not supported")
+		return true, errors.New("non-select queries are not supported")
 	}
 	//parse one rule and get forbidden tables and columns for specific 'where' clause
 	var whereClause sqlparser.SQLNode

--- a/acra-writer/acra-writer.go
+++ b/acra-writer/acra-writer.go
@@ -42,7 +42,7 @@ func CreateAcrastruct(data []byte, acraPublic *keys.PublicKey, context []byte) (
 		return nil, err
 	}
 	if n != base.SYMMETRIC_KEY_SIZE {
-		return nil, errors.New("Read incorrect num of random bytes")
+		return nil, errors.New("read incorrect num of random bytes")
 	}
 
 	// create smessage for encrypting symmetric key

--- a/cmd/acra-authmanager/acra_authmanager.go
+++ b/cmd/acra-authmanager/acra_authmanager.go
@@ -118,7 +118,7 @@ func parseHtpasswd(htpasswdBytes []byte) (passwords HashedPasswords, err error) 
 		}
 		parts := strings.Split(line, AuthFieldSeparator)
 		if len(parts) != AuthFieldCount {
-			err = errors.New(fmt.Sprintf("wrong line no. %d, unexpected number (%v) of splitted parts split by %v", index+1, len(parts), AuthFieldSeparator))
+			err = fmt.Errorf("wrong line no. %d, unexpected number (%v) of splitted parts split by %v", index+1, len(parts), AuthFieldSeparator)
 			return
 		}
 		for i, part := range parts {
@@ -126,7 +126,7 @@ func parseHtpasswd(htpasswdBytes []byte) (passwords HashedPasswords, err error) 
 		}
 		_, alreadyExists := passwords[parts[0]]
 		if alreadyExists {
-			err = errors.New(fmt.Sprintf("wrong line no. %d, user (%v) already defined", index, parts[0]))
+			err = fmt.Errorf("wrong line no. %d, user (%v) already defined", index, parts[0])
 			return
 		}
 		passwords[parts[0]] = strings.Join(parts[1:AuthFieldCount], AuthFieldSeparator)

--- a/cmd/acra-server/auth.go
+++ b/cmd/acra-server/auth.go
@@ -15,14 +15,13 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"github.com/cossacklabs/acra/utils"
 	"io/ioutil"
 )
 
 // ErrGetAuthDataFromFile can't find auth config error
-var ErrGetAuthDataFromFile = errors.New(fmt.Sprintf("No auth config [%v]", authPath))
+var ErrGetAuthDataFromFile = fmt.Errorf("no auth config [%v]", authPath)
 
 func getAuthDataFromFile(authPath string) (data []byte, err error) {
 	configPath, err := utils.AbsPath(authPath)

--- a/cmd/acra-server/config.go
+++ b/cmd/acra-server/config.go
@@ -281,7 +281,7 @@ func (config *Config) SetDBPort(port int) error {
 // SetByteaFormat sets bytea format for connecting to database
 func (config *Config) SetByteaFormat(format int8) error {
 	if format != HEX_BYTEA_FORMAT && format != ESCAPE_BYTEA_FORMAT {
-		return errors.New("Incorrect bytea format")
+		return errors.New("incorrect bytea format")
 	}
 	config.byteaFormat = format
 	return nil

--- a/cmd/acra-translator/grpc_api/decryptor.go
+++ b/cmd/acra-translator/grpc_api/decryptor.go
@@ -24,7 +24,7 @@ func NewDecryptGRPCService(data *common.TranslatorData) (*DecryptGRPCService, er
 // Errors possible during decrypting AcraStructs.
 var (
 	ErrCantDecrypt      = errors.New("can't decrypt data")
-	ErrClientIDRequired = errors.New("ClientID is empty")
+	ErrClientIDRequired = errors.New("clientID is empty")
 )
 
 // Decrypt decrypts AcraStruct from gRPC request and returns decrypted data or error.

--- a/cmd/acra-webconfig/acra-webconfig.go
+++ b/cmd/acra-webconfig/acra-webconfig.go
@@ -54,7 +54,7 @@ var (
 )
 
 // ErrGetAuthDataFromAcraServer any error during loading AcraWebconfig
-var ErrGetAuthDataFromAcraServer = errors.New("Wrong status for loadAuthData")
+var ErrGetAuthDataFromAcraServer = errors.New("wrong status for loadAuthData")
 
 // Connection timeout secs
 const (

--- a/decryptor/mysql/utils.go
+++ b/decryptor/mysql/utils.go
@@ -8,7 +8,7 @@ import (
 )
 
 // ErrMalformPacket if packet parsing failed
-var ErrMalformPacket = errors.New("Malform packet error")
+var ErrMalformPacket = errors.New("malform packet error")
 
 // LengthEncodedInt https://dev.mysql.com/doc/internals/en/integer.html#packet-Protocol::LengthEncodedInteger
 func LengthEncodedInt(data []byte) (num uint64, isNull bool, n int, err error) {

--- a/decryptor/postgresql/pg_escape_decryptor.go
+++ b/decryptor/postgresql/pg_escape_decryptor.go
@@ -32,10 +32,12 @@ import (
 	"github.com/cossacklabs/themis/gothemis/message"
 )
 
-var ESCAPE_TAG_BEGIN = EncodeToOctal(base.TAG_BEGIN)
-
-var ESCAPE_ZONE_TAG_LENGTH = zone.ZONE_TAG_LENGTH
-var ESCAPE_ZONE_ID_BLOCK_LENGTH = zone.ZONE_ID_BLOCK_LENGTH
+// ZoneID begin tags, lengths, etc
+var (
+	ESCAPE_TAG_BEGIN            = EncodeToOctal(base.TAG_BEGIN)
+	ESCAPE_ZONE_TAG_LENGTH      = zone.ZONE_TAG_LENGTH
+	ESCAPE_ZONE_ID_BLOCK_LENGTH = zone.ZONE_ID_BLOCK_LENGTH
+)
 
 func encodeToOctal(from, to []byte) {
 	to = to[:0]
@@ -62,6 +64,8 @@ func encodeToOctal(from, to []byte) {
 	}
 }
 
+// EncodeToOctal returns octal representation on bytes
+// each byte has 4 bytes, filled with leading 0's is needed
 func EncodeToOctal(from []byte) []byte {
 	// count output size
 	outputLength := 0
@@ -81,6 +85,7 @@ func EncodeToOctal(from []byte) []byte {
 	return buffer
 }
 
+// PgEscapeDecryptor decrypts AcraStruct from Escape-encoded PostgreSQL binary format
 type PgEscapeDecryptor struct {
 	currentIndex    uint8
 	outputSize      int
@@ -99,6 +104,7 @@ type PgEscapeDecryptor struct {
 	zoneMatcher  *zone.ZoneIDMatcher
 }
 
+// NewPgEscapeDecryptor returns new PgEscapeDecryptor
 func NewPgEscapeDecryptor() *PgEscapeDecryptor {
 	return &PgEscapeDecryptor{
 		currentIndex:          0,
@@ -108,6 +114,8 @@ func NewPgEscapeDecryptor() *PgEscapeDecryptor {
 	}
 }
 
+// MatchBeginTag returns true and updates currentIndex and outputSize,
+// if currentIndex matches beginning of ESCAPE_TAG_BEGIN
 func (decryptor *PgEscapeDecryptor) MatchBeginTag(char byte) bool {
 	if char == ESCAPE_TAG_BEGIN[decryptor.currentIndex] {
 		decryptor.currentIndex++
@@ -116,13 +124,19 @@ func (decryptor *PgEscapeDecryptor) MatchBeginTag(char byte) bool {
 	}
 	return false
 }
+
+// IsMatched returns true if decryptor has processed ESCAPE_TAG_BEGIN
 func (decryptor *PgEscapeDecryptor) IsMatched() bool {
 	return int(decryptor.currentIndex) == len(ESCAPE_TAG_BEGIN)
 }
+
+// Reset resets current index and output size
 func (decryptor *PgEscapeDecryptor) Reset() {
 	decryptor.currentIndex = 0
 	decryptor.outputSize = 0
 }
+
+// GetMatched returns already matched bytes from ESCAPE_TAG_BEGIN
 func (decryptor *PgEscapeDecryptor) GetMatched() []byte {
 	return ESCAPE_TAG_BEGIN[:decryptor.currentIndex]
 }
@@ -196,6 +210,8 @@ func (decryptor *PgEscapeDecryptor) readOctalData(data, octData []byte, reader i
 	}
 }
 
+// ReadSymmetricKey decrypts symmetric key hidden in AcraStruct using SecureMessage and privateKey
+// returns decrypted symmetric key or ErrFakeAcraStruct error if can't decrypt
 func (decryptor *PgEscapeDecryptor) ReadSymmetricKey(privateKey *keys.PrivateKey, reader io.Reader) ([]byte, []byte, error) {
 	dataLength, octDataLength, err := decryptor.readOctalData(decryptor.decodedKeyBlockBuffer, decryptor.octKeyBlockBuffer[:], reader)
 	if err != nil {
@@ -249,6 +265,7 @@ func (decryptor *PgEscapeDecryptor) getFullDataLength() int {
 	return decryptor.outputSize
 }
 
+// ReadData returns plaintext content from reader data, decrypting using SecureCell with ZoneID and symmetricKey
 func (decryptor *PgEscapeDecryptor) ReadData(symmetricKey, zoneID []byte, reader io.Reader) ([]byte, error) {
 	length, hexLengthBuf, err := decryptor.readDataLength(reader)
 	if err != nil {
@@ -269,6 +286,7 @@ func (decryptor *PgEscapeDecryptor) ReadData(symmetricKey, zoneID []byte, reader
 	return EncodeToOctal(decrypted), nil
 }
 
+// GetTagBeginLength returns length of ESCAPE_TAG_BEGIN
 func (decryptor *PgEscapeDecryptor) GetTagBeginLength() int {
 	return len(ESCAPE_TAG_BEGIN)
 }

--- a/decryptor/postgresql/pg_hex_decryptor.go
+++ b/decryptor/postgresql/pg_hex_decryptor.go
@@ -32,15 +32,18 @@ import (
 	"github.com/cossacklabs/themis/gothemis/message"
 )
 
-// TAG_BEGIN in hex format
-//var HEX_TAG_BEGIN = []byte{56, 53, 50, 48, 102, 98}
-var HEX_TAG_BEGIN = []byte(hex.EncodeToString(base.TAG_BEGIN))
+// ZoneID begin tags, lengths, etc
+var (
+	// TAG_BEGIN in hex format
+	//var HEX_TAG_BEGIN = []byte{56, 53, 50, 48, 102, 98}
+	HEX_TAG_BEGIN            = []byte(hex.EncodeToString(base.TAG_BEGIN))
+	HEX_ZONE_ID_BEGIN        = []byte(hex.EncodeToString(zone.ZONE_ID_BEGIN))
+	HEX_ZONE_TAG_LENGTH      = len(HEX_ZONE_ID_BEGIN)
+	HEX_ZONE_ID_LENGTH       = hex.EncodedLen(16)
+	HEX_ZONE_ID_BLOCK_LENGTH = int(HEX_ZONE_TAG_LENGTH + HEX_ZONE_ID_LENGTH)
+)
 
-var HEX_ZONE_ID_BEGIN = []byte(hex.EncodeToString(zone.ZONE_ID_BEGIN))
-var HEX_ZONE_TAG_LENGTH = len(HEX_ZONE_ID_BEGIN)
-var HEX_ZONE_ID_LENGTH = hex.EncodedLen(16)
-var HEX_ZONE_ID_BLOCK_LENGTH = int(HEX_ZONE_TAG_LENGTH + HEX_ZONE_ID_LENGTH)
-
+// PgHexDecryptor decrypts AcraStruct from Hex-encoded PostgreSQL binary format
 type PgHexDecryptor struct {
 	currentIndex uint8
 	isWithZone   bool
@@ -65,6 +68,7 @@ type PgHexDecryptor struct {
 	callbackStorage *base.PoisonCallbackStorage
 }
 
+// NewPgHexDecryptor returns new PgHexDecryptor without zone
 func NewPgHexDecryptor() *PgHexDecryptor {
 	return &PgHexDecryptor{
 		currentIndex:          0,
@@ -80,6 +84,8 @@ func (decryptor *PgHexDecryptor) checkBuf(buf *[]byte, length int) {
 	}
 }
 
+// MatchBeginTag returns true and updates currentIndex,
+// if currentIndex matches beginning of HEX_TAG_BEGIN
 func (decryptor *PgHexDecryptor) MatchBeginTag(char byte) bool {
 	if char == HEX_TAG_BEGIN[decryptor.currentIndex] {
 		decryptor.currentIndex++
@@ -88,15 +94,23 @@ func (decryptor *PgHexDecryptor) MatchBeginTag(char byte) bool {
 	return false
 }
 
+// IsMatched returns true if decryptor has processed HEX_TAG_BEGIN
 func (decryptor *PgHexDecryptor) IsMatched() bool {
 	return int(decryptor.currentIndex) == len(HEX_TAG_BEGIN)
 }
+
+// Reset resets current index
 func (decryptor *PgHexDecryptor) Reset() {
 	decryptor.currentIndex = 0
 }
+
+// GetMatched returns already matched bytes from HEX_TAG_BEGIN
 func (decryptor *PgHexDecryptor) GetMatched() []byte {
 	return HEX_TAG_BEGIN[:decryptor.currentIndex]
 }
+
+// ReadSymmetricKey decrypts symmetric key hidden in AcraStruct using SecureMessage and privateKey
+// returns decrypted symmetric key or ErrFakeAcraStruct error if can't decrypt
 func (decryptor *PgHexDecryptor) ReadSymmetricKey(privateKey *keys.PrivateKey, reader io.Reader) ([]byte, []byte, error) {
 	n, err := io.ReadFull(reader, decryptor.keyBlockBuffer[:])
 	if err != nil {
@@ -186,6 +200,7 @@ func (*PgHexDecryptor) getFullDataLength(dataLength uint64) int {
 	return hex.EncodedLen(len(base.TAG_BEGIN) + base.KEY_BLOCK_LENGTH + 8 + int(dataLength))
 }
 
+// ReadData returns plaintext content from reader data, decrypting using SecureCell with ZoneID and symmetricKey
 func (decryptor *PgHexDecryptor) ReadData(symmetricKey, zoneID []byte, reader io.Reader) ([]byte, error) {
 	length, hexLengthBuf, err := decryptor.readDataLength(reader)
 	if err != nil {
@@ -213,6 +228,7 @@ func (decryptor *PgHexDecryptor) ReadData(symmetricKey, zoneID []byte, reader io
 	return decryptor.output[:outputLength], nil
 }
 
+// GetTagBeginLength returns length of HEX_TAG_BEGIN
 func (decryptor *PgHexDecryptor) GetTagBeginLength() int {
 	return len(HEX_TAG_BEGIN)
 }

--- a/fuzz/fuzz.go
+++ b/fuzz/fuzz.go
@@ -25,7 +25,7 @@ import (
 	"fmt"
 	"github.com/cossacklabs/acra/acra-writer"
 	"github.com/cossacklabs/themis/gothemis/keys"
-	_ "github.com/lib/pq"
+	_ "github.com/lib/pq" // pq
 	log "github.com/sirupsen/logrus"
 )
 

--- a/keystore/filesystem/connector_keystore.go
+++ b/keystore/filesystem/connector_keystore.go
@@ -57,7 +57,7 @@ func (store *ConnectorFileSystemKeyStore) GetPeerPublicKey(id []byte) (*keys.Pub
 	case connector_mode.AcraTranslatorMode:
 		filename = getTranslatorKeyFilename(store.clientID)
 	default:
-		return nil, errors.New("Unsupported ConnectorMode, can't find PeerPublicKey")
+		return nil, errors.New("unsupported ConnectorMode, can't find PeerPublicKey")
 	}
 
 	key, err := ioutil.ReadFile(filepath.Join(store.directory, getPublicKeyFilename([]byte(filename))))

--- a/network/raw_wrapper.go
+++ b/network/raw_wrapper.go
@@ -4,15 +4,19 @@ package network
 
 import "net"
 
+// RawConnectionWrapper doesn't add any encryption above connection
 type RawConnectionWrapper struct {
 	net.Conn
 	ClientID []byte
 }
 
+// WrapClient returns RawConnectionWrapper above client connection
 func (wrapper *RawConnectionWrapper) WrapClient(id []byte, conn net.Conn) (net.Conn, error) {
 	wrapper.Conn = conn
 	return conn, nil
 }
+
+// WrapServer returns RawConnectionWrapper above server connection
 func (wrapper *RawConnectionWrapper) WrapServer(conn net.Conn) (net.Conn, []byte, error) {
 	wrapper.Conn = conn
 	return conn, wrapper.ClientID, nil

--- a/network/tls_wrapper.go
+++ b/network/tls_wrapper.go
@@ -13,17 +13,21 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// TLSConnectionWrapper for wrapping connection into TLS encryption
 type TLSConnectionWrapper struct {
 	config   *tls.Config
 	clientID []byte
 }
 
+// ErrEmptyTLSConfig if not TLS config found
 var ErrEmptyTLSConfig = errors.New("empty TLS config")
 
+// NewTLSConnectionWrapper returns new TLSConnectionWrapper
 func NewTLSConnectionWrapper(clientID []byte, config *tls.Config) (*TLSConnectionWrapper, error) {
 	return &TLSConnectionWrapper{config: config, clientID: clientID}, nil
 }
 
+// WrapClient wraps client connection into TLS
 func (wrapper *TLSConnectionWrapper) WrapClient(id []byte, conn net.Conn) (net.Conn, error) {
 	tlsConn := tls.Client(conn, wrapper.config)
 	err := tlsConn.Handshake()
@@ -32,6 +36,8 @@ func (wrapper *TLSConnectionWrapper) WrapClient(id []byte, conn net.Conn) (net.C
 	}
 	return tlsConn, nil
 }
+
+// WrapServer wraps server connection into TLS
 func (wrapper *TLSConnectionWrapper) WrapServer(conn net.Conn) (net.Conn, []byte, error) {
 	tlsConn := tls.Server(conn, wrapper.config)
 	err := tlsConn.Handshake()
@@ -41,6 +47,7 @@ func (wrapper *TLSConnectionWrapper) WrapServer(conn net.Conn) (net.Conn, []byte
 	return tlsConn, wrapper.clientID, nil
 }
 
+// NewTLSConfig creates x509 TLS config from provided params, tried to load system CA certificate
 func NewTLSConfig(serverName string, caPath, keyPath, crtPath string, authType tls.ClientAuthType) (*tls.Config, error) {
 	var roots *x509.CertPool
 	var err error

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -36,12 +36,13 @@ const (
 	SESSION_DATA_LIMIT = 8 * 1024 // 8 kb
 )
 
+// ErrBigDataBlockSize represents data encoding error
 var ErrBigDataBlockSize = fmt.Errorf("Block size greater than %v", SESSION_DATA_LIMIT)
 
+// WriteFull writes data to io.Writer.
+// if wr.Write will return n <= len(data) will
+//	sent the rest of data until error or total sent byte count == len(data)
 func WriteFull(data []byte, wr io.Writer) (int, error) {
-	/* write data to io.Writer. if wr.Write will return n <= len(data) will
-	sent the rest of data until error or total sent byte count == len(data)
-	*/
 	sliceCopy := data[:]
 	totalSent := 0
 	for {
@@ -57,6 +58,7 @@ func WriteFull(data []byte, wr io.Writer) (int, error) {
 	}
 }
 
+// SendData writes length of data block to connection, then writes data itself
 func SendData(data []byte, conn io.Writer) error {
 	var buf [4]byte
 	binary.LittleEndian.PutUint32(buf[:], uint32(len(data)))
@@ -71,6 +73,8 @@ func SendData(data []byte, conn io.Writer) error {
 	return nil
 }
 
+// ReadData reads length of data block, then reads data content
+// returns data content
 func ReadData(reader io.Reader) ([]byte, error) {
 	var length [4]byte
 	_, err := io.ReadFull(reader, length[:])
@@ -86,6 +90,7 @@ func ReadData(reader io.Reader) ([]byte, error) {
 	return buf, nil
 }
 
+// AbsPath transforms relative file path to absolute
 func AbsPath(path string) (string, error) {
 	if len(path) == 0 {
 		return path, nil
@@ -111,6 +116,7 @@ func AbsPath(path string) (string, error) {
 	return path, nil
 }
 
+// ReadFile returns contents of file
 func ReadFile(path string) ([]byte, error) {
 	absPath, err := AbsPath(path)
 	if err != nil {
@@ -123,6 +129,7 @@ func ReadFile(path string) ([]byte, error) {
 	return ioutil.ReadAll(file)
 }
 
+// LoadPublicKey returns contents as PublicKey from keyfile
 func LoadPublicKey(path string) (*keys.PublicKey, error) {
 	key, err := ReadFile(path)
 	if err != nil {
@@ -131,6 +138,7 @@ func LoadPublicKey(path string) (*keys.PublicKey, error) {
 	return &keys.PublicKey{Value: key}, nil
 }
 
+// LoadPrivateKey returns contents as PrivateKey from keyfile
 func LoadPrivateKey(path string) (*keys.PrivateKey, error) {
 	fi, err := os.Stat(path)
 	if nil == err && runtime.GOOS == "linux" && fi.Mode().Perm().String() != "-rw-------" && fi.Mode().Perm().String() != "-r--------" {
@@ -144,12 +152,14 @@ func LoadPrivateKey(path string) (*keys.PrivateKey, error) {
 	return &keys.PrivateKey{Value: key}, nil
 }
 
+// FillSlice fills bytes with value, used for filling bytes with zeros
 func FillSlice(value byte, data []byte) {
 	for i := range data {
 		data[i] = value
 	}
 }
 
+// FileExists returns true if file exists from path, path can be relative
 func FileExists(path string) (bool, error) {
 	absPath, err := AbsPath(path)
 	if err != nil {
@@ -165,15 +175,20 @@ func FileExists(path string) (bool, error) {
 }
 
 const (
+	// NOT_FOUND indicated not found symbol
 	NOT_FOUND = -1
 )
 
+// Min returns minimum integer out of two
 func Min(x, y int) int {
 	if x < y {
 		return x
 	}
 	return y
 }
+
+// FindTag returns first index of symbol in block
+// return -1 if not found
 func FindTag(symbol byte, count int, block []byte) int {
 	if len(block) < count {
 		return NOT_FOUND
@@ -211,6 +226,7 @@ func FindTag(symbol byte, count int, block []byte) int {
 	return NOT_FOUND
 }
 
+// GetConfigPathByName returns filepath to config file named "name" from default configs folder
 func GetConfigPathByName(name string) string {
 	return fmt.Sprintf("configs/%s.yaml", name)
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -135,7 +135,7 @@ func LoadPrivateKey(path string) (*keys.PrivateKey, error) {
 	fi, err := os.Stat(path)
 	if nil == err && runtime.GOOS == "linux" && fi.Mode().Perm().String() != "-rw-------" && fi.Mode().Perm().String() != "-r--------" {
 		log.Errorf("private key file %v has incorrect permissions", path)
-		return nil, fmt.Errorf("Error: private key file %v has incorrect permissions", path)
+		return nil, fmt.Errorf("error: private key file %v has incorrect permissions", path)
 	}
 	key, err := ReadFile(path)
 	if err != nil {

--- a/zone/byte_reader_binary.go
+++ b/zone/byte_reader_binary.go
@@ -15,18 +15,23 @@
 // limitations under the License.
 package zone
 
+// BinaryByteReader generic reader structure
 type BinaryByteReader struct{}
 
+// NewBinaryByteReader returns new BinaryByteReader
 func NewBinaryByteReader() *BinaryByteReader {
 	return &BinaryByteReader{}
 }
 
+// GetBuffered returns empty bytes
 func (reader *BinaryByteReader) GetBuffered() []byte {
 	return []byte{}
 }
 
+// Reset current reader index
 func (reader *BinaryByteReader) Reset() {}
 
+// ReadByte always returns c as output
 func (reader *BinaryByteReader) ReadByte(c byte) (bool, byte, error) {
 	return true, c, nil
 }

--- a/zone/byte_reader_pg_escape.go
+++ b/zone/byte_reader_pg_escape.go
@@ -20,19 +20,23 @@ import (
 	"strconv"
 )
 
+// PgEscapeByteReader reads escaped bytes from binary input
 type PgEscapeByteReader struct {
 	currentIndex byte
 	buffer       [4]byte
 }
 
+// NewPgEscapeByteReader returns new PgEscapeByteReader
 func NewPgEscapeByteReader() *PgEscapeByteReader {
 	return &PgEscapeByteReader{currentIndex: 0}
 }
 
+// GetBuffered returns bytes from buffer to currentIndex
 func (reader *PgEscapeByteReader) GetBuffered() []byte {
 	return reader.buffer[:reader.currentIndex]
 }
 
+// Reset current reader index
 func (reader *PgEscapeByteReader) Reset() {
 	reader.currentIndex = 0
 }
@@ -42,6 +46,7 @@ func (reader *PgEscapeByteReader) returnError() (bool, byte, error) {
 	return false, 0, FAKE_DB_BYTE
 }
 
+// ReadByte reads c and returns the bytes decoded from escaped format
 func (reader *PgEscapeByteReader) ReadByte(c byte) (bool, byte, error) {
 	if !utils.IsPrintableEscapeChar(c) {
 		return reader.returnError()

--- a/zone/byte_reader_pg_escape.go
+++ b/zone/byte_reader_pg_escape.go
@@ -43,7 +43,7 @@ func (reader *PgEscapeByteReader) Reset() {
 
 func (reader *PgEscapeByteReader) returnError() (bool, byte, error) {
 	reader.Reset()
-	return false, 0, FAKE_DB_BYTE
+	return false, 0, ErrFakeDBByte
 }
 
 // ReadByte reads c and returns the bytes decoded from escaped format

--- a/zone/byte_reader_pg_hex.go
+++ b/zone/byte_reader_pg_hex.go
@@ -20,21 +20,26 @@ import (
 	"errors"
 )
 
-var FAKE_DB_BYTE = errors.New("Fake db format byte")
+// FAKE_DB_BYTE error for wrong database byte format
+var FAKE_DB_BYTE = errors.New("fake db format byte")
 
+// PgHexByteReader reads hexadecimal bytes from binary input
 type PgHexByteReader struct {
 	currentIndex byte
 	buffer       [2]byte
 }
 
+// NewPgHexByteReader returns new PgHexByteReader
 func NewPgHexByteReader() *PgHexByteReader {
 	return &PgHexByteReader{currentIndex: 0}
 }
 
+// Reset current reader index
 func (reader *PgHexByteReader) Reset() {
 	reader.currentIndex = 0
 }
 
+// GetBuffered returns bytes from buffer to currentIndex
 func (reader *PgHexByteReader) GetBuffered() []byte {
 	return reader.buffer[:reader.currentIndex]
 }
@@ -48,6 +53,7 @@ func (reader *PgHexByteReader) returnError() (bool, byte, error) {
 	return false, 0, FAKE_DB_BYTE
 }
 
+// ReadByte reads c and returns the bytes represented by the hexadecimal string
 func (reader *PgHexByteReader) ReadByte(c byte) (bool, byte, error) {
 	// 0-9 == 48-57
 	// a-f == 65-70

--- a/zone/byte_reader_pg_hex.go
+++ b/zone/byte_reader_pg_hex.go
@@ -20,8 +20,8 @@ import (
 	"errors"
 )
 
-// FAKE_DB_BYTE error for wrong database byte format
-var FAKE_DB_BYTE = errors.New("fake db format byte")
+// ErrFakeDBByte error for wrong database byte format
+var ErrFakeDBByte = errors.New("fake db format byte")
 
 // PgHexByteReader reads hexadecimal bytes from binary input
 type PgHexByteReader struct {
@@ -50,7 +50,7 @@ func (reader *PgHexByteReader) reset() {
 
 func (reader *PgHexByteReader) returnError() (bool, byte, error) {
 	reader.reset()
-	return false, 0, FAKE_DB_BYTE
+	return false, 0, ErrFakeDBByte
 }
 
 // ReadByte reads c and returns the bytes represented by the hexadecimal string

--- a/zone/matcher.go
+++ b/zone/matcher.go
@@ -21,47 +21,57 @@ package zone
 // catch three upper consonants in a row
 //var ZONE_ID_BEGIN = []byte{'Z', 'X', 'C'}
 //'44' - D - 68 - 0b1000100
-var ZONE_TAG_SYMBOL byte = 'D'
-var ZONE_ID_BEGIN = []byte{ZONE_TAG_SYMBOL, ZONE_TAG_SYMBOL, ZONE_TAG_SYMBOL, ZONE_TAG_SYMBOL, ZONE_TAG_SYMBOL, ZONE_TAG_SYMBOL, ZONE_TAG_SYMBOL, ZONE_TAG_SYMBOL}
+var (
+	ZONE_TAG_SYMBOL      byte = 'D'
+	ZONE_ID_BEGIN             = []byte{ZONE_TAG_SYMBOL, ZONE_TAG_SYMBOL, ZONE_TAG_SYMBOL, ZONE_TAG_SYMBOL, ZONE_TAG_SYMBOL, ZONE_TAG_SYMBOL, ZONE_TAG_SYMBOL, ZONE_TAG_SYMBOL}
+	ZONE_TAG_LENGTH           = len(ZONE_ID_BEGIN)
+	ZONE_ID_LENGTH            = 16
+	ZONE_ID_BLOCK_LENGTH      = int(ZONE_TAG_LENGTH + ZONE_ID_LENGTH)
+)
 
-var ZONE_TAG_LENGTH = len(ZONE_ID_BEGIN)
-var ZONE_ID_LENGTH = 16
-var ZONE_ID_BLOCK_LENGTH = int(ZONE_TAG_LENGTH + ZONE_ID_LENGTH)
-
+// DbByteReader reads bytes
 type DbByteReader interface {
 	ReadByte(c byte) (bool, byte, error)
 	GetBuffered() []byte
 	Reset()
 }
 
+// MatcherFactory creates matchers
 type MatcherFactory interface {
 	CreateMatcher() Matcher
 }
 
 /* custom matcher factories */
 
+// PgHexMatcherFactory makes new pgMatchers for HexBytes mode
 type PgHexMatcherFactory struct{}
 
+// NewPgHexMatcherFactory creates new PgHexMatcherFactory
 func NewPgHexMatcherFactory() MatcherFactory {
 	return &PgHexMatcherFactory{}
 }
 
+// CreateMatcher returns new PgHexMatcher
 func (*PgHexMatcherFactory) CreateMatcher() Matcher {
 	return NewPgMatcher(NewPgHexByteReader())
 }
 
+// PgEscapeMatcherFactory makes new pgMatchers for EscapedBytes mode
 type PgEscapeMatcherFactory struct{}
 
+// NewPgEscapeMatcherFactory creates new PgEscapeMatcherFactory
 func NewPgEscapeMatcherFactory() MatcherFactory {
 	return &PgEscapeMatcherFactory{}
 }
 
+// CreateMatcher returns new PgEscapeMatcher
 func (*PgEscapeMatcherFactory) CreateMatcher() Matcher {
 	return NewPgMatcher(NewPgEscapeByteReader())
 }
 
 /* end custom matcher factories */
 
+// Matcher basic interface
 type Matcher interface {
 	Match(byte) bool
 	Reset()
@@ -70,27 +80,34 @@ type Matcher interface {
 	HasAnyMatch() bool
 }
 
+// PgMatcher concatenates two matchers: pgMatcher and binaryMatcher
 type PgMatcher struct {
 	pgMatcher     Matcher
 	binaryMatcher Matcher
 }
 
+// NewPgMatcher returns new Matcher with pgMatcher and binaryMatcher
 func NewPgMatcher(dbReader DbByteReader) Matcher {
 	return &PgMatcher{
 		pgMatcher:     NewBaseMatcher(dbReader),
 		binaryMatcher: NewBaseMatcher(NewBinaryByteReader()),
 	}
 }
+
+// Match returns true if pgMatcher or binaryMatcher has ZONE_ID block inside c bytes
 func (matcher *PgMatcher) Match(c byte) bool {
 	pgMatched := matcher.pgMatcher.Match(c)
 	binMatched := matcher.binaryMatcher.Match(c)
 	return pgMatched || binMatched
 }
 
+// HasAnyMatch returns true if pgMatcher or binaryMatcher has any match
 func (matcher *PgMatcher) HasAnyMatch() bool {
 	return matcher.pgMatcher.HasAnyMatch() || matcher.binaryMatcher.HasAnyMatch()
 }
 
+// GetZoneID returns true if pgMatcher or binaryMatcher has zoneID
+// return empty bytes if no zoneID found
 func (matcher *PgMatcher) GetZoneID() []byte {
 	if matcher.pgMatcher.IsMatched() {
 		return matcher.pgMatcher.GetZoneID()
@@ -100,17 +117,21 @@ func (matcher *PgMatcher) GetZoneID() []byte {
 		return []byte{}
 	}
 }
+
+// Reset both pgMatcher and binaryMatcher
 func (matcher *PgMatcher) Reset() {
 	matcher.pgMatcher.Reset()
 	matcher.binaryMatcher.Reset()
 }
 
+// IsMatched returns true if pgMatcher or binaryMatcher has match
 func (matcher *PgMatcher) IsMatched() bool {
 	matched := matcher.pgMatcher.IsMatched()
 	matched = matched || matcher.binaryMatcher.IsMatched()
 	return matched
 }
 
+// BaseMatcher looks for zoneID in bytes read by dbReader
 type BaseMatcher struct {
 	currentIndex byte
 	matched      bool
@@ -119,6 +140,7 @@ type BaseMatcher struct {
 	dbReader     DbByteReader
 }
 
+// NewBaseMatcher returns new Matcher
 func NewBaseMatcher(dbReader DbByteReader) Matcher {
 	return &BaseMatcher{
 		currentIndex: 0,
@@ -128,6 +150,7 @@ func NewBaseMatcher(dbReader DbByteReader) Matcher {
 		zoneID:       make([]byte, ZONE_ID_BLOCK_LENGTH)}
 }
 
+// Reset changes Matcher state to the initial one, used in tests only
 func (matcher *BaseMatcher) Reset() {
 	// used only for tests
 	matcher.currentIndex = 0
@@ -135,6 +158,7 @@ func (matcher *BaseMatcher) Reset() {
 	matcher.hasAnyMatch = false
 }
 
+// Match returns true if c has ZONE_ID block
 func (matcher *BaseMatcher) Match(c byte) bool {
 	parsed, b, err := matcher.dbReader.ReadByte(c)
 	if err != nil {
@@ -164,14 +188,17 @@ func (matcher *BaseMatcher) Match(c byte) bool {
 	return true
 }
 
+// IsMatched true if matched
 func (matcher *BaseMatcher) IsMatched() bool {
 	return matcher.matched
 }
 
+// HasAnyMatch true if has any match
 func (matcher *BaseMatcher) HasAnyMatch() bool {
 	return matcher.hasAnyMatch
 }
 
+// GetZoneID returns zoneID or empty bytes
 func (matcher *BaseMatcher) GetZoneID() []byte {
 	if matcher.IsMatched() {
 		return matcher.zoneID

--- a/zone/matcher_pool.go
+++ b/zone/matcher_pool.go
@@ -19,15 +19,18 @@ import (
 	"container/list"
 )
 
+// MatcherPool stores MatcherFactory and list of matchers
 type MatcherPool struct {
 	factory  MatcherFactory
 	matchers *list.List
 }
 
+// NewMatcherPool returns new MatcherPool with empty list of matchers
 func NewMatcherPool(factory MatcherFactory) *MatcherPool {
 	return &MatcherPool{factory: factory, matchers: list.New()}
 }
 
+// Acquire returns first matcher from the list, or creates one from factory if matchers list is empty
 func (pool *MatcherPool) Acquire() Matcher {
 	if pool.matchers.Len() == 0 {
 		return pool.factory.CreateMatcher()
@@ -36,6 +39,8 @@ func (pool *MatcherPool) Acquire() Matcher {
 	matcher := pool.matchers.Remove(pool.matchers.Front())
 	return matcher.(Matcher)
 }
+
+// Release resets matcher and push it to the start of the list
 func (pool *MatcherPool) Release(matcher Matcher) {
 	matcher.Reset()
 	pool.matchers.PushFront(matcher)

--- a/zone/zone_id_matcher.go
+++ b/zone/zone_id_matcher.go
@@ -19,10 +19,12 @@ import (
 	"container/list"
 )
 
+// KeyChecker checks if Zone Private key is available
 type KeyChecker interface {
 	HasZonePrivateKey([]byte) bool
 }
 
+// ZoneIDMatcher represents exact binary Matcher
 type ZoneIDMatcher struct {
 	matched     bool
 	matchers    *list.List
@@ -31,6 +33,8 @@ type ZoneIDMatcher struct {
 	keychecker  KeyChecker
 }
 
+// NewZoneMatcher returns new ZoneIDMatcher for exact zoneID
+// with keychecker and empty matchers
 func NewZoneMatcher(matcherPool *MatcherPool, keychecker KeyChecker) *ZoneIDMatcher {
 	matcher := &ZoneIDMatcher{
 		matchers:    list.New(),
@@ -42,15 +46,19 @@ func NewZoneMatcher(matcherPool *MatcherPool, keychecker KeyChecker) *ZoneIDMatc
 	return matcher
 }
 
+// IsMatched returns true if zoneID found
 func (zoneMatcher *ZoneIDMatcher) IsMatched() bool {
 	return zoneMatcher.matched
 }
 
+// Reset clears matchers and reset matching state
 func (zoneMatcher *ZoneIDMatcher) Reset() {
 	zoneMatcher.matched = false
 	zoneMatcher.clearMatchers()
 }
 
+// GetZoneID returns zoneID if matched found it
+// return empty bytes otherwise
 func (zoneMatcher *ZoneIDMatcher) GetZoneID() []byte {
 	if zoneMatcher.IsMatched() {
 		return zoneMatcher.zoneID
@@ -58,11 +66,14 @@ func (zoneMatcher *ZoneIDMatcher) GetZoneID() []byte {
 	return []byte{}
 }
 
+// SetMatched sets that matcher has found zoneID – id
 func (zoneMatcher *ZoneIDMatcher) SetMatched(id []byte) {
 	zoneMatcher.zoneID = id
 	zoneMatcher.matched = true
 }
 
+// Match returns true if zoneID found inside c bytes
+// checks using different matchers from the loop
 func (zoneMatcher *ZoneIDMatcher) Match(c byte) bool {
 	currentElement := zoneMatcher.matchers.Front()
 	var toRemove *list.Element


### PR DESCRIPTION
- More comments.
- Fix errors naming.
- Small fixes here and there.
- Enable golint checks on CircleCI. Builds will fail if amount of issues will be more than 250.

Current amount of issues: 241.

Basically, most issues that are left connected with:
- names of constants ("don't use ALL_CAPS in Go names; use CamelCase" -> 219 issues)
- name of packages ("don't use an underscore in package name" -> 8 issues)

As soon as we don't want to change constants style, I think we're done with golint fixing for now.