### PR TITLE
AcraCensor: normalize queries and fix QueryCaptureHandler

### DIFF
--- a/acra-censor/acra-censor_implementation.go
+++ b/acra-censor/acra-censor_implementation.go
@@ -48,7 +48,7 @@ func (acraCensor *AcraCensor) ReleaseAll() {
 
 // HandleQuery processes every query through each handler.
 func (acraCensor *AcraCensor) HandleQuery(query string) error {
-	queryWithHiddenValues, err := handlers.RedactSQLQuery(query)
+	normalizedQuery, queryWithHiddenValues, err := handlers.NormalizeAndRedactSQLQuery(query)
 	if err == handlers.ErrQuerySyntaxError && acraCensor.ignoreParseError {
 		acraCensor.logger.WithError(err).Infof("Parsing error on query (first %v symbols): %s", handlers.LogQueryLength, handlers.TrimStringToN(queryWithHiddenValues, handlers.LogQueryLength))
 	}
@@ -58,7 +58,7 @@ func (acraCensor *AcraCensor) HandleQuery(query string) error {
 			queryCaptureHandler.CheckQuery(queryWithHiddenValues)
 			continue
 		}
-		continueHandling, err := handler.CheckQuery(query)
+		continueHandling, err := handler.CheckQuery(normalizedQuery)
 		if err != nil {
 			if err == handlers.ErrQuerySyntaxError && acraCensor.ignoreParseError {
 				acraCensor.logger.WithError(err).Infof("Parsing error on query (first %v symbols): %s", handlers.LogQueryLength, handlers.TrimStringToN(queryWithHiddenValues, handlers.LogQueryLength))

--- a/acra-censor/acra-censor_implementation.go
+++ b/acra-censor/acra-censor_implementation.go
@@ -53,6 +53,11 @@ func (acraCensor *AcraCensor) HandleQuery(query string) error {
 		acraCensor.logger.WithError(err).Infof("Parsing error on query (first %v symbols): %s", handlers.LogQueryLength, handlers.TrimStringToN(queryWithHiddenValues, handlers.LogQueryLength))
 	}
 	for _, handler := range acraCensor.handlers {
+		// in QueryCapture Handler use only redacted queries
+		if queryCaptureHandler, ok := handler.(*handlers.QueryCaptureHandler); ok {
+			queryCaptureHandler.CheckQuery(queryWithHiddenValues)
+			continue
+		}
 		continueHandling, err := handler.CheckQuery(query)
 		if err != nil {
 			if err == handlers.ErrQuerySyntaxError && acraCensor.ignoreParseError {

--- a/acra-censor/acra-censor_test.go
+++ b/acra-censor/acra-censor_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"fmt"
 	"github.com/cossacklabs/acra/acra-censor/handlers"
 	"github.com/cossacklabs/acra/utils"
 )
@@ -67,6 +68,25 @@ func TestWhitelistQueries(t *testing.T) {
 	}
 	//ditto
 	err = acraCensor.HandleQuery("INSERT INTO SalesStaff1 VALUES (1, 'Stephen', 'Jiang');")
+	if err != handlers.ErrQueryNotInWhitelist {
+		t.Fatal(err)
+	}
+
+	//acracensor should NOT block this query because its the same as in whitelist, but lower-cased and without ";"
+	lowerCaseWhiteListedQuery := "select * from STUDENT"
+	err = acraCensor.HandleQuery(lowerCaseWhiteListedQuery)
+	if err != nil {
+		t.Fatal(err)
+	}
+	//acracensor should NOT block this query because its the same as in whitelist, but lower-cased and without ;
+	err = acraCensor.HandleQuery("select EMP_ID, LAST_NAME from EMPLOYEE where CITY = 'Seattle' order BY EMP_ID")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	whitelistHandler.RemoveQueries([]string{lowerCaseWhiteListedQuery})
+	err = acraCensor.HandleQuery(lowerCaseWhiteListedQuery)
+	//now acracensor should block this query because it is not in whitelist anymore
 	if err != handlers.ErrQueryNotInWhitelist {
 		t.Fatal(err)
 	}
@@ -523,7 +543,8 @@ func TestBlacklistQueries(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	testQuery := "INSERT INTO Customers (CustomerName, City, Country) VALUES ('Cardinal', 'Stavanger', 'Norway');"
+
+	testQuery := "insert INTO Customers (CustomerName, City, Country) VALUES ('Cardinal', 'Stavanger', 'Norway');"
 	blacklist.AddQueries([]string{testQuery})
 	err = acraCensor.HandleQuery(testQuery)
 	//acracensor should block this query because it's in blacklist
@@ -996,7 +1017,7 @@ func TestQueryIgnoring(t *testing.T) {
 		}
 	}
 }
-func TestSerialization(t *testing.T) {
+func TestSerializationOnUniqueQueries(t *testing.T) {
 	testQueries := []string{
 		"SELECT Student_ID FROM STUDENT;",
 		"SELECT * FROM STUDENT;",
@@ -1012,7 +1033,6 @@ func TestSerialization(t *testing.T) {
 		"INSERT SalesStaff1 VALUES (2, 'Michael', 'Blythe'), (3, 'Linda', 'Mitchell'),(4, 'Jillian', 'Carson'), (5, 'Garrett', 'Vargas');",
 		"INSERT INTO SalesStaff2 (StaffGUID, FirstName, LastName) VALUES (NEWID(), 'Stephen', 'Jiang');",
 		"INSERT INTO SalesStaff3 (StaffID, FullName) VALUES (X, 'Y');",
-		"INSERT INTO SalesStaff3 (StaffID, FullName) VALUES (X, 'Z');",
 		"INSERT INTO SalesStaff3 (StaffID, FullNameTbl) VALUES (X, M);",
 		"INSERT INTO X.Customers (CustomerName, ContactName, Address, City, PostalCode, Country) VALUES ('Cardinal', 'Tom B. Erichsen', 'Skagen 21', 'Stavanger', '4006', 'Norway');",
 		"INSERT INTO Customers (CustomerName, City, Country) VALUES ('Cardinal', 'Stavanger', 'Norway');",
@@ -1034,7 +1054,7 @@ func TestSerialization(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, query := range testQueries {
-		_, err = handler.CheckQuery(query)
+		_, err = handler.RedactAndCheckQuery(query)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1070,30 +1090,78 @@ func TestSerialization(t *testing.T) {
 		t.Fatal(err)
 	}
 }
-func TestLogging(t *testing.T) {
+func TestSerializationOnSameQueries(t *testing.T) {
+	// 5 queries, 3 unique redacted queries
+	numOfUniqueQueries := 3
+	testQueries := []string{
+		// will be redacted
+		"SELECT NAME WHERE EMP_ID = '1234';",
+		"SELECT NAME WHERE EMP_ID = '345';",
+
+		// different
+		"SELECT EMP_ID, LAST_NAME FROM EMPLOYEE WHERE CITY = 'Seattle' ORDER BY EMP_ID;",
+		"SELECT EMP_ID FROM EMPLOYEE WHERE CITY = 'Seattle' ORDER BY EMP_ID;",
+
+		// similar to previous one, will be redacted
+		"SELECT EMP_ID FROM EMPLOYEE WHERE CITY = 'London' ORDER BY EMP_ID;",
+	}
+	tmpFile, err := ioutil.TempFile("", "censor_log")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = tmpFile.Close(); err != nil {
+		t.Fatal(err)
+	}
+	handler, err := handlers.NewQueryCaptureHandler(tmpFile.Name())
+	defer handler.Release()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, query := range testQueries {
+		_, err = handler.RedactAndCheckQuery(query)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	defaultTimeout := handler.GetSerializationTimeout()
+	handler.SetSerializationTimeout(50 * time.Millisecond)
+	//wait until goroutine handles complex serialization
+	time.Sleep(defaultTimeout + handler.GetSerializationTimeout() + 10*time.Millisecond)
+
+	if len(handler.GetAllInputQueries()) != numOfUniqueQueries {
+		t.Fatal("Expected to have " + fmt.Sprint(numOfUniqueQueries) + " unique queries. \n Got:" + strings.Join(handler.GetAllInputQueries(), " | "))
+	}
+	err = handler.DumpAllQueriesToFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	handler.Reset()
+	if len(handler.GetAllInputQueries()) != 0 {
+		t.Fatal("Expected no queries \nGot: " + strings.Join(handler.GetAllInputQueries(), " | "))
+	}
+	err = handler.ReadAllQueriesFromFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(handler.GetAllInputQueries()) != numOfUniqueQueries {
+		t.Fatal("Expected to have " + fmt.Sprint(numOfUniqueQueries) + " unique queries. \n Got:" + strings.Join(handler.GetAllInputQueries(), " | "))
+	}
+	for index, query := range handler.GetAllInputQueries() {
+		if strings.EqualFold(testQueries[index], query) {
+			t.Fatal("Expected: " + testQueries[index] + "\nGot: " + query)
+		}
+	}
+	if err = os.Remove(tmpFile.Name()); err != nil {
+		t.Fatal(err)
+	}
+}
+func TestAddingCapturedQueriesIntoBlacklist(t *testing.T) {
+	// Currently we support adding only non-redacted queries
 	testQueries := []string{
 		"SELECT Student_ID FROM STUDENT;",
 		"SELECT * FROM STUDENT;",
-		"SELECT * FROM X;",
+		"select * FROM X;",
 		"SELECT * FROM Y;",
-		"SELECT EMP_ID, NAME FROM EMPLOYEE_TBL WHERE EMP_ID = '0000';",
-		"SELECT EMP_ID, LAST_NAME FROM EMPLOYEE WHERE CITY = 'Seattle' ORDER BY EMP_ID;",
-		"SELECT EMP_ID, LAST_NAME FROM EMPLOYEE_TBL WHERE CITY = 'INDIANAPOLIS' ORDER BY EMP_ID asc;",
-		"SELECT Name, Age FROM Patients WHERE Age > 40 GROUP BY Age ORDER BY Name;",
-		"SELECT COUNT(CustomerID), Country FROM Customers GROUP BY Country;",
-		"SELECT SUM(Salary)FROM Employee WHERE Emp_Age < 30;",
-		"SELECT AVG(Price)FROM Products;",
-		"INSERT SalesStaff1 VALUES (2, 'Michael', 'Blythe'), (3, 'Linda', 'Mitchell'),(4, 'Jillian', 'Carson'), (5, 'Garrett', 'Vargas');",
-		"INSERT INTO SalesStaff2 (StaffGUID, FirstName, LastName) VALUES (NEWID(), 'Stephen', 'Jiang');",
-		"INSERT INTO SalesStaff3 (StaffID, FullName) VALUES (X, 'Y');",
-		"INSERT INTO SalesStaff3 (StaffID, FullName) VALUES (X, 'Z');",
-		"INSERT INTO SalesStaff3 (StaffID, FullNameTbl) VALUES (X, M);",
-		"INSERT INTO X.Customers (CustomerName, ContactName, Address, City, PostalCode, Country) VALUES ('Cardinal', 'Tom B. Erichsen', 'Skagen 21', 'Stavanger', '4006', 'Norway');",
-		"INSERT INTO Customers (CustomerName, City, Country) VALUES ('Cardinal', 'Stavanger', 'Norway');",
-		"INSERT INTO Production (Name, UnitMeasureCode,	ModifiedDate) VALUES ('Square Yards', 'Y2', GETDATE());",
-		"INSERT INTO T1 (Name, UnitMeasureCode,	ModifiedDate) VALUES ('Square Yards', 'Y2', GETDATE());",
-		"INSERT INTO dbo.Points (Type, PointValue) VALUES ('Point', '1,5');",
-		"INSERT INTO dbo.Points (PointValue) VALUES ('1,99');",
 	}
 	tmpFile, err := ioutil.TempFile("", "censor_log")
 	if err != nil {
@@ -1117,9 +1185,9 @@ func TestLogging(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	captureHandler.MarkQueryAsForbidden(testQueries[0])
-	captureHandler.MarkQueryAsForbidden(testQueries[1])
-	captureHandler.MarkQueryAsForbidden(testQueries[2])
+	captureHandler.RedactAndMarkQueryAsForbidden(testQueries[0])
+	captureHandler.RedactAndMarkQueryAsForbidden(testQueries[1])
+	captureHandler.RedactAndMarkQueryAsForbidden(testQueries[2])
 	captureHandler.DumpAllQueriesToFile()
 
 	blacklist.AddQueries(captureHandler.GetForbiddenQueries())
@@ -1168,15 +1236,15 @@ func TestQueryCapture(t *testing.T) {
 		"SELECT * FROM Y;",
 	}
 	for _, query := range testQueries {
-		_, err = handler.CheckQuery(query)
+		_, err = handler.RedactAndCheckQuery(query)
 		if err != nil {
 			t.Fatal(err)
 		}
 	}
-	expected := "{\"RawQuery\":\"SELECT Student_ID FROM STUDENT\",\"IsForbidden\":false}\n" +
-		"{\"RawQuery\":\"SELECT * FROM STUDENT\",\"IsForbidden\":false}\n" +
-		"{\"RawQuery\":\"SELECT * FROM X\",\"IsForbidden\":false}\n" +
-		"{\"RawQuery\":\"SELECT * FROM Y\",\"IsForbidden\":false}\n"
+	expected := "{\"RawQuery\":\"SELECT Student_ID FROM STUDENT\",\"_BlockedByWebConfig\":false}\n" +
+		"{\"RawQuery\":\"SELECT * FROM STUDENT\",\"_BlockedByWebConfig\":false}\n" +
+		"{\"RawQuery\":\"SELECT * FROM X\",\"_BlockedByWebConfig\":false}\n" +
+		"{\"RawQuery\":\"SELECT * FROM Y\",\"_BlockedByWebConfig\":false}\n"
 
 	defaultTimeout := handler.GetSerializationTimeout()
 	handler.SetSerializationTimeout(50 * time.Millisecond)
@@ -1190,15 +1258,15 @@ func TestQueryCapture(t *testing.T) {
 		t.Fatal("Expected: " + expected + "\nGot: " + string(result))
 	}
 	testQuery := "SELECT * FROM Z;"
-	_, err = handler.CheckQuery(testQuery)
+	_, err = handler.RedactAndCheckQuery(testQuery)
 	if err != nil {
 		t.Fatal(err)
 	}
-	expected = "{\"RawQuery\":\"SELECT Student_ID FROM STUDENT\",\"IsForbidden\":false}\n" +
-		"{\"RawQuery\":\"SELECT * FROM STUDENT\",\"IsForbidden\":false}\n" +
-		"{\"RawQuery\":\"SELECT * FROM X\",\"IsForbidden\":false}\n" +
-		"{\"RawQuery\":\"SELECT * FROM Y\",\"IsForbidden\":false}\n" +
-		"{\"RawQuery\":\"SELECT * FROM Z\",\"IsForbidden\":false}\n"
+	expected = "{\"RawQuery\":\"SELECT Student_ID FROM STUDENT\",\"_BlockedByWebConfig\":false}\n" +
+		"{\"RawQuery\":\"SELECT * FROM STUDENT\",\"_BlockedByWebConfig\":false}\n" +
+		"{\"RawQuery\":\"SELECT * FROM X\",\"_BlockedByWebConfig\":false}\n" +
+		"{\"RawQuery\":\"SELECT * FROM Y\",\"_BlockedByWebConfig\":false}\n" +
+		"{\"RawQuery\":\"SELECT * FROM Z\",\"_BlockedByWebConfig\":false}\n"
 
 	time.Sleep(handler.GetSerializationTimeout() + extraWaitTime)
 	result, err = ioutil.ReadFile(tmpFile.Name())
@@ -1212,7 +1280,7 @@ func TestQueryCapture(t *testing.T) {
 	//Check that values are hidden while logging
 	testQuery = "select songName from t where personName in ('Ryan', 'Holly') group by songName having count(distinct personName) = 10"
 
-	handler.CheckQuery(testQuery)
+	handler.RedactAndCheckQuery(testQuery)
 
 	//wait until serialization completes
 	time.Sleep(handler.GetSerializationTimeout() + 10*time.Millisecond)
@@ -1222,11 +1290,11 @@ func TestQueryCapture(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expectedPrefix := "{\"RawQuery\":\"SELECT Student_ID FROM STUDENT\",\"IsForbidden\":false}\n" +
-		"{\"RawQuery\":\"SELECT * FROM STUDENT\",\"IsForbidden\":false}\n" +
-		"{\"RawQuery\":\"SELECT * FROM X\",\"IsForbidden\":false}\n" +
-		"{\"RawQuery\":\"SELECT * FROM Y\",\"IsForbidden\":false}\n" +
-		"{\"RawQuery\":\"SELECT * FROM Z\",\"IsForbidden\":false}\n" +
+	expectedPrefix := "{\"RawQuery\":\"SELECT Student_ID FROM STUDENT\",\"_BlockedByWebConfig\":false}\n" +
+		"{\"RawQuery\":\"SELECT * FROM STUDENT\",\"_BlockedByWebConfig\":false}\n" +
+		"{\"RawQuery\":\"SELECT * FROM X\",\"_BlockedByWebConfig\":false}\n" +
+		"{\"RawQuery\":\"SELECT * FROM Y\",\"_BlockedByWebConfig\":false}\n" +
+		"{\"RawQuery\":\"SELECT * FROM Z\",\"_BlockedByWebConfig\":false}\n" +
 		"{\"RawQuery\":\"select songName from t where personName in"
 
 	suffix := strings.TrimPrefix(strings.ToUpper(string(result)), strings.ToUpper(expectedPrefix))

--- a/acra-censor/acra-censor_test.go
+++ b/acra-censor/acra-censor_test.go
@@ -1261,10 +1261,10 @@ func TestQueryCapture(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	expected := "{\"raw_query\":\"SELECT Student_ID FROM STUDENT\",\"_blocked_by_web_config\":false}\n" +
-		"{\"raw_query\":\"SELECT * FROM STUDENT\",\"_blocked_by_web_config\":false}\n" +
-		"{\"raw_query\":\"SELECT * FROM X\",\"_blocked_by_web_config\":false}\n" +
-		"{\"raw_query\":\"SELECT * FROM Y\",\"_blocked_by_web_config\":false}\n"
+	expected := "{\"raw_query\":\"SELECT Student_ID FROM STUDENT\",\"_blacklisted_by_web_config\":false}\n" +
+		"{\"raw_query\":\"SELECT * FROM STUDENT\",\"_blacklisted_by_web_config\":false}\n" +
+		"{\"raw_query\":\"SELECT * FROM X\",\"_blacklisted_by_web_config\":false}\n" +
+		"{\"raw_query\":\"SELECT * FROM Y\",\"_blacklisted_by_web_config\":false}\n"
 
 	defaultTimeout := handler.GetSerializationTimeout()
 	handler.SetSerializationTimeout(50 * time.Millisecond)
@@ -1282,11 +1282,11 @@ func TestQueryCapture(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expected = "{\"raw_query\":\"SELECT Student_ID FROM STUDENT\",\"_blocked_by_web_config\":false}\n" +
-		"{\"raw_query\":\"SELECT * FROM STUDENT\",\"_blocked_by_web_config\":false}\n" +
-		"{\"raw_query\":\"SELECT * FROM X\",\"_blocked_by_web_config\":false}\n" +
-		"{\"raw_query\":\"SELECT * FROM Y\",\"_blocked_by_web_config\":false}\n" +
-		"{\"raw_query\":\"SELECT * FROM Z\",\"_blocked_by_web_config\":false}\n"
+	expected = "{\"raw_query\":\"SELECT Student_ID FROM STUDENT\",\"_blacklisted_by_web_config\":false}\n" +
+		"{\"raw_query\":\"SELECT * FROM STUDENT\",\"_blacklisted_by_web_config\":false}\n" +
+		"{\"raw_query\":\"SELECT * FROM X\",\"_blacklisted_by_web_config\":false}\n" +
+		"{\"raw_query\":\"SELECT * FROM Y\",\"_blacklisted_by_web_config\":false}\n" +
+		"{\"raw_query\":\"SELECT * FROM Z\",\"_blacklisted_by_web_config\":false}\n"
 
 	time.Sleep(handler.GetSerializationTimeout() + extraWaitTime)
 	result, err = ioutil.ReadFile(tmpFile.Name())
@@ -1310,11 +1310,11 @@ func TestQueryCapture(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expectedPrefix := "{\"raw_query\":\"SELECT Student_ID FROM STUDENT\",\"_blocked_by_web_config\":false}\n" +
-		"{\"raw_query\":\"SELECT * FROM STUDENT\",\"_blocked_by_web_config\":false}\n" +
-		"{\"raw_query\":\"SELECT * FROM X\",\"_blocked_by_web_config\":false}\n" +
-		"{\"raw_query\":\"SELECT * FROM Y\",\"_blocked_by_web_config\":false}\n" +
-		"{\"raw_query\":\"SELECT * FROM Z\",\"_blocked_by_web_config\":false}\n" +
+	expectedPrefix := "{\"raw_query\":\"SELECT Student_ID FROM STUDENT\",\"_blacklisted_by_web_config\":false}\n" +
+		"{\"raw_query\":\"SELECT * FROM STUDENT\",\"_blacklisted_by_web_config\":false}\n" +
+		"{\"raw_query\":\"SELECT * FROM X\",\"_blacklisted_by_web_config\":false}\n" +
+		"{\"raw_query\":\"SELECT * FROM Y\",\"_blacklisted_by_web_config\":false}\n" +
+		"{\"raw_query\":\"SELECT * FROM Z\",\"_blacklisted_by_web_config\":false}\n" +
 		"{\"raw_query\":\"select songName from t where personName in"
 
 	suffix := strings.TrimPrefix(strings.ToUpper(string(result)), strings.ToUpper(expectedPrefix))

--- a/acra-censor/acra-censor_test.go
+++ b/acra-censor/acra-censor_test.go
@@ -662,6 +662,7 @@ func testBlacklistSelectPattern(t *testing.T) {
 		"INSERT INTO T1 (Name, UnitMeasureCode,	ModifiedDate) VALUES ('Square Yards', 'Y2', GETDATE());",
 		"INSERT INTO dbo.Points (Type, PointValue) VALUES ('Point', '1,5');",
 		"INSERT INTO dbo.Points (PointValue) VALUES ('1,99');",
+		"DROP TABLE table_name",
 	}
 	blacklistPattern := "%%SELECT%%"
 	err = blacklist.AddPatterns([]string{blacklistPattern})

--- a/acra-censor/handlers/blacklist_handler.go
+++ b/acra-censor/handlers/blacklist_handler.go
@@ -188,17 +188,25 @@ func (handler *BlacklistHandler) Release() {
 	handler.Reset()
 }
 
-// AddQueries adds queries to the list that should be blacklisted
+// AddQueries normalizes and adds queries to the list that should be blacklisted
 func (handler *BlacklistHandler) AddQueries(queries []string) {
 	for _, query := range queries {
-		handler.queries[query] = true
+		normalizedQuery, _, err := NormalizeAndRedactSQLQuery(query)
+		if err != nil {
+			continue
+		}
+		handler.queries[normalizedQuery] = true
 	}
 }
 
 // RemoveQueries removes queries from the list that should be blacklisted
 func (handler *BlacklistHandler) RemoveQueries(queries []string) {
 	for _, query := range queries {
-		delete(handler.queries, query)
+		normalizedQuery, _, err := NormalizeAndRedactSQLQuery(query)
+		if err != nil {
+			continue
+		}
+		delete(handler.queries, normalizedQuery)
 	}
 }
 

--- a/acra-censor/handlers/handlers_util.go
+++ b/acra-censor/handlers/handlers_util.go
@@ -61,7 +61,7 @@ func TrimStringToN(query string, n int) string {
 // Taken from sqlparser package
 func NormalizeAndRedactSQLQuery(sql string) (normalizedQuery string, redactedQuery string, error error) {
 	bv := map[string]*querypb.BindVariable{}
-	sqlStripped, comments := sqlparser.SplitMarginComments(sql)
+	sqlStripped, _ := sqlparser.SplitMarginComments(sql)
 
 	// sometimes queries might have ; at the end, that should be stripped
 	sqlStripped = strings.TrimSuffix(sqlStripped, ";")
@@ -71,11 +71,11 @@ func NormalizeAndRedactSQLQuery(sql string) (normalizedQuery string, redactedQue
 		return "", "", err
 	}
 
-	normalizedQ := comments.Leading + sqlparser.String(stmt) + comments.Trailing
+	normalizedQ := sqlparser.String(stmt)
 
 	// redact and mask VALUES
 	sqlparser.Normalize(stmt, bv, ValuePlaceholder)
-	redactedQ := comments.Leading + sqlparser.String(stmt) + comments.Trailing
+	redactedQ := sqlparser.String(stmt)
 
 	return normalizedQ, redactedQ, nil
 }

--- a/acra-censor/handlers/handlers_util.go
+++ b/acra-censor/handlers/handlers_util.go
@@ -56,17 +56,28 @@ func TrimStringToN(query string, n int) string {
 	return query[:n]
 }
 
-// RedactSQLQuery returns a sql string with the params stripped out for display. Taken from sqlparser package
-func RedactSQLQuery(sql string) (string, error) {
+// NormalizeAndRedactSQLQuery returns a normalized (lowercases SQL commands) SQL string,
+// and redacted SQL string with the params stripped out for display.
+// Taken from sqlparser package
+func NormalizeAndRedactSQLQuery(sql string) (normalizedQuery string, redactedQuery string, error error) {
 	bv := map[string]*querypb.BindVariable{}
 	sqlStripped, comments := sqlparser.SplitMarginComments(sql)
 
+	// sometimes queries might have ; at the end, that should be stripped
+	sqlStripped = strings.TrimSuffix(sqlStripped, ";")
+
 	stmt, err := sqlparser.Parse(sqlStripped)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
+
+	normalizedQ := comments.Leading + sqlparser.String(stmt) + comments.Trailing
+
+	// redact and mask VALUES
 	sqlparser.Normalize(stmt, bv, ValuePlaceholder)
-	return comments.Leading + sqlparser.String(stmt) + comments.Trailing, nil
+	redactedQ := comments.Leading + sqlparser.String(stmt) + comments.Trailing
+
+	return normalizedQ, redactedQ, nil
 }
 
 func checkPatternsMatching(patterns [][]sqlparser.SQLNode, query string) (bool, error) {

--- a/acra-censor/handlers/querycapture_handler.go
+++ b/acra-censor/handlers/querycapture_handler.go
@@ -31,8 +31,8 @@ type QueryCaptureHandler struct {
 
 // QueryInfo describes Query and if it was blocked by external source.
 type QueryInfo struct {
-	RawQuery    string `json:"RawQuery"`
-	IsForbidden bool   `json:"_BlockedByWebConfig"`
+	RawQuery    string `json:"raw_query"`
+	IsForbidden bool   `json:"_blocked_by_web_config"`
 }
 
 // NewQueryCaptureHandler creates new QueryCaptureHandler, connected to QueryCaptureLog file at filePath.

--- a/acra-censor/handlers/querycapture_handler.go
+++ b/acra-censor/handlers/querycapture_handler.go
@@ -32,7 +32,7 @@ type QueryCaptureHandler struct {
 // QueryInfo describes Query and if it was blocked by external source.
 type QueryInfo struct {
 	RawQuery    string `json:"raw_query"`
-	IsForbidden bool   `json:"_blocked_by_web_config"`
+	IsForbidden bool   `json:"_blacklisted_by_web_config"`
 }
 
 // NewQueryCaptureHandler creates new QueryCaptureHandler, connected to QueryCaptureLog file at filePath.

--- a/acra-censor/handlers/querycapture_handler.go
+++ b/acra-censor/handlers/querycapture_handler.go
@@ -29,10 +29,10 @@ type QueryCaptureHandler struct {
 	logger               *log.Entry
 }
 
-// QueryInfo describes Query and its status (was forbidden or allowed).
+// QueryInfo describes Query and if it was blocked by external source.
 type QueryInfo struct {
-	RawQuery    string
-	IsForbidden bool
+	RawQuery    string `json:"RawQuery"`
+	IsForbidden bool   `json:"_BlockedByWebConfig"`
 }
 
 // NewQueryCaptureHandler creates new QueryCaptureHandler, connected to QueryCaptureLog file at filePath.
@@ -230,11 +230,7 @@ func (handler *QueryCaptureHandler) SerializeQueries(queries []*QueryInfo) []byt
 	var linesToAppend []byte
 	var tempQueryInfo = &QueryInfo{}
 	for _, queryInfo := range queries {
-		queryWithHiddenValues, err := RedactSQLQuery(queryInfo.RawQuery)
-		if err != nil {
-			handler.logger.WithError(ErrQuerySyntaxError).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCensorQuerySerializeError).Errorln("Can't serialize stored queries")
-		}
-		tempQueryInfo.RawQuery = queryWithHiddenValues
+		tempQueryInfo.RawQuery = queryInfo.RawQuery
 		tempQueryInfo.IsForbidden = queryInfo.IsForbidden
 		jsonQueryInfo, err := json.Marshal(tempQueryInfo)
 		if err != nil {

--- a/acra-censor/handlers/queryignore_handler.go
+++ b/acra-censor/handlers/queryignore_handler.go
@@ -31,16 +31,24 @@ func (handler *QueryIgnoreHandler) Release() {
 	handler.Reset()
 }
 
-// AddQueries adds queries to the list that should be ignored
+// AddQueries normalizes and adds queries to the list that should be ignored
 func (handler *QueryIgnoreHandler) AddQueries(queries []string) {
 	for _, query := range queries {
-		handler.ignoredQueries[query] = true
+		normalizedQuery, _, err := NormalizeAndRedactSQLQuery(query)
+		if err != nil {
+			continue
+		}
+		handler.ignoredQueries[normalizedQuery] = true
 	}
 }
 
 // RemoveQueries removes queries from the list that should be whitelisted
 func (handler *QueryIgnoreHandler) RemoveQueries(queries []string) {
 	for _, query := range queries {
-		delete(handler.ignoredQueries, query)
+		normalizedQuery, _, err := NormalizeAndRedactSQLQuery(query)
+		if err != nil {
+			continue
+		}
+		delete(handler.ignoredQueries, normalizedQuery)
 	}
 }

--- a/acra-censor/handlers/whitelist_handler.go
+++ b/acra-censor/handlers/whitelist_handler.go
@@ -216,17 +216,25 @@ func (handler *WhitelistHandler) Release() {
 	handler.Reset()
 }
 
-// AddQueries adds queries to the list that should be whitelisted
+// AddQueries normalizes and adds queries to the list that should be whitelisted
 func (handler *WhitelistHandler) AddQueries(queries []string) {
 	for _, query := range queries {
-		handler.queries[query] = true
+		normalizedQuery, _, err := NormalizeAndRedactSQLQuery(query)
+		if err != nil {
+			continue
+		}
+		handler.queries[normalizedQuery] = true
 	}
 }
 
 // RemoveQueries removes queries from the list that should be whitelisted
 func (handler *WhitelistHandler) RemoveQueries(queries []string) {
 	for _, query := range queries {
-		delete(handler.queries, query)
+		normalizedQuery, _, err := NormalizeAndRedactSQLQuery(query)
+		if err != nil {
+			continue
+		}
+		delete(handler.queries, normalizedQuery)
 	}
 }
 

--- a/cmd/acra-server/listener.go
+++ b/cmd/acra-server/listener.go
@@ -44,6 +44,7 @@ type SServer struct {
 	listeners             []net.Listener
 	errorSignalChannel    chan os.Signal
 	restartSignalsChannel chan os.Signal
+	connectionsToClose    map[net.Conn]struct{}
 }
 
 // NewServer creates new SServer.
@@ -55,6 +56,7 @@ func NewServer(config *Config, keystorage keystore.KeyStore, errorChan chan os.S
 		cmAPI:                 network.NewConnectionManager(),
 		errorSignalChannel:    errorChan,
 		restartSignalsChannel: restarChan,
+		connectionsToClose:    make(map[net.Conn]struct{}),
 	}, nil
 }
 
@@ -91,6 +93,10 @@ func (server *SServer) Close() {
 	}
 	if err != nil {
 		log.WithError(err).Infoln("server.Close()")
+	}
+	for conn, _ := range server.connectionsToClose {
+		// don't check errors because here can be already closed connections and we don't need handle it
+		conn.Close()
 	}
 	log.Debugln("Closed server listeners")
 }
@@ -138,6 +144,8 @@ handle new connection by initializing secure session, starting proxy request
 to db and decrypting responses from db
 */
 func (server *SServer) handleConnection(connection net.Conn) {
+	server.cmACRA.Incr()
+	defer server.cmACRA.Done()
 	log.Infof("Handle new connection")
 	wrappedConnection, clientID, err := server.config.ConnectionWrapper.WrapServer(connection)
 	if err != nil {
@@ -165,58 +173,62 @@ func (server *SServer) handleConnection(connection net.Conn) {
 	clientSession.HandleClientConnection(clientID, decryptor)
 }
 
+func (server *SServer) start(listener net.Listener, connectionHandler func(net.Conn), logger *log.Entry) {
+	logger.Infof("Start listening connections")
+	for {
+		connection, err := listener.Accept()
+		if err != nil {
+			if nerr, ok := err.(net.Error); ok && nerr.Timeout() {
+				logger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorConnectionDroppedByTimeout).
+					Errorln("Stop accepting new connections due net.Timeout")
+				return
+			}
+			logger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantAcceptNewConnections).
+				Errorln("Can't accept new connection")
+			continue
+		}
+		// unix socket and value == '@'
+		if len(connection.RemoteAddr().String()) == 1 {
+			logger.Infof("Got new connection to AcraServer: %v", connection.LocalAddr())
+		} else {
+			logger.Infof("Got new connection to AcraServer: %v", connection.RemoteAddr())
+		}
+		go func() {
+			server.connectionsToClose[connection] = struct{}{}
+			connectionHandler(connection)
+			delete(server.connectionsToClose, connection)
+		}()
+	}
+}
+
 // Start listening connections from proxy
 func (server *SServer) Start() {
-	var connection net.Conn
+	logger := log.WithFields(log.Fields{"connection_string": server.config.GetAcraConnectionString(), "from_descriptor": false})
+	logger.Infoln("Create listener")
 	var listener, err = network.Listen(server.config.GetAcraConnectionString())
 	if err != nil {
-		log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantStartListenConnections).
+		logger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantStartListenConnections).
 			Errorln("Can't start listen connections")
 		server.errorSignalChannel <- syscall.SIGTERM
 		return
 	}
 	server.listenerACRA = listener
 	server.addListener(listener)
-
-	log.Infof("Start listening connection: %s", server.config.GetAcraConnectionString())
-	for {
-		connection, err = listener.Accept()
-		if err != nil {
-			if nerr, ok := err.(net.Error); ok && nerr.Timeout() {
-				log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorConnectionDroppedByTimeout).
-					Errorln("Stop accepting new connections due net.Timeout")
-				return
-			}
-			log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantAcceptNewConnections).
-				Errorf("Can't accept new connection (connection=%v)", connection)
-			continue
-		}
-		// unix socket and value == '@'
-		if len(connection.RemoteAddr().String()) == 1 {
-			log.Infof("Got new connection to AcraServer: %v", connection.LocalAddr())
-		} else {
-			log.Infof("Got new connection to AcraServer: %v", connection.RemoteAddr())
-		}
-		go func() {
-			server.cmACRA.Incr()
-			server.handleConnection(connection)
-			server.cmACRA.Done()
-		}()
-
-	}
+	server.start(listener, server.handleConnection, logger)
 }
 
 // StartFromFileDescriptor starts listening Acra data connections from file descriptor.
 func (server *SServer) StartFromFileDescriptor(fd uintptr) {
+	logger := log.WithFields(log.Fields{"connection_string": server.config.GetAcraConnectionString(), "from_descriptor": true})
 	file := os.NewFile(fd, "/tmp/acra-server")
 	if file == nil {
-		log.Errorln("Can't create new file from descriptor for acra listener")
+		logger.Errorln("Can't create new file from descriptor for acra listener")
 		server.errorSignalChannel <- syscall.SIGTERM
 		return
 	}
 	listenerFile, err := net.FileListener(file)
 	if err != nil {
-		log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantOpenFileByDescriptor).
+		logger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantOpenFileByDescriptor).
 			Errorln("System error: can't start listen for file descriptor")
 		server.errorSignalChannel <- syscall.SIGTERM
 		return
@@ -224,38 +236,13 @@ func (server *SServer) StartFromFileDescriptor(fd uintptr) {
 
 	listenerWithFileDescriptor, ok := listenerFile.(network.ListenerWithFileDescriptor)
 	if !ok {
-		log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorFileDescriptionIsNotValid).
+		logger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorFileDescriptionIsNotValid).
 			Errorf("System error: file descriptor %d is not a valid socket", fd)
 		return
 	}
 	server.listenerACRA = listenerWithFileDescriptor
-	server.addListener(listenerFile)
-
-	log.Infof("Start listening connection: %s", server.config.GetAcraConnectionString())
-	for {
-		connection, err := listenerWithFileDescriptor.Accept()
-		if err != nil {
-			if nerr, ok := err.(net.Error); ok && nerr.Timeout() {
-				log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorConnectionDroppedByTimeout).
-					Errorf("Stop accepting new connections")
-				return
-			}
-			log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantAcceptNewConnections).
-				Errorf("Can't accept new connection")
-			continue
-		}
-		// unix socket and value == '@'
-		if len(connection.RemoteAddr().String()) == 1 {
-			log.Infof("Got new connection to AcraServer: %v", connection.LocalAddr())
-		} else {
-			log.Infof("Got new connection to AcraServer: %v", connection.RemoteAddr())
-		}
-		go func() {
-			server.cmACRA.Incr()
-			server.handleConnection(connection)
-			server.cmACRA.Done()
-		}()
-	}
+	server.addListener(listenerWithFileDescriptor)
+	server.start(listenerWithFileDescriptor, server.handleConnection, logger)
 }
 
 // stopAcceptConnections stop accepting by setting deadline and then background code that call Accept will took error and
@@ -333,6 +320,8 @@ handle new connection by initializing secure session, starting proxy request
 to db and decrypting responses from db
 */
 func (server *SServer) handleCommandsConnection(connection net.Conn) {
+	server.cmAPI.Incr()
+	defer server.cmAPI.Done()
 	log.Infof("Handle commands connection")
 	clientSession, err := NewClientCommandsSession(server.keystorage, server.config, connection)
 	clientSession.Server = server
@@ -354,92 +343,42 @@ func (server *SServer) handleCommandsConnection(connection net.Conn) {
 
 // StartCommands starts listening commands connections from proxy.
 func (server *SServer) StartCommands() {
-	var connection net.Conn
+	logger := log.WithFields(log.Fields{"connection_string": server.config.GetAcraAPIConnectionString(), "from_descriptor": false})
 	var listener, err = network.Listen(server.config.GetAcraAPIConnectionString())
 	if err != nil {
-		log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantStartListenConnections).
+		logger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantStartListenConnections).
 			Errorln("Can't start listen command API connections")
 		server.errorSignalChannel <- syscall.SIGTERM
 		return
 	}
 	server.listenerAPI = listener
 	server.addListener(listener)
-
-	log.Infof("Start listening API: %s", server.config.GetAcraAPIConnectionString())
-	for {
-		connection, err = listener.Accept()
-		if err != nil {
-			if nerr, ok := err.(net.Error); ok && nerr.Timeout() {
-				log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantAcceptNewConnections).
-					Errorln("Stop accepting new connections", connection)
-				return
-			}
-			log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantAcceptNewConnections).
-				Errorf("Can't accept new connection (connection=%v)", connection)
-			continue
-		}
-		// unix socket and value == '@'
-		if len(connection.RemoteAddr().String()) == 1 {
-			log.Infof("Got new connection to http API: %v", connection.LocalAddr())
-		} else {
-			log.Infof("Got new connection to http API: %v", connection.RemoteAddr())
-		}
-		go func() {
-			server.cmAPI.Incr()
-			server.handleCommandsConnection(connection)
-			server.cmAPI.Done()
-		}()
-	}
+	server.start(listener, server.handleCommandsConnection, logger)
 }
 
 // StartCommandsFromFileDescriptor starts listening commands connections from file descriptor.
 func (server *SServer) StartCommandsFromFileDescriptor(fd uintptr) {
-	var connection net.Conn
+	logger := log.WithFields(log.Fields{"connection_string": server.config.GetAcraConnectionString(), "from_descriptor": true})
 	file := os.NewFile(fd, "/tmp/acra-server_http_api")
 	if file == nil {
-		log.Errorln("Can't create new file from descriptor for api listener")
+		logger.Errorln("Can't create new file from descriptor for API listener")
 		server.errorSignalChannel <- syscall.SIGTERM
 		return
 	}
 	listenerFile, err := net.FileListener(file)
 	if err != nil {
-		log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantOpenFileByDescriptor).
+		logger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantOpenFileByDescriptor).
 			Errorln("System error: can't start listen for file descriptor")
 		server.errorSignalChannel <- syscall.SIGTERM
 		return
 	}
 	listenerWithFileDescriptor, ok := listenerFile.(network.ListenerWithFileDescriptor)
 	if !ok {
-		log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorFileDescriptionIsNotValid).
+		logger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorFileDescriptionIsNotValid).
 			Errorf("System error: file descriptor %d is not a valid socket", fd)
 		return
 	}
 	server.listenerAPI = listenerWithFileDescriptor
 	server.addListener(listenerWithFileDescriptor)
-
-	log.Infof("Start listening API from file descriptor: %s", server.config.GetAcraAPIConnectionString())
-	for {
-		connection, err = listenerWithFileDescriptor.Accept()
-		if err != nil {
-			if nerr, ok := err.(net.Error); ok && nerr.Timeout() {
-				log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorConnectionDroppedByTimeout).
-					Errorln("Stop accepting new connections", connection)
-				return
-			}
-			log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantAcceptNewConnections).
-				Errorf("System error: can't accept new connection (connection=%v)", connection)
-			continue
-		}
-		// unix socket and value == '@'
-		if len(connection.RemoteAddr().String()) == 1 {
-			log.Infof("Got new connection to http API: %v", connection.LocalAddr())
-		} else {
-			log.Infof("Got new connection to http API: %v", connection.RemoteAddr())
-		}
-		go func() {
-			server.cmAPI.Incr()
-			server.handleCommandsConnection(connection)
-			server.cmAPI.Done()
-		}()
-	}
+	server.start(listenerWithFileDescriptor, server.handleCommandsConnection, logger)
 }

--- a/decryptor/mysql/response_proxy.go
+++ b/decryptor/mysql/response_proxy.go
@@ -267,7 +267,7 @@ func (handler *MysqlHandler) ClientToDbConnector(errCh chan<- error) {
 			return
 		case COM_QUERY, COM_STMT_EXECUTE:
 			query := string(data)
-			queryWithHiddenValues, _, err := handlers.NormalizeAndRedactSQLQuery(query)
+			_, queryWithHiddenValues, err := handlers.NormalizeAndRedactSQLQuery(query)
 			if err == handlers.ErrQuerySyntaxError {
 				clientLog.WithError(err).Infof("Parsing error on query (first %v symbols): %s", handlers.LogQueryLength, handlers.TrimStringToN(queryWithHiddenValues, handlers.LogQueryLength))
 			}

--- a/decryptor/mysql/response_proxy.go
+++ b/decryptor/mysql/response_proxy.go
@@ -267,7 +267,7 @@ func (handler *MysqlHandler) ClientToDbConnector(errCh chan<- error) {
 			return
 		case COM_QUERY, COM_STMT_EXECUTE:
 			query := string(data)
-			queryWithHiddenValues, err := handlers.RedactSQLQuery(query)
+			queryWithHiddenValues, _, err := handlers.NormalizeAndRedactSQLQuery(query)
 			if err == handlers.ErrQuerySyntaxError {
 				clientLog.WithError(err).Infof("Parsing error on query (first %v symbols): %s", handlers.LogQueryLength, handlers.TrimStringToN(queryWithHiddenValues, handlers.LogQueryLength))
 			}

--- a/decryptor/postgresql/pg_decryptor.go
+++ b/decryptor/postgresql/pg_decryptor.go
@@ -343,7 +343,7 @@ func (proxy *PgProxy) PgProxyClientRequests(acraCensor acracensor.Interface, dbC
 			continue
 		}
 		query := string(row.descriptionBuf.Bytes()[:row.dataLength-1])
-		queryWithHiddenValues, err := handlers.RedactSQLQuery(query)
+		queryWithHiddenValues, _, err := handlers.NormalizeAndRedactSQLQuery(query)
 		if err == handlers.ErrQuerySyntaxError {
 			log.WithError(err).Infof("Parsing error on query (first %v symbols): %s", handlers.LogQueryLength, handlers.TrimStringToN(queryWithHiddenValues, handlers.LogQueryLength))
 		}

--- a/decryptor/postgresql/pg_decryptor.go
+++ b/decryptor/postgresql/pg_decryptor.go
@@ -343,7 +343,7 @@ func (proxy *PgProxy) PgProxyClientRequests(acraCensor acracensor.Interface, dbC
 			continue
 		}
 		query := string(row.descriptionBuf.Bytes()[:row.dataLength-1])
-		queryWithHiddenValues, _, err := handlers.NormalizeAndRedactSQLQuery(query)
+		_, queryWithHiddenValues, err := handlers.NormalizeAndRedactSQLQuery(query)
 		if err == handlers.ErrQuerySyntaxError {
 			log.WithError(err).Infof("Parsing error on query (first %v symbols): %s", handlers.LogQueryLength, handlers.TrimStringToN(queryWithHiddenValues, handlers.LogQueryLength))
 		}

--- a/tests/acra-censor_configs/acra-censor_blacklist.yaml
+++ b/tests/acra-censor_configs/acra-censor_blacklist.yaml
@@ -4,17 +4,28 @@ handlers:
     queries:
       #mysql
       - ROLLBACK
-      - SET AUTOCOMMIT = 0
       - SHOW VARIABLES LIKE 'sql_mode'
+      - SELECT VERSION()
+      - SELECT DATABASE()
+      - SELECT @@transaction_isolation
       - show collation where `Charset` = 'utf8' and `Collation` = 'utf8_bin'
+      - SELECT CAST('test plain returns' AS CHAR(60)) AS anon_1
+      - SELECT CAST('test unicode returns' AS CHAR(60)) AS anon_1
+      - SELECT CAST('test collated returns' AS CHAR CHARACTER SET utf8) COLLATE utf8_bin AS anon_1
+      - SELECT CAST('test collated returns' AS CHAR CHARACTER SET utf8mb4) COLLATE utf8mb4_bin AS anon_1
+      - select 1
+      - SET AUTOCOMMIT = 0
       #postgres
       - BEGIN
+      - "SELECT t.oid, typarray\nFROM pg_type t JOIN pg_namespace ns\n    ON typnamespace = ns.oid\nWHERE typname = 'hstore';\n"
       - "UPDATE pg_settings SET setting = 'hex' WHERE name = 'bytea_output'"
       - COMMIT
+      - select version()
+      - select current_schema()
       - show transaction isolation level
-      - "SELECT CAST('test plain returns' AS VARCHAR(60)) AS anon_1"
-      - "SELECT CAST('test unicode returns' AS VARCHAR(60)) AS anon_1"
       - show standard_conforming_strings
+      - SELECT CAST('test plain returns' AS VARCHAR(60)) AS anon_1
+      - SELECT CAST('test unicode returns' AS VARCHAR(60)) AS anon_1
 
   - handler: blacklist
     queries:

--- a/tests/acra-censor_configs/acra-censor_blacklist.yaml
+++ b/tests/acra-censor_configs/acra-censor_blacklist.yaml
@@ -18,6 +18,7 @@ handlers:
       #postgres
       - BEGIN
       - "SELECT t.oid, typarray\nFROM pg_type t JOIN pg_namespace ns\n    ON typnamespace = ns.oid\nWHERE typname = 'hstore';\n"
+      - ROLLBACK
       - "UPDATE pg_settings SET setting = 'hex' WHERE name = 'bytea_output'"
       - COMMIT
       - select version()

--- a/tests/acra-censor_configs/acra-censor_whitelist.yaml
+++ b/tests/acra-censor_configs/acra-censor_whitelist.yaml
@@ -12,8 +12,8 @@ handlers:
       - SELECT CAST('test plain returns' AS CHAR(60)) AS anon_1
       - SELECT CAST('test unicode returns' AS CHAR(60)) AS anon_1
       - SELECT CAST('test collated returns' AS CHAR CHARACTER SET utf8) COLLATE utf8_bin AS anon_1
+      - SELECT CAST('test collated returns' AS CHAR CHARACTER SET utf8mb4) COLLATE utf8mb4_bin AS anon_1
       - select 1
-      - select 1;
       - SET AUTOCOMMIT = 0
       #postgres
       - BEGIN

--- a/tests/acra-censor_configs/acra-censor_whitelist.yaml
+++ b/tests/acra-censor_configs/acra-censor_whitelist.yaml
@@ -18,6 +18,7 @@ handlers:
       #postgres
       - BEGIN
       - "SELECT t.oid, typarray\nFROM pg_type t JOIN pg_namespace ns\n    ON typnamespace = ns.oid\nWHERE typname = 'hstore';\n"
+      - ROLLBACK
       - "UPDATE pg_settings SET setting = 'hex' WHERE name = 'bytea_output'"
       - COMMIT
       - select version()

--- a/tests/test.py
+++ b/tests/test.py
@@ -1524,7 +1524,8 @@ class AcraCatchLogsMixin(object):
         with open(self.log_files[process].name, 'r', errors='replace',
                   encoding='utf-8') as f:
             log = f.read()
-            print(log.encode(encoding='utf-8', errors='replace'))
+            #print(log.encode(encoding='utf-8', errors='replace'))
+            print(log)
             return log
 
     def fork_acra(self, popen_kwargs: dict=None, **acra_kwargs: dict):

--- a/tests/test.py
+++ b/tests/test.py
@@ -1524,7 +1524,7 @@ class AcraCatchLogsMixin(object):
         with open(self.log_files[process].name, 'r', errors='replace',
                   encoding='utf-8') as f:
             log = f.read()
-            print(log)
+            print(log.encode(encoding='utf-8', errors='replace'))
             return log
 
     def fork_acra(self, popen_kwargs: dict=None, **acra_kwargs: dict):

--- a/tests/test.py
+++ b/tests/test.py
@@ -825,7 +825,7 @@ class CensorBlacklistTest(BaseCensorTest):
 
         #test block by query
         with self.assertRaises(expectedException):
-                result = self.engine1.execute(sa.text("select data from test where id='1'"))
+            result = self.engine1.execute(sa.text("select data from test where id='1'"))
         #test block by table
         with self.assertRaises(expectedException):
             result = self.engine1.execute(sa.text("select data_raw from test"))


### PR DESCRIPTION
1. **QueryCaptureHandler** was storing in the `query_capture` log file redacted queries (which is good), but was comparing non-redacted queries during `CheckQuery` (which is bad and leads to duplication of the same redacted queries in the `query_capture` log file). 

**Fixed:** now QueryCaptureHandler uses redacted queries for checking and writing/reading from `query_capture` log file.

2. **QueryCaptureHandler** used `IsForbidden` as keyword for queries-that-should-be-blocked-some-day-via-WebConfig, which lead to users confusion (because `IsForbidden` doesn't indicate state of query after passing the AcraCensor).


Numerous tests were updated to handle multiple cases and redacted queries.renamed to `_blacklisted_by_web_config ` which indicates that this is private field and points on its future use.

Numerous tests were updated to redacted queries and new param name.

3. ⚠️**Whitelist handler, blacklist handler and query ignore handler have case-sensitive strings checks**, which leads to numerous configuration mistakes.

F.e. blacklisting query `SELECT * FROM Z` will result in allowing its lower-case version `select * from Z`.

Moreover, the semicolon at the end of the query matters.

F.e. blacklisting query `SELECT * FROM Z;` _(semicolon)_ will result in allowing its lower-case version `SELECT * FROM Z` _(no semicolon)_.

Because SQL queries contains values and table/column names that can be case-sensitive, we can't just "lowercase/uppercase" entire SQL statement. 

**Fixed**: I decided to use "normalizedQuery" as query-to-operate-with for `CheckQuery`/`AddQuery`/`RemoveQuery` functions of W, B, I handlers. I stripped comments while normalizing

Numerous tests were updated to handle different query cases.