### PR TITLE
Small fixes of poison records handling

### DIFF
--- a/cmd/acra-connector/acra-connector.go
+++ b/cmd/acra-connector/acra-connector.go
@@ -179,13 +179,13 @@ func main() {
 	keysDir := flag.String("keys_dir", keystore.DefaultKeyDirShort, "Folder from which will be loaded keys")
 	clientID := flag.String("client_id", "", "Client ID")
 	acraServerHost := flag.String("acraserver_connection_host", "", "IP or domain to AcraServer daemon")
-	acraServerAPIPort := flag.Int("acraserver_api_connection_port", cmd.DEFAULT_ACRASERVER_API_PORT, "Port of Acra HTTP api")
+	acraServerAPIPort := flag.Int("acraserver_api_connection_port", cmd.DEFAULT_ACRASERVER_API_PORT, "Port of Acra HTTP API")
 	acraServerPort := flag.Int("acraserver_connection_port", cmd.DEFAULT_ACRASERVER_PORT, "Port of AcraServer daemon")
 	acraServerID := flag.String("acraserver_securesession_id", "acra_server", "Expected id from AcraServer for Secure Session")
 	verbose := flag.Bool("v", false, "Log to stderr")
 	acraConnectorPort := flag.Int("incoming_connection_port", cmd.DEFAULT_ACRACONNECTOR_PORT, "Port to AcraConnector")
-	acraConnectorAPIPort := flag.Int("incoming_connection_api_port", cmd.DEFAULT_ACRACONNECTOR_API_PORT, "Port for AcraConnector HTTP api")
-	acraServerEnableHTTPAPI := flag.Bool("http_api_enable", false, "Enable AcraServer HTTP API")
+	acraConnectorAPIPort := flag.Int("incoming_connection_api_port", cmd.DEFAULT_ACRACONNECTOR_API_PORT, "Port for AcraConnector HTTP API")
+	acraServerEnableHTTPAPI := flag.Bool("http_api_enable", false, "Enable connection to AcraServer via HTTP API")
 	disableUserCheck := flag.Bool("user_check_disable", false, "Disable checking that connections from app running from another user")
 	useTLS := flag.Bool("acraserver_tls_transport_enable", false, "Use tls to encrypt transport between AcraServer and AcraConnector/client")
 	tlsCA := flag.String("tls_ca", "", "Path to root certificate which will be used with system root certificates to validate AcraServer's certificate")
@@ -198,7 +198,7 @@ func main() {
 	connectionAPIString := flag.String("incoming_connection_api_string", network.BuildConnectionString(cmd.DEFAULT_ACRACONNECTOR_CONNECTION_PROTOCOL, cmd.DEFAULT_ACRACONNECTOR_HOST, cmd.DEFAULT_ACRACONNECTOR_API_PORT, ""), "Connection string like tcp://x.x.x.x:yyyy or unix:///path/to/socket")
 	acraServerConnectionString := flag.String("acraserver_connection_string", "", "Connection string to AcraServer like tcp://x.x.x.x:yyyy or unix:///path/to/socket")
 	acraServerAPIConnectionString := flag.String("acraserver_api_connection_string", "", "Connection string to Acra's API like tcp://x.x.x.x:yyyy or unix:///path/to/socket")
-	prometheusAddress := flag.String("prometheus_metrics_address", "", "")
+	prometheusAddress := flag.String("prometheus_metrics_address", "", "URL of Prometheus server for AcraConnector to upload stats and metrics (upload address is <URL>/metrics)")
 
 	connectorModeString := flag.String("mode", "AcraServer", "Expected mode of connection. Possible values are: AcraServer or AcraTranslator. Corresponded connection host/port/string/session_id will be used.")
 	acraTranslatorHost := flag.String("acratranslator_connection_host", cmd.DEFAULT_ACRATRANSLATOR_GRPC_HOST, "IP or domain to AcraTranslator daemon")
@@ -434,8 +434,8 @@ func main() {
 		if err != nil {
 			panic(err)
 		}
+		log.Infof("Configured to send metrics and stats to `prometheus_metrics_address`")
 		sigHandler.AddListener(prometheusListener)
-
 	}
 
 	for {

--- a/cmd/acra-server/acra-server.go
+++ b/cmd/acra-server/acra-server.go
@@ -107,9 +107,9 @@ func main() {
 	debugServer := flag.Bool("ds", false, "Turn on http debug server")
 	closeConnectionTimeout := flag.Int("incoming_connection_close_timeout", DEFAULT_ACRASERVER_WAIT_TIMEOUT, "Time that AcraServer will wait (in seconds) on restart before closing all connections")
 
-	detectPoisonRecords := flag.Bool("poison_detect_enable", true, "Turn on poison record detection")
-	stopOnPoison := flag.Bool("poison_shutdown_enable", false, "Stop on detecting poison record")
-	scriptOnPoison := flag.String("poison_run_script_file", "", "Execute script on detecting poison record")
+	detectPoisonRecords := flag.Bool("poison_detect_enable", true, "Turn on poison record detection, if server shutdown is disabled, AcraServer logs the poison record detection and returns decrypted data")
+	stopOnPoison := flag.Bool("poison_shutdown_enable", false, "On detecting poison record: log about poison record detection, stop and shutdown")
+	scriptOnPoison := flag.String("poison_run_script_file", "", "On detecting poison record: log about poison record detection, execute script, return decrypted data")
 
 	withZone := flag.Bool("zonemode_enable", false, "Turn on zone mode")
 	enableHTTPAPI := flag.Bool("http_api_enable", false, "Enable HTTP API")

--- a/cmd/acra-server/acra-server.go
+++ b/cmd/acra-server/acra-server.go
@@ -85,7 +85,7 @@ func main() {
 	dbHost := flag.String("db_host", "", "Host to db")
 	dbPort := flag.Int("db_port", 5432, "Port to db")
 
-	prometheusAddress := flag.String("prometheus_metrics_address", "", "")
+	prometheusAddress := flag.String("prometheus_metrics_address", "", "URL of Prometheus server for AcraConnector to upload stats and metrics (upload address is <URL>/metrics)")
 
 	host := flag.String("incoming_connection_host", cmd.DEFAULT_ACRA_HOST, "Host for AcraServer")
 	port := flag.Int("incoming_connection_port", cmd.DEFAULT_ACRASERVER_PORT, "Port for AcraServer")
@@ -316,6 +316,7 @@ func main() {
 		if err != nil {
 			panic(err)
 		}
+		log.Infof("Configured to send metrics and stats to `prometheus_metrics_address`")
 		sigHandlerSIGHUP.AddListener(prometheusListener)
 		sigHandlerSIGTERM.AddListener(prometheusListener)
 	}

--- a/cmd/acra-server/listener.go
+++ b/cmd/acra-server/listener.go
@@ -361,7 +361,7 @@ func (server *SServer) StartCommandsFromFileDescriptor(fd uintptr) {
 	logger := log.WithFields(log.Fields{"connection_string": server.config.GetAcraConnectionString(), "from_descriptor": true})
 	file := os.NewFile(fd, "/tmp/acra-server_http_api")
 	if file == nil {
-		logger.Errorln("Can't create new file from descriptor for api listener")
+		logger.Errorln("Can't create new file from descriptor for API listener")
 		server.errorSignalChannel <- syscall.SIGTERM
 		return
 	}

--- a/cmd/acra-translator/acra-translator.go
+++ b/cmd/acra-translator/acra-translator.go
@@ -60,9 +60,9 @@ func main() {
 
 	secureSessionID := flag.String("securesession_id", "acra_translator", "Id that will be sent in secure session")
 
-	detectPoisonRecords := flag.Bool("poison_detect_enable", true, "Turn on poison record detection")
-	stopOnPoison := flag.Bool("poison_shutdown_enable", false, "Stop on detecting poison record")
-	scriptOnPoison := flag.String("poison_run_script_file", "", "Execute script on detecting poison record")
+	detectPoisonRecords := flag.Bool("poison_detect_enable", true, "Turn on poison record detection, if server shutdown is disabled, AcraTranslator logs the poison record detection and returns error")
+	stopOnPoison := flag.Bool("poison_shutdown_enable", false, "On detecting poison record: log about poison record detection, stop and shutdown")
+	scriptOnPoison := flag.String("poison_run_script_file", "", "On detecting poison record: log about poison record detection, execute script, return decrypted data")
 
 	closeConnectionTimeout := flag.Int("incoming_connection_close_timeout", DEFAULT_WAIT_TIMEOUT, "Time that AcraTranslator will wait (in seconds) on stop signal before closing all connections")
 

--- a/cmd/acra-translator/grpc_api/decryptor.go
+++ b/cmd/acra-translator/grpc_api/decryptor.go
@@ -83,7 +83,8 @@ func (service *DecryptGRPCService) Decrypt(ctx context.Context, request *Decrypt
 						logger.WithError(err).Errorln("Unexpected error on poison record's callbacks")
 					}
 				}
-				return nil, base.ErrPoisonRecord
+				// don't show users that we found poison record
+				return nil, ErrCantDecrypt
 			}
 		}
 		return nil, ErrCantDecrypt

--- a/cmd/acra-translator/grpc_api/decryptor.go
+++ b/cmd/acra-translator/grpc_api/decryptor.go
@@ -83,7 +83,7 @@ func (service *DecryptGRPCService) Decrypt(ctx context.Context, request *Decrypt
 						logger.WithError(err).Errorln("Unexpected error on poison record's callbacks")
 					}
 				}
-				return nil, ErrCantDecrypt
+				return nil, base.ErrPoisonRecord
 			}
 		}
 		return nil, ErrCantDecrypt

--- a/cmd/acra-translator/server.go
+++ b/cmd/acra-translator/server.go
@@ -194,11 +194,13 @@ func (server *ReaderServer) Start(parentContext context.Context) {
 	logger := logging.GetLoggerFromContext(parentContext)
 	poisonCallbacks := base.NewPoisonCallbackStorage()
 	if server.config.DetectPoisonRecords() {
-		if server.config.stopOnPoison {
-			poisonCallbacks.AddCallback(&base.StopCallback{})
-		}
 		if server.config.scriptOnPoison != "" {
 			poisonCallbacks.AddCallback(base.NewExecuteScriptCallback(server.config.scriptOnPoison))
+		}
+
+		// must be last
+		if server.config.stopOnPoison {
+			poisonCallbacks.AddCallback(&base.StopCallback{})
 		}
 	}
 	decryptorData := &common.TranslatorData{Keystorage: server.keystorage, PoisonRecordCallbacks: poisonCallbacks, CheckPoisonRecords: server.config.detectPoisonRecords}

--- a/configs/acra-connector.yaml
+++ b/configs/acra-connector.yaml
@@ -1,4 +1,4 @@
-# Port of Acra HTTP api
+# Port of Acra HTTP API
 acraserver_api_connection_port: 9090
 
 # Connection string to Acra's API like tcp://x.x.x.x:yyyy or unix:///path/to/socket
@@ -43,10 +43,10 @@ config_file:
 # dump config
 dump_config: false
 
-# Enable AcraServer HTTP API
+# Enable connection to AcraServer via HTTP API
 http_api_enable: false
 
-# Port for AcraConnector HTTP api
+# Port for AcraConnector HTTP API
 incoming_connection_api_port: 9191
 
 # Connection string like tcp://x.x.x.x:yyyy or unix:///path/to/socket
@@ -66,6 +66,9 @@ logging_format: plaintext
 
 # Expected mode of connection. Possible values are: AcraServer or AcraTranslator. Corresponded connection host/port/string/session_id will be used.
 mode: AcraServer
+
+# URL of Prometheus server for AcraConnector to upload stats and metrics (upload address is <URL>/metrics)
+prometheus_metrics_address: 
 
 # Expected Server Name (SNI) from AcraServer
 tls_acraserver_sni: 

--- a/configs/acra-server.yaml
+++ b/configs/acra-server.yaml
@@ -76,13 +76,13 @@ pgsql_escape_bytea: false
 # Hex format for Postgresql bytea data (default)
 pgsql_hex_bytea: false
 
-# Turn on poison record detection
+# Turn on poison record detection, if server shutdown is disabled, AcraServer logs the poison record detection and returns decrypted data
 poison_detect_enable: true
 
-# Execute script on detecting poison record
+# On detecting poison record: log about poison record detection, execute script, return decrypted data
 poison_run_script_file: 
 
-# Stop on detecting poison record
+# On detecting poison record: log about poison record detection, stop and shutdown
 poison_shutdown_enable: false
 
 # Handle Postgresql connections (default true)

--- a/configs/acra-server.yaml
+++ b/configs/acra-server.yaml
@@ -61,6 +61,9 @@ incoming_connection_string: tcp://0.0.0.0:9393/
 # Folder from which will be loaded keys
 keys_dir: .acrakeys
 
+# Count of keys that will be stored in in-memory LRU cache in encrypted form. 0 - no limits, -1 - turn off cache
+keystore_cache_size: 0
+
 # Logging format: plaintext, json or CEF
 logging_format: plaintext
 
@@ -84,6 +87,9 @@ poison_shutdown_enable: false
 
 # Handle Postgresql connections (default true)
 postgresql_enable: false
+
+# URL of Prometheus server for AcraConnector to upload stats and metrics (upload address is <URL>/metrics)
+prometheus_metrics_address: 
 
 # Id that will be sent in secure session
 securesession_id: acra_server

--- a/configs/acra-translator.yaml
+++ b/configs/acra-translator.yaml
@@ -19,6 +19,9 @@ incoming_connection_http_string: http://0.0.0.0:9595/
 # Folder from which will be loaded keys
 keys_dir: .acrakeys
 
+# Count of keys that will be stored in in-memory LRU cache in encrypted form. 0 - no limits, -1 - turn off cache
+keystore_cache_size: 0
+
 # Logging format: plaintext, json or CEF
 logging_format: plaintext
 

--- a/configs/acra-translator.yaml
+++ b/configs/acra-translator.yaml
@@ -25,13 +25,13 @@ keystore_cache_size: 0
 # Logging format: plaintext, json or CEF
 logging_format: plaintext
 
-# Turn on poison record detection
+# Turn on poison record detection, if server shutdown is disabled, AcraTranslator logs the poison record detection and returns error
 poison_detect_enable: true
 
-# Execute script on detecting poison record
+# On detecting poison record: log about poison record detection, execute script, return decrypted data
 poison_run_script_file: 
 
-# Stop on detecting poison record
+# On detecting poison record: log about poison record detection, stop and shutdown
 poison_shutdown_enable: false
 
 # Id that will be sent in secure session


### PR DESCRIPTION
While polishing documentation, I found and fixed these issues:

- ATran: fix poison records callback order – first handle script, then shutdown.
- update user-friendly descripton for poison records params AS/ATran
- return Poison Record decryption error for gRPC connection of ATran
- fix naming and logs here and there
- re-generate configs