### PR TITLE
refactor processing clients packets

### DIFF
--- a/cmd/acra-connector/acra-connector.go
+++ b/cmd/acra-connector/acra-connector.go
@@ -160,10 +160,11 @@ func handleConnection(config *Config, connection net.Conn) {
 	}
 	log.Infoln("Close wrapped connection with AcraServer")
 	if err := acraConnWrapped.Close(); err != nil {
-		log.WithError(err).Errorln("Error on closing wrapped connection with AcraServer")
+		log.WithError(err).Errorf("Error on closing wrapped connection with %s", connector_mode.ModeToServiceName(config.Mode))
+
 	}
 	if err := acraConn.Close(); err != nil {
-		log.WithError(err).Errorln("Error on closing connection with AcraServer")
+		log.WithError(err).Errorln("Error on closing connection with %s", connector_mode.ModeToServiceName(config.Mode))
 	}
 }
 
@@ -177,6 +178,7 @@ type Config struct {
 	DisableUserCheck         bool
 	KeyStore                 keystore.SecureSessionKeyStore
 	ConnectionWrapper        network.ConnectionWrapper
+	Mode                     connector_mode.ConnectorMode
 }
 
 func main() {
@@ -339,7 +341,7 @@ func main() {
 
 	// --------- Config  -----------
 	log.Infof("Configuring transport...")
-	config := &Config{KeyStore: keyStore, KeysDir: *keysDir, ClientID: []byte(*clientID), OutgoingConnectionString: outgoingConnectionString, IncomingConnectionString: *connectionString, OutgoingServiceID: []byte(outgoingSecureSessionID), DisableUserCheck: *disableUserCheck}
+	config := &Config{KeyStore: keyStore, KeysDir: *keysDir, ClientID: []byte(*clientID), OutgoingConnectionString: outgoingConnectionString, IncomingConnectionString: *connectionString, OutgoingServiceID: []byte(outgoingSecureSessionID), DisableUserCheck: *disableUserCheck, Mode: connectorMode}
 	listener, err := network.Listen(*connectionString)
 	if err != nil {
 		log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantStartListenConnections).

--- a/cmd/acra-connector/connector-mode/connector-mode.go
+++ b/cmd/acra-connector/connector-mode/connector-mode.go
@@ -32,6 +32,18 @@ const (
 	AcraTranslatorMode ConnectorMode = "AcraTranslator"
 )
 
+// ModeToServiceName return service name related with mode
+func ModeToServiceName(mode ConnectorMode) string {
+	switch mode {
+	case AcraServerMode:
+		return "AcraServer"
+	case AcraTranslatorMode:
+		return "AcraTranslator"
+	default:
+		return "Undefined service"
+	}
+}
+
 // CheckConnectorMode converts string to ConnectorMode.
 func CheckConnectorMode(mode string) ConnectorMode {
 	lowerCaseMode := strings.ToLower(mode)

--- a/decryptor/postgresql/packet_handler_test.go
+++ b/decryptor/postgresql/packet_handler_test.go
@@ -56,9 +56,11 @@ func TestClientUnknownCommand(t *testing.T) {
 }
 
 func TestClientSpecialMessageTypes(t *testing.T) {
-	lengthBuf := []byte{0, 0, 0, 8}
-	for _, data := range [][]byte{SSLRequest, CancelRequest, StartupRequest} {
-		packet := bytes.Join([][]byte{lengthBuf, data}, []byte{})
+	sslLengthBuf := []byte{0, 0, 0, 8}
+	cancelRequestLengthBuf := []byte{0, 0, 0, 16}
+	lengthBufs := [][]byte{sslLengthBuf, cancelRequestLengthBuf}
+	for i, data := range [][]byte{SSLRequest, CancelRequest} {
+		packet := bytes.Join([][]byte{lengthBufs[i], data}, []byte{})
 		reader := bytes.NewReader(packet)
 		output := make([]byte, 8)
 		writer := bufio.NewWriter(bytes.NewBuffer(output[:0]))
@@ -72,10 +74,10 @@ func TestClientSpecialMessageTypes(t *testing.T) {
 		if packetHander.messageType[0] != WithoutMessageType {
 			t.Fatal("Incorrect message type")
 		}
-		if !bytes.Equal(packetHander.descriptionLengthBuf, lengthBuf) {
+		if !bytes.Equal(packetHander.descriptionLengthBuf, lengthBufs[i]) {
 			t.Fatal("Incorrect length buf")
 		}
-		if !bytes.Equal(packetHander.descriptionBuf.Bytes(), SSLRequest) {
+		if !bytes.Equal(packetHander.descriptionBuf.Bytes(), data) {
 			t.Fatal("Incorrect data buf")
 		}
 		if err := packetHander.sendPacket(); err != nil {

--- a/decryptor/postgresql/packet_handler_test.go
+++ b/decryptor/postgresql/packet_handler_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2018, Cossack Labs Limited
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package postgresql
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/hex"
+	"testing"
+)
+
+func TestClientUnknownCommand(t *testing.T) {
+	unknownMessageType := byte(1)
+	lengthBuf := []byte{0, 0, 0, 7}
+	dataBuf := []byte{1, 2, 3}
+	packet := bytes.Join([][]byte{[]byte{unknownMessageType}, lengthBuf, dataBuf}, []byte{})
+	reader := bytes.NewReader(packet)
+	output := make([]byte, 8)
+	writer := bufio.NewWriter(bytes.NewBuffer(output[:0]))
+	packetHander, err := NewClientSidePacketHandler(reader, writer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := packetHander.ReadClientPacket(); err != nil {
+		t.Fatal(err)
+	}
+	if packetHander.messageType[0] != unknownMessageType {
+		t.Fatal("Incorrect message type")
+	}
+	if !bytes.Equal(packetHander.descriptionLengthBuf, lengthBuf) {
+		t.Fatal("Incorrect length buf")
+	}
+	if !bytes.Equal(packetHander.descriptionBuf.Bytes(), dataBuf) {
+		t.Fatal("Incorrect data buf")
+	}
+	if err := packetHander.sendPacket(); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(output, packet) {
+		t.Fatal("Output not equal to correct packet")
+	}
+}
+
+func TestClientSpecialMessageTypes(t *testing.T) {
+	lengthBuf := []byte{0, 0, 0, 8}
+	for _, data := range [][]byte{SSLRequest, CancelRequest, StartupRequest} {
+		packet := bytes.Join([][]byte{lengthBuf, data}, []byte{})
+		reader := bytes.NewReader(packet)
+		output := make([]byte, 8)
+		writer := bufio.NewWriter(bytes.NewBuffer(output[:0]))
+		packetHander, err := NewClientSidePacketHandler(reader, writer)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := packetHander.ReadClientPacket(); err != nil {
+			t.Fatal(err)
+		}
+		if packetHander.messageType[0] != WithoutMessageType {
+			t.Fatal("Incorrect message type")
+		}
+		if !bytes.Equal(packetHander.descriptionLengthBuf, lengthBuf) {
+			t.Fatal("Incorrect length buf")
+		}
+		if !bytes.Equal(packetHander.descriptionBuf.Bytes(), SSLRequest) {
+			t.Fatal("Incorrect data buf")
+		}
+		if err := packetHander.sendPacket(); err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(output, packet) {
+			t.Fatal("Output not equal to correct packet")
+		}
+	}
+}
+
+func TestClientStartupMessageWithData(t *testing.T) {
+	// took some startup auth message with wireshark
+	packet, err := hex.DecodeString("0000004c000300007573657200746573740064617461626173650074657374006170706c69636174696f6e5f6e616d65007073716c00636c69656e745f656e636f64696e6700555446380000")
+	if err != nil {
+		t.Fatal(err)
+	}
+	reader := bytes.NewReader(packet)
+	output := &bytes.Buffer{}
+	writer := bufio.NewWriter(output)
+	packetHander, err := NewClientSidePacketHandler(reader, writer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := packetHander.ReadClientPacket(); err != nil {
+		t.Fatal(err)
+	}
+	if packetHander.messageType[0] != WithoutMessageType {
+		t.Fatal("Incorrect message type")
+	}
+	if err := packetHander.sendPacket(); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(output.Bytes(), packet) {
+		t.Fatal("Output not equal to correct packet")
+	}
+}

--- a/network/proxy.go
+++ b/network/proxy.go
@@ -31,7 +31,7 @@ func Proxy(connFrom, connTo net.Conn, errCh chan<- error) {
 			return
 		}
 		if n == 0 {
-			log.Warningln("read 0 bytes")
+			log.Warningln("Read 0 bytes")
 			continue
 		}
 		for nTo := 0; nTo < n; {

--- a/tests/test.py
+++ b/tests/test.py
@@ -71,8 +71,8 @@ DB_HOST = os.environ.get('TEST_DB_HOST', '127.0.0.1')
 DB_NAME = os.environ.get('TEST_DB_NAME', 'postgres')
 DB_PORT = os.environ.get('TEST_DB_PORT', 5432)
 
-DATA_MIN_SIZE = 1000
-DATA_MAX_SIZE = DATA_MIN_SIZE * 10
+DATA_MIN_SIZE = 10
+DATA_MAX_SIZE = DATA_MIN_SIZE * 1000
 # 200 is overhead of encryption (chosen manually)
 # multiply 2 because tested acrastruct in acrastruct
 COLUMN_DATA_SIZE = (DATA_MAX_SIZE + 200) * 2

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -35,9 +35,6 @@ const (
 	SessionDataLimit = 8 * 1024 // 8 kb
 )
 
-// ErrBigDataBlockSize represents data encoding error
-var ErrBigDataBlockSize = fmt.Errorf("Block size greater than %v", SessionDataLimit)
-
 // WriteFull writes data to io.Writer.
 // if wr.Write will return n <= len(data) will
 //	sent the rest of data until error or total sent byte count == len(data)
@@ -59,8 +56,6 @@ func WriteFull(data []byte, wr io.Writer) (int, error) {
 
 // SendData writes length of data block to connection, then writes data itself
 func SendData(data []byte, conn io.Writer) error {
-	log.Infof("Send %v bytes", len(data))
-	log.Infof("send data ", string(data))
 	var buf [4]byte
 	binary.LittleEndian.PutUint32(buf[:], uint32(len(data)))
 	_, err := WriteFull(buf[:], conn)
@@ -82,7 +77,6 @@ func ReadDataLength(reader io.Reader) ([]byte, int, error) {
 		return nil, 0, err
 	}
 	dataSize := int(binary.LittleEndian.Uint32(length[:]))
-	log.Infof("Read %v bytes", dataSize)
 	return length[:], dataSize, nil
 }
 
@@ -98,7 +92,6 @@ func ReadData(reader io.Reader) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	log.Infof("Read data ", string(buf))
 	return buf, nil
 }
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -59,6 +59,8 @@ func WriteFull(data []byte, wr io.Writer) (int, error) {
 
 // SendData writes length of data block to connection, then writes data itself
 func SendData(data []byte, conn io.Writer) error {
+	log.Infof("Send %v bytes", len(data))
+	log.Infof("send data ", string(data))
 	var buf [4]byte
 	binary.LittleEndian.PutUint32(buf[:], uint32(len(data)))
 	_, err := WriteFull(buf[:], conn)
@@ -80,6 +82,7 @@ func ReadDataLength(reader io.Reader) ([]byte, int, error) {
 		return nil, 0, err
 	}
 	dataSize := int(binary.LittleEndian.Uint32(length[:]))
+	log.Infof("Read %v bytes", dataSize)
 	return length[:], dataSize, nil
 }
 
@@ -95,6 +98,7 @@ func ReadData(reader io.Reader) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	log.Infof("Read data ", string(buf))
 	return buf, nil
 }
 


### PR DESCRIPTION
postgresql has 3 special message types that has format another than all other message: startup, ssl request and cancelation request. 
before we try to parse only first packet as special and all other as general
but was case when client send ssl request (first special), then if it continue after db response it send startup message. we correctly handle case when db accept ssl request and didn't handle deny from db.
Now processing re-writed for client's side of processing and we try to recognize these special messages or other known general messages and doesn't depend on their order (first, second etc). Plus in a future can process them separately. 

plus added handling columns with null values (it fixes panics [T790])