### PR TITLE
Zeroing private keys in acrawriters

### DIFF
--- a/acra-writer/acra-writer.go
+++ b/acra-writer/acra-writer.go
@@ -55,6 +55,8 @@ func CreateAcrastruct(data []byte, acraPublic *keys.PublicKey, context []byte) (
 	if err != nil {
 		return nil, err
 	}
+	utils.FillSlice('0', randomKeyPair.Private.Value)
+
 	// create scell for encrypting data
 	scell := cell.New(randomKey, cell.CELL_MODE_SEAL)
 	encryptedData, _, err := scell.Protect(data, context)
@@ -62,6 +64,7 @@ func CreateAcrastruct(data []byte, acraPublic *keys.PublicKey, context []byte) (
 		return nil, err
 	}
 	utils.FillSlice('0', randomKey)
+
 	// pack acrastruct
 	dateLength := make([]byte, base.DataLengthSize)
 	binary.LittleEndian.PutUint64(dateLength, uint64(len(encryptedData)))

--- a/wrappers/nodejs/acrawriter.js
+++ b/wrappers/nodejs/acrawriter.js
@@ -14,6 +14,7 @@
 
 var themis = require('jsthemis');
 var int64 = require('int64-buffer').Uint64LE
+var crypto = require('crypto');
 
 
 module.exports = {
@@ -23,9 +24,10 @@ module.exports = {
 	var context_buffer = Buffer.isBuffer(context)?context:(new Buffer(context));
 	var random_keypair = new themis.KeyPair();
 	var sm = new themis.SecureMessage(random_keypair.private(), acra_public_key);
-	var random_key = require('crypto').randomBytes(32);
+	var random_key = crypto.randomBytes(32);
 	var wrapped_random_key = sm.encrypt(random_key);
 	var sc = new themis.SecureCellSeal(random_key);
+	crypto.randomFillSync(random_key);
 	var encrypted_data = context?sc.encrypt(data_buffer, context_buffer):sc.encrypt(data_buffer);
 	var begin_tag = new Buffer([34,34,34,34,34,34,34,34]);
 	var encrypted_data_length = new int64(encrypted_data.length).toBuffer();

--- a/wrappers/objc/AcraWriter/AcraWriter.m
+++ b/wrappers/objc/AcraWriter/AcraWriter.m
@@ -71,6 +71,9 @@ static NSUInteger kAcraStructHeaderByte = 34;
     return nil;
   }
   
+  // zeroing private key
+  [keygenEC.privateKey resetBytesInRange:NSMakeRange(0, [keygenEC.privateKey length])];
+  
   // 4. encrypt payload using symmetric encryption and random symm key
   TSCellSeal * symmetricEncrypter = [[TSCellSeal alloc] initWithKey:symmetricKey];
   NSData * encryptedMessage = [symmetricEncrypter wrapData:message context:zoneID error:error];

--- a/wrappers/ruby/acrawriter/lib/acrawriter.rb
+++ b/wrappers/ruby/acrawriter/lib/acrawriter.rb
@@ -24,9 +24,11 @@ def create_acrastruct(data, acra_public_key, context=nil)
   generator = Themis::SKeyPairGen.new
   private, public = generator.ec
   smessage = Themis::Smessage.new(private.to_s, acra_public_key.to_s)
+  private.clear
   random_key = Random.new.bytes(SYMMETRIC_KEY_LENGTH)
   wrapped_random_key = smessage.wrap(random_key.to_s)
   scell = Themis::Scell.new(random_key.to_s, Themis::Scell::SEAL_MODE)
+  random_key.clear
   encrypted_data = scell.encrypt(data, context)
   data_length = Array(encrypted_data.length).pack('Q<')
   BEGIN_TAG + public + wrapped_random_key + data_length + encrypted_data


### PR DESCRIPTION
According to @secumod comments, I've added zeroing of symmetric key and keypair private key to most of acra-writer wrappers (excluding php).

I've run acra-writer tests manually to make sure the syntax is correct and tests are succeed.