### PR TITLE
Add parameter to generate CLI agrs in markdown

### DIFF
--- a/configs/acra-addzone.yaml
+++ b/configs/acra-addzone.yaml
@@ -7,6 +7,9 @@ dump_config: false
 # Use filesystem key store
 fs_keystore_enable: true
 
+# Generate with yaml config markdown text file with descriptions of all args
+generate_markdown_args_table: false
+
 # Folder where will be saved generated zone keys
 keys_output_dir: .acrakeys
 

--- a/configs/acra-authmanager.yaml
+++ b/configs/acra-authmanager.yaml
@@ -10,6 +10,9 @@ dump_config: false
 # Auth file
 file: configs/auth.keys
 
+# Generate with yaml config markdown text file with descriptions of all args
+generate_markdown_args_table: false
+
 # Folder from which will be loaded keys
 keys_dir: .acrakeys
 

--- a/configs/acra-connector.yaml
+++ b/configs/acra-connector.yaml
@@ -46,6 +46,9 @@ d: false
 # dump config
 dump_config: false
 
+# Generate with yaml config markdown text file with descriptions of all args
+generate_markdown_args_table: false
+
 # Enable connection to AcraServer via HTTP API
 http_api_enable: false
 

--- a/configs/acra-keymaker.yaml
+++ b/configs/acra-keymaker.yaml
@@ -22,6 +22,9 @@ generate_acrawebconfig_keys: false
 # Create keypair for data encryption/decryption
 generate_acrawriter_keys: false
 
+# Generate with yaml config markdown text file with descriptions of all args
+generate_markdown_args_table: false
+
 # Generate new random master key and save to file
 generate_master_key: 
 

--- a/configs/acra-poisonrecordmaker.yaml
+++ b/configs/acra-poisonrecordmaker.yaml
@@ -7,6 +7,9 @@ data_length: -1
 # dump config
 dump_config: false
 
+# Generate with yaml config markdown text file with descriptions of all args
+generate_markdown_args_table: false
+
 # Folder from which will be loaded keys
 keys_dir: .acrakeys
 

--- a/configs/acra-rollback.yaml
+++ b/configs/acra-rollback.yaml
@@ -16,6 +16,9 @@ escape: false
 # Execute inserts
 execute: false
 
+# Generate with yaml config markdown text file with descriptions of all args
+generate_markdown_args_table: false
+
 # Query for insert decrypted data with placeholders (pg: $n, mysql: ?)
 insert: 
 

--- a/configs/acra-rotate.yaml
+++ b/configs/acra-rotate.yaml
@@ -1,12 +1,30 @@
 # path to config
 config_file: 
 
+# Connection string to db
+db_connection_string: 
+
 # dump config
 dump_config: false
 
 # Path to file with map of <ZoneId>: <FilePaths> in json format {"zone_id1": ["filepath1", "filepath2"], "zone_id2": ["filepath1", "filepath2"]}
 file_map_config: 
 
+# Generate with yaml config markdown text file with descriptions of all args
+generate_markdown_args_table: false
+
 # Folder from which the keys will be loaded
 keys_dir: .acrakeys
+
+# Handle MySQL connections
+mysql_enable: false
+
+# Handle Postgresql connections
+postgresql_enable: false
+
+# Select query with ? as placeholders where last columns in result must be ClientId/ZoneId and AcraStruct. Other columns will be passed into insert/update query into placeholders
+sql_select: 
+
+# Insert/Update query with ? as placeholder where into first will be placed rotated AcraStruct
+sql_update: 
 

--- a/configs/acra-server.yaml
+++ b/configs/acra-server.yaml
@@ -37,6 +37,9 @@ ds: false
 # dump config
 dump_config: false
 
+# Generate with yaml config markdown text file with descriptions of all args
+generate_markdown_args_table: false
+
 # Enable HTTP API
 http_api_enable: false
 

--- a/configs/acra-translator.yaml
+++ b/configs/acra-translator.yaml
@@ -40,9 +40,6 @@ poison_run_script_file:
 # On detecting poison record: log about poison record detection, stop and shutdown
 poison_shutdown_enable: false
 
-# URL of Prometheus server for AcraConnector to upload stats and metrics (upload address is <URL>/metrics)
-prometheus_metrics_address: 
-
 # Id that will be sent in secure session
 securesession_id: acra_translator
 

--- a/configs/acra-translator.yaml
+++ b/configs/acra-translator.yaml
@@ -7,6 +7,9 @@ d: false
 # dump config
 dump_config: false
 
+# Generate with yaml config markdown text file with descriptions of all args
+generate_markdown_args_table: false
+
 # Time that AcraTranslator will wait (in seconds) on stop signal before closing all connections
 incoming_connection_close_timeout: 10
 
@@ -33,6 +36,9 @@ poison_run_script_file:
 
 # On detecting poison record: log about poison record detection, stop and shutdown
 poison_shutdown_enable: false
+
+# URL of Prometheus server for AcraConnector to upload stats and metrics (upload address is <URL>/metrics)
+prometheus_metrics_address: 
 
 # Id that will be sent in secure session
 securesession_id: acra_translator

--- a/configs/acra-webconfig.yaml
+++ b/configs/acra-webconfig.yaml
@@ -13,6 +13,9 @@ destination_port: 9191
 # dump config
 dump_config: false
 
+# Generate with yaml config markdown text file with descriptions of all args
+generate_markdown_args_table: false
+
 # Mode for basic auth. Possible values: auth_on|auth_off_local|auth_off
 http_auth_mode: auth_on
 


### PR DESCRIPTION
in a past was added logic to generate description of cli args in markdown format as table and was leaved as is with hardcoded paths. It was used for our documentation in a past

I refactored it. Let discuss do we need it now and do we want to add it to repo