### PR TITLE
Remove repetitive and redundant logs

### DIFF
--- a/acra-censor/acra-censor_implementation.go
+++ b/acra-censor/acra-censor_implementation.go
@@ -65,6 +65,7 @@ func (acraCensor *AcraCensor) ReleaseAll() {
 // HandleQuery processes every query through each handler.
 func (acraCensor *AcraCensor) HandleQuery(query string) error {
 	if len(acraCensor.handlers) == 0 {
+		// no handlers, AcraCensor won't work
 		return nil
 	}
 	normalizedQuery, queryWithHiddenValues, err := handlers.NormalizeAndRedactSQLQuery(query)
@@ -79,8 +80,8 @@ func (acraCensor *AcraCensor) HandleQuery(query string) error {
 		}
 		continueHandling, err := handler.CheckQuery(normalizedQuery)
 		if err != nil {
+			// continue to next handler
 			if err == handlers.ErrQuerySyntaxError && acraCensor.ignoreParseError {
-				acraCensor.logger.WithError(err).Infof("Parsing error on query (first %v symbols): %s", handlers.LogQueryLength, handlers.TrimStringToN(queryWithHiddenValues, handlers.LogQueryLength))
 				continue
 			}
 			acraCensor.logger.Errorf("Forbidden query: '%s'", queryWithHiddenValues)

--- a/decryptor/mysql/response_proxy.go
+++ b/decryptor/mysql/response_proxy.go
@@ -281,10 +281,17 @@ func (handler *MysqlHandler) ClientToDbConnector(errCh chan<- error) {
 			return
 		case COM_QUERY, COM_STMT_EXECUTE:
 			query := string(data)
-			_, queryWithHiddenValues, err := handlers.NormalizeAndRedactSQLQuery(query)
-			if err == handlers.ErrQuerySyntaxError {
-				clientLog.WithError(err).Infof("Parsing error on query (first %v symbols): %s", handlers.LogQueryLength, handlers.TrimStringToN(queryWithHiddenValues, handlers.LogQueryLength))
+
+			// log query with hidden values for debug mode
+			if logging.GetLogLevel() == logging.LOG_DEBUG {
+				_, queryWithHiddenValues, err := handlers.NormalizeAndRedactSQLQuery(query)
+				if err == handlers.ErrQuerySyntaxError {
+					clientLog.WithError(err).Infof("Parsing error on query: %s", queryWithHiddenValues)
+				} else {
+					clientLog.WithField("sql", queryWithHiddenValues).Debugln("Com_query")
+				}
 			}
+
 			if err := handler.acracensor.HandleQuery(query); err != nil {
 				clientLog.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCensorQueryIsNotAllowed).Errorln("Error on AcraCensor check")
 				errPacket := NewQueryInterruptedError(handler.clientProtocol41)
@@ -295,7 +302,6 @@ func (handler *MysqlHandler) ClientToDbConnector(errCh chan<- error) {
 				}
 				continue
 			}
-			clientLog.WithField("sql", queryWithHiddenValues).Debugln("Com_query")
 			handler.setQueryHandler(handler.QueryResponseHandler)
 			break
 		case COM_STMT_PREPARE, COM_STMT_CLOSE, COM_STMT_SEND_LONG_DATA, COM_STMT_RESET:

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -51,6 +51,17 @@ func SetLogLevel(level int) {
 	}
 }
 
+// GetLogLevel gets logrus log level and returns int Acra log level
+func GetLogLevel() int {
+	if log.GetLevel() == log.DebugLevel {
+		return LOG_DEBUG
+	}
+	if log.GetLevel() == log.InfoLevel {
+		return LOG_VERBOSE
+	}
+	return LOG_DISCARD
+}
+
 // CustomizeLogging changes logging format
 func CustomizeLogging(loggingFormat string, serviceName string) {
 	log.SetOutput(os.Stderr)


### PR DESCRIPTION
Log queries during decryption by AcraCensor if enabled, or only in Debug mode.

Actually, this is an attempt to optimize too often usage of `NormalizeAndRedact` function.