### PR TITLE
AcraTranslator startup, and logs

### DIFF
--- a/cmd/acra-connector/acra-connector.go
+++ b/cmd/acra-connector/acra-connector.go
@@ -182,7 +182,7 @@ func main() {
 	acraServerAPIPort := flag.Int("acraserver_api_connection_port", cmd.DEFAULT_ACRASERVER_API_PORT, "Port of Acra HTTP API")
 	acraServerPort := flag.Int("acraserver_connection_port", cmd.DEFAULT_ACRASERVER_PORT, "Port of AcraServer daemon")
 	acraServerID := flag.String("acraserver_securesession_id", "acra_server", "Expected id from AcraServer for Secure Session")
-	verbose := flag.Bool("v", false, "Log to stderr")
+
 	acraConnectorPort := flag.Int("incoming_connection_port", cmd.DEFAULT_ACRACONNECTOR_PORT, "Port to AcraConnector")
 	acraConnectorAPIPort := flag.Int("incoming_connection_api_port", cmd.DEFAULT_ACRACONNECTOR_API_PORT, "Port for AcraConnector HTTP API")
 	acraServerEnableHTTPAPI := flag.Bool("http_api_enable", false, "Enable connection to AcraServer via HTTP API")
@@ -206,6 +206,9 @@ func main() {
 	acraTranslatorConnectionString := flag.String("acratranslator_connection_string", "", "Connection string to AcraTranslator like grpc://0.0.0.0:9696 or http://0.0.0.0:9595")
 	acraTranslatorID := flag.String("acratranslator_securesession_id", "acra_translator", "Expected id from AcraTranslator for Secure Session")
 
+	verbose := flag.Bool("v", false, "Log to stderr all INFO, WARNING and ERROR logs")
+	debug := flag.Bool("d", false, "Log everything to stderr")
+
 	err := cmd.Parse(DEFAULT_CONFIG_PATH, SERVICE_NAME)
 	if err != nil {
 		log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantReadServiceConfig).
@@ -215,7 +218,7 @@ func main() {
 
 	// if log format was overridden
 	logging.CustomizeLogging(*loggingFormat, SERVICE_NAME)
-	log.Infof("Validating service configuration")
+	log.Infof("Validating service configuration...")
 
 	if err := checkDependencies(); err != nil {
 		log.Infoln(err.Error())
@@ -308,7 +311,7 @@ func main() {
 	// --------- check keys -----------
 	cmd.ValidateClientID(*clientID)
 
-	log.Infof("Reading keys...")
+	log.Infof("Reading transport keys...")
 
 	exists, err := keyStore.CheckIfPrivateKeyExists([]byte(*clientID))
 	if !exists || err != nil {
@@ -316,7 +319,7 @@ func main() {
 			Errorf("Configuration error: can't check that AcraConnector private key exists, got error - %v", err)
 		os.Exit(1)
 	}
-	log.Infof("Client id and client key is OK")
+	log.Infof("Client id = %v, and client key is OK", *clientID)
 
 	_, err = keyStore.GetPeerPublicKey([]byte(*clientID))
 	if err != nil {
@@ -391,7 +394,7 @@ func main() {
 				commandsConfig := *config
 				commandsConfig.OutgoingConnectionString = *acraServerAPIConnectionString
 
-				log.Infof("Start listening http API: %s", *connectionAPIString)
+				log.Infof("Start listening HTTP API: %s", *connectionAPIString)
 				commandsListener, err := network.Listen(*connectionAPIString)
 				if err != nil {
 					log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantStartListenConnections).
@@ -422,10 +425,14 @@ func main() {
 	// -------- START -----------
 	log.Infof("Setup ready. Start listening connection %s", *connectionString)
 
-	if *verbose {
+	if *debug {
+		log.Infof("Enabling DEBUG log level")
+		logging.SetLogLevel(logging.LOG_DEBUG)
+	} else if *verbose {
+		log.Infof("Enabling VERBOSE log level")
 		logging.SetLogLevel(logging.LOG_VERBOSE)
 	} else {
-		log.Infof("Disabling future logs.. Set -v to see logs")
+		log.Infof("Disabling future logs.. Set -v -d to see logs")
 		logging.SetLogLevel(logging.LOG_DISCARD)
 	}
 

--- a/cmd/acra-server/acra-server.go
+++ b/cmd/acra-server/acra-server.go
@@ -99,11 +99,9 @@ func main() {
 
 	secureSessionID := flag.String("securesession_id", "acra_server", "Id that will be sent in secure session")
 
-	verbose := flag.Bool("v", false, "Log to stderr")
 	flag.Bool("acrastruct_wholecell_enable", true, "Acrastruct will stored in whole data cell")
 	injectedcell := flag.Bool("acrastruct_injectedcell_enable", false, "Acrastruct may be injected into any place of data cell")
 
-	debug := flag.Bool("d", false, "Turn on debug logging")
 	debugServer := flag.Bool("ds", false, "Turn on http debug server")
 	closeConnectionTimeout := flag.Int("incoming_connection_close_timeout", DEFAULT_ACRASERVER_WAIT_TIMEOUT, "Time that AcraServer will wait (in seconds) on restart before closing all connections")
 
@@ -130,6 +128,9 @@ func main() {
 	usePostgresql := flag.Bool("postgresql_enable", false, "Handle Postgresql connections (default true)")
 	censorConfig := flag.String("acracensor_config_file", "", "Path to AcraCensor configuration file")
 
+	verbose := flag.Bool("v", false, "Log to stderr all INFO, WARNING and ERROR logs")
+	debug := flag.Bool("d", false, "Log everything to stderr")
+
 	err := cmd.Parse(DEFAULT_CONFIG_PATH, SERVICE_NAME)
 	if err != nil {
 		log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantReadServiceConfig).
@@ -140,7 +141,7 @@ func main() {
 	// if log format was overridden
 	logging.CustomizeLogging(*loggingFormat, SERVICE_NAME)
 
-	log.Infof("Validating service configuration")
+	log.Infof("Validating service configuration...")
 	cmd.ValidateClientID(*secureSessionID)
 
 	if *host != cmd.DEFAULT_ACRA_HOST || *port != cmd.DEFAULT_ACRASERVER_PORT {
@@ -150,13 +151,6 @@ func main() {
 		*acraConnectionString = network.BuildConnectionString("tcp", *host, *apiPort, "")
 	}
 
-	if *debug {
-		logging.SetLogLevel(logging.LOG_DEBUG)
-	} else if *verbose {
-		logging.SetLogLevel(logging.LOG_VERBOSE)
-	} else {
-		logging.SetLogLevel(logging.LOG_DISCARD)
-	}
 	if *dbHost == "" {
 		log.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorWrongConfiguration).
 			Errorln("db_host is empty: you must specify db_host")
@@ -208,7 +202,7 @@ func main() {
 		config.SetByteaFormat(ESCAPE_BYTEA_FORMAT)
 	}
 
-	log.Infof("Initialising keystore")
+	log.Infof("Initialising keystore...")
 	masterKey, err := keystore.GetMasterKeyFromEnvironment()
 	if err != nil {
 		log.WithError(err).Errorln("can't load master key")
@@ -225,6 +219,9 @@ func main() {
 			Errorln("Can't initialise keystore")
 		os.Exit(1)
 	}
+	log.Infof("Keystore init OK")
+
+	log.Infof("Configuring transport...")
 	var tlsConfig *tls.Config
 	if *useTLS || *tlsKey != "" {
 		tlsConfig, err = network.NewTLSConfig(network.SNIOrHostname(*tlsDbSNI, *dbHost), *tlsCA, *tlsKey, *tlsCert, tls.ClientAuthType(*tlsAuthType))
@@ -242,7 +239,7 @@ func main() {
 	}
 	config.SetTLSConfig(tlsConfig)
 	if *useTLS {
-		log.Println("Using TLS transport wrapper")
+		log.Println("Selecting transport: use TLS transport wrapper")
 		config.ConnectionWrapper, err = network.NewTLSConnectionWrapper([]byte(*clientID), tlsConfig)
 		if err != nil {
 			log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorTransportConfiguration).
@@ -391,6 +388,17 @@ func main() {
 	})
 
 	log.Infof("Start listening to connections. Current PID: %v", os.Getpid())
+
+	if *debug {
+		log.Infof("Enabling DEBUG log level")
+		logging.SetLogLevel(logging.LOG_DEBUG)
+	} else if *verbose {
+		log.Infof("Enabling VERBOSE log level")
+		logging.SetLogLevel(logging.LOG_VERBOSE)
+	} else {
+		log.Infof("Disabling future logs.. Set -v -d to see logs")
+		logging.SetLogLevel(logging.LOG_DISCARD)
+	}
 
 	if os.Getenv(GRACEFUL_ENV) == "true" {
 		if *withZone || *enableHTTPAPI {

--- a/cmd/acra-translator/acra-translator.go
+++ b/cmd/acra-translator/acra-translator.go
@@ -52,8 +52,8 @@ func main() {
 	logging.CustomizeLogging(*loggingFormat, SERVICE_NAME)
 	log.Infof("Starting service %v", SERVICE_NAME)
 
-	incomingConnectionHTTPString := flag.String("incoming_connection_http_string", network.BuildConnectionString(network.HTTP_SCHEME, cmd.DEFAULT_ACRATRANSLATOR_HTTP_HOST, cmd.DEFAULT_ACRATRANSLATOR_HTTP_PORT, ""), "Connection string for HTTP transport like http://x.x.x.x:yyyy")
-	incomingConnectionGRPCString := flag.String("incoming_connection_grpc_string", network.BuildConnectionString(network.GRPC_SCHEME, cmd.DEFAULT_ACRATRANSLATOR_GRPC_HOST, cmd.DEFAULT_ACRATRANSLATOR_GRPC_PORT, ""), "Connection string for gRPC transport like grpc://x.x.x.x:yyyy")
+	incomingConnectionHTTPString := flag.String("incoming_connection_http_string", "", "Connection string for HTTP transport like http://0.0.0.0:9595")
+	incomingConnectionGRPCString := flag.String("incoming_connection_grpc_string", "", "Connection string for gRPC transport like grpc://0.0.0.0:9696")
 
 	keysDir := flag.String("keys_dir", keystore.DefaultKeyDirShort, "Folder from which will be loaded keys")
 	keysCacheSize := flag.Int("keystore_cache_size", keystore.INFINITE_CACHE_SIZE, "Count of keys that will be stored in in-memory LRU cache in encrypted form. 0 - no limits, -1 - turn off cache")

--- a/cmd/acra-translator/server.go
+++ b/cmd/acra-translator/server.go
@@ -208,6 +208,7 @@ func (server *ReaderServer) Start(parentContext context.Context) {
 		go func() {
 			httpContext := logging.SetLoggerToContext(parentContext, logger.WithField(CONNECTION_TYPE_KEY, HTTP_CONNECTION_TYPE))
 			httpDecryptor, err := http_api.NewHTTPConnectionsDecryptor(decryptorData)
+			logger.WithField("connection_string", server.config.incomingConnectionHTTPString).Infof("Start process HTTP requests")
 			if err != nil {
 				log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorTranslatorCantHandleHTTPConnection).
 					Errorln("Can't create http decryptor")
@@ -223,7 +224,7 @@ func (server *ReaderServer) Start(parentContext context.Context) {
 	if server.config.incomingConnectionGRPCString != "" {
 		go func() {
 			grpcLogger := logger.WithField(CONNECTION_TYPE_KEY, GRPC_CONNECTION_TYPE)
-			logger.WithField("connection_string", server.config.incomingConnectionGRPCString).Infof("Start process grpc requests")
+			logger.WithField("connection_string", server.config.incomingConnectionGRPCString).Infof("Start process gRPC requests")
 			secureSessionListener, err := network.NewSecureSessionListener(server.config.incomingConnectionGRPCString, server.keystorage)
 			if err != nil {
 				grpcLogger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorTranslatorCantHandleGRPCConnection).

--- a/configs/acra-connector.yaml
+++ b/configs/acra-connector.yaml
@@ -40,6 +40,9 @@ client_id:
 # path to config
 config_file: 
 
+# Log everything to stderr
+d: false
+
 # dump config
 dump_config: false
 
@@ -88,6 +91,6 @@ tls_key:
 # Disable checking that connections from app running from another user
 user_check_disable: false
 
-# Log to stderr
+# Log to stderr all INFO, WARNING and ERROR logs
 v: false
 

--- a/configs/acra-server.yaml
+++ b/configs/acra-server.yaml
@@ -22,7 +22,7 @@ client_id:
 # path to config
 config_file: 
 
-# Turn on debug logging
+# Log everything to stderr
 d: false
 
 # Host to db
@@ -109,7 +109,7 @@ tls_db_sni:
 # Path to private key that will be used in TLS handshake with AcraConnector as server's key and Postgresql as client's key
 tls_key: 
 
-# Log to stderr
+# Log to stderr all INFO, WARNING and ERROR logs
 v: false
 
 # Turn on zone mode

--- a/configs/acra-translator.yaml
+++ b/configs/acra-translator.yaml
@@ -10,11 +10,11 @@ dump_config: false
 # Time that AcraTranslator will wait (in seconds) on stop signal before closing all connections
 incoming_connection_close_timeout: 10
 
-# Connection string for gRPC transport like grpc://x.x.x.x:yyyy
-incoming_connection_grpc_string: grpc://0.0.0.0:9696/
+# Connection string for gRPC transport like grpc://0.0.0.0:9696
+incoming_connection_grpc_string: 
 
-# Connection string for HTTP transport like http://x.x.x.x:yyyy
-incoming_connection_http_string: http://0.0.0.0:9595/
+# Connection string for HTTP transport like http://0.0.0.0:9595
+incoming_connection_http_string: 
 
 # Folder from which will be loaded keys
 keys_dir: .acrakeys

--- a/configs/acra-translator.yaml
+++ b/configs/acra-translator.yaml
@@ -1,7 +1,7 @@
 # path to config
 config_file: 
 
-# Turn on debug logging
+# Log everything to stderr
 d: false
 
 # dump config
@@ -10,8 +10,8 @@ dump_config: false
 # Time that AcraTranslator will wait (in seconds) on stop signal before closing all connections
 incoming_connection_close_timeout: 10
 
-# Connection string for gRPC transport like grpc://0.0.0.0:9696
-incoming_connection_grpc_string: 
+# Default option: connection string for gRPC transport like grpc://0.0.0.0:9696
+incoming_connection_grpc_string: grpc://0.0.0.0:9696/
 
 # Connection string for HTTP transport like http://0.0.0.0:9595
 incoming_connection_http_string: 
@@ -37,6 +37,6 @@ poison_shutdown_enable: false
 # Id that will be sent in secure session
 securesession_id: acra_translator
 
-# Log to stderr
+# Log to stderr all INFO, WARNING and ERROR logs
 v: false
 


### PR DESCRIPTION
- AT: start only gRPC connection by default
- AT, AS, AC: unify start up logs