### PR TITLE
validate clientid packet length [T696]

### DIFF
--- a/acra-censor/handlers/handlers_util.go
+++ b/acra-censor/handlers/handlers_util.go
@@ -260,25 +260,20 @@ func handleSelectWherePattern(queryNodes, patternNodes []sqlparser.SQLNode) bool
 
 // handle SELECT a, b FROM t1 WHERE userID=%%VALUE%% pattern
 func handleValuePattern(queryNodes, patternNodes []sqlparser.SQLNode) bool {
-	querySelect, ok := queryNodes[0].(*sqlparser.Select)
-	if !ok {
+	// collect only SelectExpr, From, Where, OrderBy ... nodes without their children
+	queryTopNodes, err := getTopNodes(queryNodes[0])
+	if err != nil {
 		return false
 	}
-	patternSelect, ok := patternNodes[0].(*sqlparser.Select)
-	if !ok {
+	patternTopNodes, err := getTopNodes(patternNodes[0])
+	if err != nil {
 		return false
+	}
+	hasStar := false
+	if selectExpr, ok := patternNodes[0].(*sqlparser.Select); ok {
+		hasStar = starFound(selectExpr.SelectExprs)
 	}
 
-	// collect only SelectExpr, From, Where, OrderBy ... nodes without their children
-	queryTopNodes, err := getTopNodes(querySelect)
-	if err != nil {
-		return false
-	}
-	patternTopNodes, err := getTopNodes(patternSelect)
-	if err != nil {
-		return false
-	}
-	hasStar := starFound(patternSelect.SelectExprs)
 	for i := 0; i < len(queryTopNodes); i++ {
 		patternNode := patternTopNodes[i]
 		queryNode := queryTopNodes[i]

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -73,16 +73,25 @@ func SendData(data []byte, conn io.Writer) error {
 	return nil
 }
 
-// ReadData reads length of data block, then reads data content
-// returns data content
-func ReadData(reader io.Reader) ([]byte, error) {
+// ReadDataLength return read data from reader, parsed data length or err
+func ReadDataLength(reader io.Reader) ([]byte, int, error) {
 	var length [4]byte
 	_, err := io.ReadFull(reader, length[:])
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	dataSize := int(binary.LittleEndian.Uint32(length[:]))
-	buf := make([]byte, dataSize)
+	return length[:], dataSize, nil
+}
+
+// ReadData reads length of data block, then reads data content
+// returns data content
+func ReadData(reader io.Reader) ([]byte, error) {
+	lengthBuf, length, err := ReadDataLength(reader)
+	if err != nil {
+		return lengthBuf, err
+	}
+	buf := make([]byte, length)
 	_, err = io.ReadFull(reader, buf)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
added validation of first packet from acra-connector to acra-server that send before secure session packets and has limited length that we can check (client id can have 255 symbols as length plus some overhead with length of packet). set 1kb limit

p.s. plus found old local code with extended tests for acra-censor that forget to add to some previous pr. added to this pr because not so much and simple changes
