### PR TITLE
acra censor support of range conditions [T814]

### DIFF
--- a/acra-censor/acra-censor_test.go
+++ b/acra-censor/acra-censor_test.go
@@ -932,6 +932,7 @@ func testBlacklistWherePattern(t *testing.T) {
 		}
 	}
 }
+
 func testBlacklistValuePattern(t *testing.T) {
 	var err error
 

--- a/acra-censor/handlers/common.go
+++ b/acra-censor/handlers/common.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2018, Cossack Labs Limited
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlers
+
+import (
+	"github.com/cossacklabs/acra/logging"
+	log "github.com/sirupsen/logrus"
+	"github.com/xwb1989/sqlparser"
+	"strings"
+)
+
+// ParsePatterns replace placeholders with our values which used to match patterns and parse them with sqlparser
+func ParsePatterns(patterns []string) ([][]sqlparser.SQLNode, error) {
+	placeholders := []string{SelectConfigPlaceholder, ColumnConfigPlaceholder, WhereConfigPlaceholder, ValueConfigPlaceholder}
+	replacers := []string{SelectConfigPlaceholderReplacer, ColumnConfigPlaceholderReplacer, WhereConfigPlaceholderReplacer, ValueConfigPlaceholderReplacer}
+	patternValue := ""
+	var outputPatterns [][]sqlparser.SQLNode
+	for _, pattern := range patterns {
+		patternValue = pattern
+		for index, placeholder := range placeholders {
+			patternValue = strings.Replace(patternValue, placeholder, replacers[index], -1)
+		}
+		statement, err := sqlparser.Parse(patternValue)
+		if err != nil {
+			log.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCensorQueryParseError).WithError(err).Errorln("Can't add specified pattern in blacklist handler")
+			return nil, ErrPatternSyntaxError
+		}
+		var newPatternNodes []sqlparser.SQLNode
+		sqlparser.Walk(func(node sqlparser.SQLNode) (bool, error) {
+			newPatternNodes = append(newPatternNodes, node)
+			return true, nil
+		}, statement)
+		outputPatterns = append(outputPatterns, newPatternNodes)
+	}
+	return outputPatterns, nil
+
+}

--- a/acra-censor/handlers/handlers_util.go
+++ b/acra-censor/handlers/handlers_util.go
@@ -24,6 +24,7 @@ limitations under the License.
 package handlers
 
 import (
+	"bytes"
 	"errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/xwb1989/sqlparser"
@@ -69,7 +70,10 @@ const (
 	WhereConfigPlaceholderReplacerPart2  = "VALUE_EF930A9B = 'VALUE_CD329E0D'"
 	WhereConfigPlaceholderReplacer       = WhereConfigPlaceholderReplacerPart1 + " " + WhereConfigPlaceholderReplacerPart2
 	ValueConfigPlaceholder               = "%%VALUE%%"
-	ValueConfigPlaceholderReplacer       = "'VALUE_AE920B7D'"
+	// value without quotes
+	ValueConfigPlaceholderRawReplacer = "VALUE_AE920B7D"
+	// quoted value
+	ValueConfigPlaceholderReplacer = "'" + ValueConfigPlaceholderRawReplacer + "'"
 )
 
 // TrimStringToN trims query to N chars.
@@ -105,16 +109,15 @@ func NormalizeAndRedactSQLQuery(sql string) (normalizedQuery string, redactedQue
 }
 
 func checkPatternsMatching(patterns [][]sqlparser.SQLNode, query string) (bool, error) {
-	var queryNodes []sqlparser.SQLNode
 	statement, err := sqlparser.Parse(query)
 	if err != nil {
 		log.WithError(err).Errorln("Can't parse query")
 		return false, ErrQuerySyntaxError
 	}
-	sqlparser.Walk(func(node sqlparser.SQLNode) (bool, error) {
-		queryNodes = append(queryNodes, node)
-		return true, nil
-	}, statement)
+	queryNodes, err := getAllNodes(statement)
+	if err != nil {
+		return false, err
+	}
 	for _, singlePatternNodes := range patterns {
 		if checkSinglePatternMatch(queryNodes, singlePatternNodes) {
 			return true, nil
@@ -168,6 +171,19 @@ func isColumnPattern(expr sqlparser.SelectExpr) bool {
 		return false
 	}
 	return false
+}
+
+// getAllNodes recusively walk through node and return all children of node with node itself
+func getAllNodes(node sqlparser.SQLNode) ([]sqlparser.SQLNode, error) {
+	var queryNodes []sqlparser.SQLNode
+	err := sqlparser.Walk(func(node sqlparser.SQLNode) (bool, error) {
+		queryNodes = append(queryNodes, node)
+		return true, nil
+	}, node)
+	if err != nil {
+		return nil, err
+	}
+	return queryNodes, nil
 }
 
 // getTopNodes walk only once at depth and return first level children of firstNode
@@ -258,6 +274,110 @@ func handleSelectWherePattern(queryNodes, patternNodes []sqlparser.SQLNode) bool
 	return true
 }
 
+// isValuePattern return true if node is ValueConfigPlaceholder pattern otherwise false
+func isValuePattern(node sqlparser.SQLNode) bool {
+	sqlVal, ok := node.(*sqlparser.SQLVal)
+	if !ok {
+		return false
+	}
+	if sqlVal.Type != sqlparser.StrVal {
+		return false
+	}
+	return bytes.Equal(sqlVal.Val, []byte(ValueConfigPlaceholderRawReplacer))
+}
+
+// handleRangeCondition handle range queries (age BETWEEN %%value%% and 5)
+// return true if match (with or without %%value%% patterns) otherwise false
+func handleRangeCondition(patternNode, queryNode *sqlparser.RangeCond) bool {
+	if queryNode.Operator != patternNode.Operator {
+		return false
+	}
+	if !reflect.DeepEqual(queryNode.Left, patternNode.Left) {
+		return false
+	}
+	if !isValuePattern(patternNode.From) {
+		if !reflect.DeepEqual(patternNode.From, queryNode.From) {
+			return false
+		}
+	}
+	if !isValuePattern(patternNode.To) {
+		if !reflect.DeepEqual(patternNode.To, queryNode.To) {
+			return false
+		}
+	}
+	return true
+}
+
+// handleWhereNode process all patterns and rules related with Where conditions
+func handleWhereNode(patternNode, queryNode sqlparser.SQLNode) bool {
+	// get all fields of node struct without recursion
+	patternWhereNodes, err := getTopNodes(patternNode)
+	if err != nil {
+		return false
+	}
+	queryWhereNodes, err := getTopNodes(queryNode)
+	if err != nil {
+		return false
+	}
+
+	// we don't need to check their length because some patterns may accept queries with different node count (list of  values as example)
+
+	//if len(patternWhereNodes) != len(queryWhereNodes) {
+	//	return false
+	//}
+	for i, patternWhereNode := range patternWhereNodes {
+		queryWhereNode := queryWhereNodes[i]
+		switch patternWhereNode.(type) {
+		case *sqlparser.Where:
+			if _, ok := queryWhereNode.(*sqlparser.Where); !ok {
+				// different types
+				return false
+			}
+			return handleWhereNode(patternWhereNode, queryWhereNode)
+		case *sqlparser.AndExpr, *sqlparser.OrExpr, *sqlparser.NotExpr:
+			// check that complex structs with children has same type and then recursively check them
+			if reflect.TypeOf(queryWhereNode) != reflect.TypeOf(patternWhereNode) {
+				return false
+			}
+			if !handleWhereNode(patternWhereNode, queryWhereNode) {
+				return false
+			}
+			continue
+		case *sqlparser.IsExpr:
+			if queryIsExpr, ok := queryWhereNode.(*sqlparser.IsExpr); ok {
+				if queryIsExpr.Operator != patternWhereNode.(*sqlparser.IsExpr).Operator {
+					return false
+				}
+				if !handleWhereNode(patternWhereNode.(*sqlparser.IsExpr).Expr, queryWhereNode.(*sqlparser.IsExpr).Expr) {
+					return false
+				}
+				continue
+			}
+			// query node has different type
+			return false
+		case *sqlparser.ComparisonExpr:
+			if queryNodeComparison, ok := queryWhereNode.(*sqlparser.ComparisonExpr); ok && queryNodeComparison != nil {
+				if IsEqualComparisonNode(patternWhereNode.(*sqlparser.ComparisonExpr), queryNodeComparison) {
+					continue
+				}
+			}
+			return false
+		case *sqlparser.RangeCond:
+			if queryRangeCondition, ok := queryWhereNode.(*sqlparser.RangeCond); ok {
+				if handleRangeCondition(patternWhereNode.(*sqlparser.RangeCond), queryRangeCondition) {
+					continue
+				}
+			}
+			return false
+		}
+		// unknown and conditions without specific rules check recursively by values as is
+		if !reflect.DeepEqual(patternWhereNode, queryWhereNode) {
+			return false
+		}
+	}
+	return true
+}
+
 // handle SELECT a, b FROM t1 WHERE userID=%%VALUE%% pattern
 func handleValuePattern(queryNodes, patternNodes []sqlparser.SQLNode) bool {
 	// collect only SelectExpr, From, Where, OrderBy ... nodes without their children
@@ -284,29 +404,11 @@ func handleValuePattern(queryNodes, patternNodes []sqlparser.SQLNode) bool {
 				continue
 			}
 		case *sqlparser.Where:
-			patternWhereNodes, err := getTopNodes(patternNode)
-			if err != nil {
+			if _, ok := queryNode.(*sqlparser.Where); !ok {
 				return false
 			}
-			queryWhereNodes, err := getTopNodes(queryNode)
-			if err != nil {
+			if !handleWhereNode(patternNode.(*sqlparser.Where), queryNode.(*sqlparser.Where)) {
 				return false
-			}
-			if len(patternWhereNodes) != len(queryWhereNodes) {
-				return false
-			}
-			for i, patternWhereNode := range patternWhereNodes {
-				queryWhereNode := queryWhereNodes[i]
-				if patternNodeComparison, ok := patternWhereNode.(*sqlparser.ComparisonExpr); ok && patternNodeComparison != nil {
-					if queryNodeComparison, ok := queryWhereNode.(*sqlparser.ComparisonExpr); ok && queryNodeComparison != nil {
-						if IsEqualComparisonNode(patternNodeComparison, queryNodeComparison) {
-							continue
-						}
-					}
-				}
-				if !reflect.DeepEqual(patternWhereNode, queryWhereNode) {
-					return false
-				}
 			}
 			continue
 		}
@@ -323,9 +425,11 @@ func IsEqualComparisonNode(patternNode, queryNode *sqlparser.ComparisonExpr) boo
 	if reflect.DeepEqual(patternNode.Left, queryNode.Left) &&
 		strings.EqualFold(patternNode.Operator, queryNode.Operator) &&
 		reflect.DeepEqual(patternNode.Escape, queryNode.Escape) {
-		if strings.EqualFold(sqlparser.String(patternNode.Right), ValueConfigPlaceholderReplacer) {
+		if isValuePattern(patternNode.Right) {
 			return true
 		}
+		// pattern node hasn't %%VALUE%% pattern so compare their values as is
+		return reflect.DeepEqual(patternNode.Right, queryNode.Right)
 	}
 	return false
 }

--- a/acra-censor/handlers/handlers_util_test.go
+++ b/acra-censor/handlers/handlers_util_test.go
@@ -1,0 +1,344 @@
+/*
+Copyright 2018, Cossack Labs Limited
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlers
+
+import (
+	"fmt"
+	"github.com/xwb1989/sqlparser"
+	"testing"
+)
+
+func TestHandleRangeCondition(t *testing.T) {
+	patterns := []string{
+		// left side value placeholder
+		fmt.Sprintf("select 1 from t where param between %s and 2", ValueConfigPlaceholder),
+		// right side value placeholder
+		fmt.Sprintf("select 1 from t where param between 1 and %s", ValueConfigPlaceholder),
+		// two sides placeholder
+		fmt.Sprintf("select 1 from t where param between %s and %s", ValueConfigPlaceholder, ValueConfigPlaceholder),
+		// two explicit int values
+		"select 1 from t where param between 1 and 2",
+		// two explicit str values
+		"select 1 from t where param between 'qwe' and 'asd'",
+	}
+	parsedPatterns, err := ParsePatterns(patterns)
+	if err != nil {
+		t.Fatal(err)
+	}
+	notMatchableQueries := [][]string{
+		// left side value placeholder
+		[]string{
+			"select 1 from t where param between 'value placeholder' and 3",
+			"select 1 from t where param between 'value placeholder' and 'qwe'",
+			"select 1 from t where param between 'value placeholder' and TRUE",
+			"select 1 from t where param between 'value placeholder' and NULL",
+		},
+		// right side value placeholder
+		[]string{
+			"select 1 from t where param between 2 and 'value placeholder'",
+			"select 1 from t where param between 'qwe' and 'value placeholder'",
+			"select 1 from t where param between TRUE and 'value placeholder'",
+			"select 1 from t where param between NULL and 'value placeholder'",
+		},
+		// two sides placeholder
+		[]string{
+			// incorrect column name
+			"select 1 from t where incorrect_column between NULL and 'value placeholder'",
+		}, // all queries should match
+		// two explicit int values
+		[]string{
+			"select 1 from t where param between 1 and 3",
+			"select 1 from t where param between 2 and 2",
+			"select 1 from t where param between 1 and True",
+			"select 1 from t where param between True and 2",
+			"select 1 from t where param between 1 and Null",
+			"select 1 from t where param between 2 and 1",
+		},
+		// two explicit str values
+		[]string{
+			"select 1 from t where param between 'qwe' and 1",
+			"select 1 from t where param between 2 and 'asd'",
+			"select 1 from t where param between True and 'asd'",
+			"select 1 from t where param between 'qwe' and NULL",
+		},
+	}
+	matchableQueries := [][]string{
+		// left side value placeholder
+		[]string{
+			"SELECT 1 FROM t WHERE param BETWEEN 1 AND 2",
+			"SELECT 1 FROM t WHERE param BETWEEN 'qwe' AND 2",
+			"SELECT 1 FROM t WHERE param BETWEEN TRUE AND 2",
+			"SELECT 1 FROM t WHERE param BETWEEN NULL AND 2",
+		},
+		// right side value placeholder
+		[]string{
+			"SELECT 1 FROM t WHERE param BETWEEN 1 AND 2",
+			"SELECT 1 FROM t WHERE param BETWEEN 1 AND 'qwe'",
+			"SELECT 1 FROM t WHERE param BETWEEN 1 AND TRUE",
+			"SELECT 1 FROM t WHERE param BETWEEN 1 AND NULL",
+		},
+		// two sides placeholder
+		[]string{
+			"SELECT 1 FROM t WHERE param BETWEEN 1 AND 2",
+			"SELECT 1 FROM t WHERE param BETWEEN NULL AND 'qwe'",
+			"SELECT 1 FROM t WHERE param BETWEEN 'qwe' AND TRUE",
+			"SELECT 1 FROM t WHERE param BETWEEN FALSE AND NULL",
+		},
+		// two explicit int values
+		[]string{
+			"SELECT 1 FROM t WHERE param BETWEEN 1 AND 2",
+		},
+		// two explicit str values
+		[]string{
+			"SELECT 1 FROM t WHERE param BETWEEN 'qwe' and 'asd'",
+		},
+	}
+	if len(parsedPatterns) != len(matchableQueries) {
+		t.Fatal("Mismatch test configuration")
+	}
+	for i := 0; i < len(parsedPatterns); i++ {
+		pattern := parsedPatterns[i][0]
+		patternRange := pattern.(*sqlparser.Select).Where.Expr.(*sqlparser.RangeCond)
+		for _, query := range matchableQueries[i] {
+			parsedQuery, err := sqlparser.Parse(query)
+			if err != nil {
+				t.Fatal(err)
+			}
+			queryRange := parsedQuery.(*sqlparser.Select).Where.Expr.(*sqlparser.RangeCond)
+			if !handleRangeCondition(patternRange, queryRange) {
+				t.Fatalf("Expected match in query <%s> with pattern <%s>", query, sqlparser.String(pattern))
+			}
+		}
+
+		for _, query := range notMatchableQueries[i] {
+			parsedQuery, err := sqlparser.Parse(query)
+			if err != nil {
+				t.Fatal(err)
+			}
+			queryRange := parsedQuery.(*sqlparser.Select).Where.Expr.(*sqlparser.RangeCond)
+			if handleRangeCondition(patternRange, queryRange) {
+				t.Fatalf("Expected not match in query <%s> with pattern <%s>", query, sqlparser.String(pattern))
+			}
+		}
+	}
+}
+
+func TestHandleValuePatternWithRangeCondition(t *testing.T) {
+	patterns := []string{
+		// left side value placeholder
+		fmt.Sprintf("select 1 from t where param between %s and 2", ValueConfigPlaceholder),
+		// left side value placeholder with other conditions
+		fmt.Sprintf("select 1 from t where param1 = 2 and param between %s and 2 or param3='qwe'", ValueConfigPlaceholder),
+		// right side value placeholder
+		fmt.Sprintf("select 1 from t where param between 1 and %s", ValueConfigPlaceholder),
+		// right side value placeholder with other conditions
+		fmt.Sprintf("select 1 from t where param1 = 2 and param between 1 and %s or param1 = TRUE", ValueConfigPlaceholder),
+		// two sides placeholder
+		fmt.Sprintf("select 1 from t where param between %s and %s", ValueConfigPlaceholder, ValueConfigPlaceholder),
+		// two sides placeholder with other conditions
+		fmt.Sprintf("select 1 from t where param1 = 2 and param between %s and %s or param2 is NULL", ValueConfigPlaceholder, ValueConfigPlaceholder),
+		// two explicit int values
+		"select 1 from t where param between 1 and 2",
+		// two explicit int values with other conditions
+		"select 1 from t where b=2 and param between 1 and 2 and True",
+		// two explicit str values
+		"select 1 from t where param between 'qwe' and 'asd'",
+		// two explicit str values with other conditions
+		"select 1 from t where b='qwe' and param between 'qwe' and 'asd' and t in (1,2,3)",
+	}
+	parsedPatterns, err := ParsePatterns(patterns)
+	if err != nil {
+		t.Fatal(err)
+	}
+	notMatchableQueries := [][]string{
+		// left side value placeholder
+		[]string{
+			"select 1 from t where param between 'value placeholder' and 3",
+			"select 1 from t where param between 'value placeholder' and 'qwe'",
+			"select 1 from t where param between 'value placeholder' and TRUE",
+			"select 1 from t where param between 'value placeholder' and NULL",
+		},
+		// left side value placeholder with other conditions
+		[]string{
+			// incorrect param1
+			"select 1 from t where param1 = 1 and param between 'value placeholder' and 2 or param3='qwe'",
+			// incorrect right value
+			"select 1 from t where param1 = 2 and param between 'value placeholder' and 3 or param3='qwe'",
+			// incorrect param3
+			"select 1 from t where param1 = 2 and param between 'value placeholder' and 2 or param3='incorrect'",
+		},
+		// right side value placeholder
+		[]string{
+			"select 1 from t where param between 2 and 'value placeholder'",
+			"select 1 from t where param between 'qwe' and 'value placeholder'",
+			"select 1 from t where param between TRUE and 'value placeholder'",
+			"select 1 from t where param between NULL and 'value placeholder'",
+		},
+		// right side value placeholder with other conditions
+		[]string{
+			// incorrect param1
+			"select 1 from t where param1 = 1 and param between 1 and 1 or param1 = TRUE",
+			// incorrect param1
+			"select 1 from t where param1 = 2 and param between 1 and 'qwe' or param1 = FALSE",
+			// incorrect left param
+			"select 1 from t where param1 = 2 and param between 2 and TRUE or param1 = TRUE",
+		},
+
+		// two sides placeholder
+		[]string{}, // all queries should match
+		// two sides placeholder with other conditions
+		[]string{
+			// incorrect param1
+			"select 1 from t where param1 = 1 and param between 'asd' and 1 or param1 = TRUE",
+			// incorrect param1
+			"select 1 from t where param1 = 2 and param between 1 and 'qwe' or param1 = FALSE",
+		},
+		// two explicit int values
+		[]string{
+			"select 1 from t where param between 1 and 3",
+			"select 1 from t where param between 2 and 2",
+			"select 1 from t where param between 1 and 'qwe'",
+			"select 1 from t where param between 1 and NULL",
+			"select 1 from t where param between 1 and TRUE",
+		},
+		// two explicit int values with other conditions
+		[]string{
+			// incorrect right condition
+			"select 1 from t where b=2 and param between 1 and 3 and True",
+			// incorrect left condition
+			"select 1 from t where b=2 and param between 2 and 2 and True",
+			// incorrect right param
+			"select 1 from t where b=2 and param between 1 and 2 and False",
+			// incorrect b param
+			"select 1 from t where b=1 and param between 1 and 2 and True",
+		},
+		// two explicit str values
+		[]string{
+			// incorrect right condition
+			"select 1 from t where param between 'qwe' and 'incorrect'",
+			// incorrect left condition
+			"select 1 from t where param between 'incorrect' and 'asd'",
+			// incorrect right condition value type
+			"select 1 from t where param between 'qwe' and 1",
+			// incorrect right condition value type
+			"select 1 from t where param between 1 and 'asd'",
+		},
+		// two explicit str values with other conditions
+		[]string{
+			// "select 1 from t where b='qwe' and param between 'qwe' and 'asd' and t in (1,2,3)",
+			// incorrect t in ()
+			"select 1 from t where b='qwe' and param between 'qwe' and 'asd' and t in (1,2,2)",
+			// incorrect b
+			"select 1 from t where b=1 and param between 'qwe' and 'asd' and t in (1,2,3)",
+			// incorrect left condition
+			"select 1 from t where b='qwe' and param between 1 and 'asd' and t in (1,2,3)",
+			// incorrect right condition
+			"select 1 from t where b='qwe' and param between 'qwe' and 1 and t in (1,2,3)",
+			// incorrect column of between
+			"select 1 from t where b='qwe' and incorrect_column between 'qwe' and 'asd' and t in (1,2,3)",
+		},
+	}
+	matchableQueries := [][]string{
+		// left side value placeholder
+		[]string{
+			"SELECT 1 FROM t WHERE param BETWEEN 1 AND 2",
+			"SELECT 1 FROM t WHERE param BETWEEN 'qwe' AND 2",
+			"SELECT 1 FROM t WHERE param BETWEEN TRUE AND 2",
+			"SELECT 1 FROM t WHERE param BETWEEN NULL AND 2",
+		},
+		// left side value placeholder with other conditions
+		[]string{
+			"select 1 from t where param1 = 2 and param between 1 and 2 or param3='qwe'",
+			"select 1 from t where param1 = 2 and param between 'qwe' and 2 or param3='qwe'",
+			"select 1 from t where param1 = 2 and param between TRUE and 2 or param3='qwe'",
+			"select 1 from t where param1 = 2 and param between NULL and 2 or param3='qwe'",
+		},
+		// right side value placeholder
+		[]string{
+			"SELECT 1 FROM t WHERE param BETWEEN 1 AND 2",
+			"SELECT 1 FROM t WHERE param BETWEEN 1 AND 'qwe'",
+			"SELECT 1 FROM t WHERE param BETWEEN 1 AND TRUE",
+			"SELECT 1 FROM t WHERE param BETWEEN 1 AND NULL",
+		},
+		// right side value placeholder with other conditions
+		[]string{
+			// incorrect param1
+			"select 1 from t where param1 = 2 and param between 1 and 1 or param1 = TRUE",
+			// incorrect param1
+			"select 1 from t where param1 = 2 and param between 1 and 'qwe' or param1 = TRUE",
+			// incorrect left param
+			"select 1 from t where param1 = 2 and param between 1 and TRUE or param1 = TRUE",
+		},
+		// two sides placeholder
+		[]string{
+			"select 1 from t where param between TRUE and 1",
+			"select 1 from t where param between TRUE and 'qwe'",
+			"select 1 from t where param between NULL and FALSE",
+			"select 1 from t where param between 'qwe' and 2",
+		},
+		// two sides placeholder with other conditions
+		[]string{
+			"select 1 from t where param1 = 2 and param between TRUE and 1 or param2 is NULL",
+			"select 1 from t where param1 = 2 and param between TRUE and 'qwe' or param2 is NULL",
+			"select 1 from t where param1 = 2 and param between NULL and FALSE or param2 is NULL",
+			"select 1 from t where param1 = 2 and param between 'qwe' and 2 or param2 is NULL",
+		},
+		// two explicit int values
+		[]string{
+			"SELECT 1 FROM t WHERE param BETWEEN 1 AND 2",
+		},
+		// two explicit int values with other conditions
+		[]string{
+			"select 1 from t where b=2 and param between 1 and 2 and True",
+		},
+		// two explicit str values
+		[]string{
+			"select 1 from t where param between 'qwe' and 'asd'",
+		},
+		// two explicit str values with other conditions
+		[]string{
+			"select 1 from t where b='qwe' and param between 'qwe' and 'asd' and t in (1,2,3)",
+		},
+	}
+	if len(patterns) != len(matchableQueries) || len(matchableQueries) != len(notMatchableQueries) {
+		t.Fatal("Mismatch test configuration with incorrect array dimensions")
+	}
+
+	for i := 0; i < len(parsedPatterns); i++ {
+		pattern := parsedPatterns[i][0]
+		for _, query := range matchableQueries[i] {
+			parsedQuery, err := sqlparser.Parse(query)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !handleValuePattern([]sqlparser.SQLNode{parsedQuery}, []sqlparser.SQLNode{pattern}) {
+				t.Fatalf("Expected match in query <%s> with pattern <%s>", query, sqlparser.String(pattern))
+			}
+		}
+
+		for _, query := range notMatchableQueries[i] {
+			parsedQuery, err := sqlparser.Parse(query)
+			if err != nil {
+				t.Fatalf("Error <%s> with query <%s>", err.Error(), query)
+			}
+			if handleValuePattern([]sqlparser.SQLNode{parsedQuery}, []sqlparser.SQLNode{pattern}) {
+				t.Fatalf("Expected not match in query <%s> with pattern <%s>", query, sqlparser.String(pattern))
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
* added support of `between`
* refactored function of processing %%value%% patterns
* added function to detect %%value%% pattern as value with direct usage of struct fields
* moved logic of parsing patterns to separate function that used in two handlers and now available to use in unit-tests