### PR TITLE
support sql IN clause in acra-censor [T815]

### DIFF
--- a/acra-censor/handlers/common.go
+++ b/acra-censor/handlers/common.go
@@ -25,8 +25,8 @@ import (
 
 // ParsePatterns replace placeholders with our values which used to match patterns and parse them with sqlparser
 func ParsePatterns(patterns []string) ([][]sqlparser.SQLNode, error) {
-	placeholders := []string{SelectConfigPlaceholder, ColumnConfigPlaceholder, WhereConfigPlaceholder, ValueConfigPlaceholder, ListOfValuesConfigPlaceholder}
-	replacers := []string{SelectConfigPlaceholderReplacer, ColumnConfigPlaceholderReplacer, WhereConfigPlaceholderReplacer, ValueConfigPlaceholderReplacer, ListOfValuesConfigPlaceholderReplacer}
+	placeholders := []string{SelectConfigPlaceholder, ColumnConfigPlaceholder, WhereConfigPlaceholder, ValueConfigPlaceholder, ListOfValuesConfigPlaceholder, SubqueryConfigPlaceholder}
+	replacers := []string{SelectConfigPlaceholderReplacer, ColumnConfigPlaceholderReplacer, WhereConfigPlaceholderReplacer, ValueConfigPlaceholderReplacer, ListOfValuesConfigPlaceholderReplacer, SubqueryConfigPlaceholderReplacer}
 	patternValue := ""
 	var outputPatterns [][]sqlparser.SQLNode
 	for _, pattern := range patterns {

--- a/acra-censor/handlers/common.go
+++ b/acra-censor/handlers/common.go
@@ -25,8 +25,8 @@ import (
 
 // ParsePatterns replace placeholders with our values which used to match patterns and parse them with sqlparser
 func ParsePatterns(patterns []string) ([][]sqlparser.SQLNode, error) {
-	placeholders := []string{SelectConfigPlaceholder, ColumnConfigPlaceholder, WhereConfigPlaceholder, ValueConfigPlaceholder}
-	replacers := []string{SelectConfigPlaceholderReplacer, ColumnConfigPlaceholderReplacer, WhereConfigPlaceholderReplacer, ValueConfigPlaceholderReplacer}
+	placeholders := []string{SelectConfigPlaceholder, ColumnConfigPlaceholder, WhereConfigPlaceholder, ValueConfigPlaceholder, ListOfValuesConfigPlaceholder}
+	replacers := []string{SelectConfigPlaceholderReplacer, ColumnConfigPlaceholderReplacer, WhereConfigPlaceholderReplacer, ValueConfigPlaceholderReplacer, ListOfValuesConfigPlaceholderReplacer}
 	patternValue := ""
 	var outputPatterns [][]sqlparser.SQLNode
 	for _, pattern := range patterns {
@@ -36,7 +36,7 @@ func ParsePatterns(patterns []string) ([][]sqlparser.SQLNode, error) {
 		}
 		statement, err := sqlparser.Parse(patternValue)
 		if err != nil {
-			log.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCensorQueryParseError).WithError(err).Errorln("Can't add specified pattern in blacklist handler")
+			log.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCensorQueryParseError).WithField("pattern", patternValue).WithError(err).Errorln("Can't add specified pattern in blacklist handler")
 			return nil, ErrPatternSyntaxError
 		}
 		var newPatternNodes []sqlparser.SQLNode

--- a/acra-censor/handlers/handlers_util_test.go
+++ b/acra-censor/handlers/handlers_util_test.go
@@ -453,7 +453,7 @@ func TestPatternsInWhereClauses(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Can't parse query <%s> with error <%s>", query, err.Error())
 			}
-			if !handleValuePattern([]sqlparser.SQLNode{parsedQuery}, []sqlparser.SQLNode{pattern}) {
+			if !handleWherePatterns([]sqlparser.SQLNode{parsedQuery}, []sqlparser.SQLNode{pattern}) {
 				t.Fatalf("Expected match in query <%s> with pattern <%s>", query, sqlparser.String(pattern))
 			}
 		}
@@ -463,7 +463,7 @@ func TestPatternsInWhereClauses(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Error <%s> with query <%s>", err.Error(), query)
 			}
-			if handleValuePattern([]sqlparser.SQLNode{parsedQuery}, []sqlparser.SQLNode{pattern}) {
+			if handleWherePatterns([]sqlparser.SQLNode{parsedQuery}, []sqlparser.SQLNode{pattern}) {
 				t.Fatalf("Expected not match in query <%s> with pattern <%s>", query, sqlparser.String(pattern))
 			}
 		}

--- a/acra-censor/handlers/handlers_util_test.go
+++ b/acra-censor/handlers/handlers_util_test.go
@@ -180,7 +180,7 @@ func TestSkipSubqueryValuePattern(t *testing.T) {
 		if !ok {
 			t.Fatal("Incorrect query syntax")
 		}
-		if !skipSubqueryValuePattern(patternSubexpr, querySubexpr) {
+		if !matchSubqueryPattern(patternSubexpr, querySubexpr) {
 			t.Fatalf("Expected true result with query - %s", query)
 		}
 	}


### PR DESCRIPTION
* support `WHERE age = (%%SUBQUERY%%)` that should match condition like `WHERE age=(select 12)` or `WHERE age=(select age from table1 union select age from table2)`
* support `WHERE age in (%%VALUE%%, %%VALUE%%)` - `WHERE age in (1, 'some string value')`
* support `WHERE age in (%%LIST_OF_VALUES%%)` - `WHERE age in (1, TRUE, FALSE, 'string')`
* support `WHERE age in (%%SUBQUERY%%)` - `WHERE age in (select age from table1)`
* support different variants like `WHERE column in (%%VALUE%%, 'special string' (%%SUBQUERY%%), %%LIST_OF_VALUES%%)` - `WHERE column in ('any value', 'special string', (select 1), 'val1', 'val2', 'val3')`

Notes:
* %%SUBQUERY%% placeholder should be wrapped with parentheses
* %%LIST_OF_VALUES%% expect at least 1 any value at the same place of query