### PR TITLE
support subquery in range comparison [T815, T817]

### DIFF
--- a/acra-censor/handlers/common.go
+++ b/acra-censor/handlers/common.go
@@ -25,8 +25,8 @@ import (
 
 // ParsePatterns replace placeholders with our values which used to match patterns and parse them with sqlparser
 func ParsePatterns(patterns []string) ([][]sqlparser.SQLNode, error) {
-	placeholders := []string{SelectConfigPlaceholder, ColumnConfigPlaceholder, WhereConfigPlaceholder, ValueConfigPlaceholder, ListOfValuesConfigPlaceholder}
-	replacers := []string{SelectConfigPlaceholderReplacer, ColumnConfigPlaceholderReplacer, WhereConfigPlaceholderReplacer, ValueConfigPlaceholderReplacer, ListOfValuesConfigPlaceholderReplacer}
+	placeholders := []string{SelectConfigPlaceholder, ColumnConfigPlaceholder, WhereConfigPlaceholder, ValueConfigPlaceholder, ListOfValuesConfigPlaceholder, SubqueryConfigPlaceholder}
+	replacers := []string{SelectConfigPlaceholderReplacer, ColumnConfigPlaceholderReplacer, WhereConfigPlaceholderReplacer, ValueConfigPlaceholderReplacer, ListOfValuesConfigPlaceholderReplacer, SubqueryConfigPlaceholderReplacer}
 	patternValue := ""
 	var outputPatterns [][]sqlparser.SQLNode
 	for _, pattern := range patterns {

--- a/acra-censor/handlers/common.go
+++ b/acra-censor/handlers/common.go
@@ -25,8 +25,8 @@ import (
 
 // ParsePatterns replace placeholders with our values which used to match patterns and parse them with sqlparser
 func ParsePatterns(patterns []string) ([][]sqlparser.SQLNode, error) {
-	placeholders := []string{SelectConfigPlaceholder, ColumnConfigPlaceholder, WhereConfigPlaceholder, ValueConfigPlaceholder}
-	replacers := []string{SelectConfigPlaceholderReplacer, ColumnConfigPlaceholderReplacer, WhereConfigPlaceholderReplacer, ValueConfigPlaceholderReplacer}
+	placeholders := []string{SelectConfigPlaceholder, ColumnConfigPlaceholder, WhereConfigPlaceholder, ValueConfigPlaceholder, ListOfValuesConfigPlaceholder}
+	replacers := []string{SelectConfigPlaceholderReplacer, ColumnConfigPlaceholderReplacer, WhereConfigPlaceholderReplacer, ValueConfigPlaceholderReplacer, ListOfValuesConfigPlaceholderReplacer}
 	patternValue := ""
 	var outputPatterns [][]sqlparser.SQLNode
 	for _, pattern := range patterns {
@@ -36,7 +36,7 @@ func ParsePatterns(patterns []string) ([][]sqlparser.SQLNode, error) {
 		}
 		statement, err := sqlparser.Parse(patternValue)
 		if err != nil {
-			log.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCensorQueryParseError).WithError(err).Errorln("Can't add specified pattern in blacklist handler")
+			log.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCensorQueryParseError).WithField("pattern", patternValue).WithError(err).Errorln("Can't add specified pattern in blacklist handler")
 			return nil, ErrPatternSyntaxError
 		}
 		var newPatternNodes []sqlparser.SQLNode

--- a/acra-censor/handlers/handlers_util.go
+++ b/acra-censor/handlers/handlers_util.go
@@ -345,12 +345,12 @@ func handleRangeCondition(patternNode, queryNode *sqlparser.RangeCond) bool {
 	if !reflect.DeepEqual(queryNode.Left, patternNode.Left) {
 		return false
 	}
-	if !matchValuePattern(patternNode.From, queryNode.From) {
+	if !(matchValuePattern(patternNode.From, queryNode.From) || matchSubqueryPattern(patternNode.From, queryNode.From)) {
 		if !reflect.DeepEqual(patternNode.From, queryNode.From) {
 			return false
 		}
 	}
-	if !matchValuePattern(patternNode.To, queryNode.To) {
+	if !(matchValuePattern(patternNode.To, queryNode.To) || matchSubqueryPattern(patternNode.To, queryNode.To)) {
 		if !reflect.DeepEqual(patternNode.To, queryNode.To) {
 			return false
 		}

--- a/acra-censor/handlers/handlers_util.go
+++ b/acra-censor/handlers/handlers_util.go
@@ -529,6 +529,9 @@ func IsEqualComparisonNodes(patternNode, queryNode *sqlparser.ComparisonExpr) bo
 			if isValuePattern(patternNode.Right) {
 				return true
 			}
+			if matchSubqueryPattern(patternNode.Right, queryNode.Right) {
+				return true
+			}
 		}
 		// pattern node hasn't %%VALUE%% pattern so compare their values as is
 		return reflect.DeepEqual(patternNode.Right, queryNode.Right)

--- a/acra-censor/handlers/handlers_util.go
+++ b/acra-censor/handlers/handlers_util.go
@@ -419,6 +419,15 @@ func handleWhereNode(patternNode, queryNode sqlparser.SQLNode) bool {
 				}
 			}
 			return false
+		case *sqlparser.ExistsExpr:
+			if queryExists, ok := queryWhereNode.(*sqlparser.ExistsExpr); ok {
+				if matchSubqueryPattern(patternWhereNode.(*sqlparser.ExistsExpr).Subquery, queryExists.Subquery) {
+					continue
+				}
+				// break switch to reflect.DeepEqual whole node
+				break
+			}
+			return false
 		}
 		// unknown and conditions without specific rules check recursively by values as is
 		if !reflect.DeepEqual(patternWhereNode, queryWhereNode) {

--- a/acra-censor/handlers/handlers_util_test.go
+++ b/acra-censor/handlers/handlers_util_test.go
@@ -453,7 +453,7 @@ func TestPatternsInWhereClauses(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Can't parse query <%s> with error <%s>", query, err.Error())
 			}
-			if !handleValuePattern([]sqlparser.SQLNode{parsedQuery}, []sqlparser.SQLNode{pattern}) {
+			if !handleWherePatterns([]sqlparser.SQLNode{parsedQuery}, []sqlparser.SQLNode{pattern}) {
 				t.Fatalf("Expected match in query <%s> with pattern <%s>", query, sqlparser.String(pattern))
 			}
 		}
@@ -463,7 +463,7 @@ func TestPatternsInWhereClauses(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Error <%s> with query <%s>", err.Error(), query)
 			}
-			if handleValuePattern([]sqlparser.SQLNode{parsedQuery}, []sqlparser.SQLNode{pattern}) {
+			if handleWherePatterns([]sqlparser.SQLNode{parsedQuery}, []sqlparser.SQLNode{pattern}) {
 				t.Fatalf("Expected not match in query <%s> with pattern <%s>", query, sqlparser.String(pattern))
 			}
 		}

--- a/acra-censor/handlers/handlers_util_test.go
+++ b/acra-censor/handlers/handlers_util_test.go
@@ -219,6 +219,8 @@ func TestPatternsInWhereClauses(t *testing.T) {
 		fmt.Sprintf("select 1 from t where b='qwe' and t IN ((%s))", SubqueryConfigPlaceholder),
 		// column IN (%%VALUE, %%SUBQUERY%%, 1, %%LIST_OF_VALUES%%)
 		fmt.Sprintf("select 1 from t where b='qwe' and t IN (%s, (%s), 1, %s)", ValueConfigPlaceholder, SubqueryConfigPlaceholder, ListOfValuesConfigPlaceholder),
+		// age = (%%SUBQUERY%%)
+		fmt.Sprintf("select 1 from t where b='qwe' and a=(%s)", SubqueryConfigPlaceholder),
 	}
 	parsedPatterns, err := ParsePatterns(patterns)
 	if err != nil {
@@ -343,6 +345,13 @@ func TestPatternsInWhereClauses(t *testing.T) {
 			// anything except subquery on subquery placeholder
 			"select 1 from t where b='qwe' and t IN (1, 2, 1, 3)",
 		},
+		// age = (%%SUBQUERY%%)
+		[]string{
+			// not subquery
+			"select 1 from t where b='qwe' and a=1",
+			// func instead subquery
+			"select 1 from t where b='qwe' and a=someFunc(2)",
+		},
 	}
 	matchableQueries := [][]string{
 		// left side value placeholder
@@ -440,6 +449,11 @@ func TestPatternsInWhereClauses(t *testing.T) {
 			"select 1 from t where b='qwe' and t IN (1, (select 1), 1, 1, 2)",
 			"select 1 from t where b='qwe' and t IN (1, (select 1 from table1), 1, 1, 2)",
 			"select 1 from t where b='qwe' and t IN (1, (select column1 from table1 where a=1 union select column1 from table2 where b=1), 1, 1, 2)",
+		},
+		// age = (%%SUBQUERY%%)
+		[]string{
+			"select 1 from t where b='qwe' and a=(select 1)",
+			"select 1 from t where b='qwe' and a=(select 1 from table1 union select 2 from table2)",
 		},
 	}
 	if len(patterns) != len(matchableQueries) || len(matchableQueries) != len(notMatchableQueries) {

--- a/acra-censor/handlers/handlers_util_test.go
+++ b/acra-censor/handlers/handlers_util_test.go
@@ -180,7 +180,7 @@ func TestSkipSubqueryValuePattern(t *testing.T) {
 		if !ok {
 			t.Fatal("Incorrect query syntax")
 		}
-		if !skipSubqueryValuePattern(patternSubexpr, querySubexpr) {
+		if !matchSubqueryPattern(patternSubexpr, querySubexpr) {
 			t.Fatalf("Expected true result with query - %s", query)
 		}
 	}


### PR DESCRIPTION
* support `WHERE a=(%%SUBQUERY%%)` - `WHERE a = (select 1)`
* support `WHERE a BETWEEN (%%SUBQUERY%%) and %%VALUE%%` - `WHERE a BETWEEN (select 1) and 'some value'`
* support `WHERE EXISTS(%%SUBQUERY%%)`