### PR TITLE
dry run rotate [T813]

### DIFF
--- a/cmd/acra-connector/acra-connector.go
+++ b/cmd/acra-connector/acra-connector.go
@@ -164,7 +164,7 @@ func handleConnection(config *Config, connection net.Conn) {
 
 	}
 	if err := acraConn.Close(); err != nil {
-		log.WithError(err).Errorln("Error on closing connection with %s", connector_mode.ModeToServiceName(config.Mode))
+		log.WithError(err).Errorf("Error on closing connection with %s", connector_mode.ModeToServiceName(config.Mode))
 	}
 }
 

--- a/cmd/acra-rotate/acra-rotate.go
+++ b/cmd/acra-rotate/acra-rotate.go
@@ -87,6 +87,9 @@ func main() {
 		log.WithError(err).Errorln("Can't initialize keystore")
 		os.Exit(1)
 	}
+	if *dryRun {
+		log.Infoln("Rotating in dry-run mode")
+	}
 	if *fileMapConfig != "" {
 		runFileRotation(*fileMapConfig, keystorage, *dryRun)
 	}
@@ -115,7 +118,7 @@ func main() {
 			os.Exit(1)
 		}
 		if err := db.Ping(); err != nil {
-			log.WithError(err).Errorln("Error on database ping", *connectionString)
+			log.WithError(err).Errorln("Error on pinging database", *connectionString)
 			os.Exit(1)
 		}
 		log.WithFields(log.Fields{"select_query": *sqlSelect, "update_query": *sqlUpdate}).Infoln("Rotate data in database")

--- a/cmd/acra-rotate/dbRotation.go
+++ b/cmd/acra-rotate/dbRotation.go
@@ -36,13 +36,13 @@ func rotateDb(selectQuery, updateQuery string, db *sql.DB, keystore keystore.Key
 
 	rows, err := db.Query(selectQuery)
 	if err != nil {
-		log.WithError(err).Errorf("Can't fetch result")
+		log.WithError(err).Errorf("Can't fetch result with sql_select query")
 		return false
 	}
 	defer rows.Close()
 	columns, err := rows.Columns()
 	if err != nil {
-		log.WithError(err).Errorln("Can't fetch info about result columns")
+		log.WithError(err).Errorln("Can't fetch metadata for result columns")
 		return false
 	}
 	if len(columns) < 2 {
@@ -97,7 +97,7 @@ func rotateDb(selectQuery, updateQuery string, db *sql.DB, keystore keystore.Key
 		if !dryRun {
 			_, err = db.Exec(updateQuery, extraArgs...)
 			if err != nil {
-				logger.WithError(err).Errorln("Can't update data in db via update query")
+				logger.WithError(err).Errorln("Can't update data in db via sql_update query")
 				return false
 			}
 		}

--- a/cmd/acra-rotate/dbRotation.go
+++ b/cmd/acra-rotate/dbRotation.go
@@ -19,90 +19,21 @@ package main
 import (
 	"database/sql"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
-	"github.com/cossacklabs/acra/acra-writer"
-	"github.com/cossacklabs/acra/decryptor/base"
 	"github.com/cossacklabs/acra/keystore"
 	"github.com/cossacklabs/acra/utils"
-	"github.com/cossacklabs/themis/gothemis/keys"
 	log "github.com/sirupsen/logrus"
 	"reflect"
 )
 
-type keyPair struct {
-	oldPrivatekey *keys.PrivateKey
-	NewPublicKey  *keys.PublicKey
-}
-
-// keyRotationStore store previous privateKeys and new public keys after rotation to use same private/public keys during rotation
-type keyRotationStore struct {
-	keys     map[string]*keyPair
-	keystore keystore.KeyStore
-}
-
-// Marshal encode new public keys for zones to json
-func (store *keyRotationStore) Marshal() ([]byte, error) {
-	// encode to json in compatible format as in file rotation
-	const PublicKey = "new_public_key"
-	output := make(map[string]map[string][]byte)
-	for id, keypair := range store.keys {
-		output[id] = map[string][]byte{PublicKey: keypair.NewPublicKey.Value}
-	}
-	return json.Marshal(output)
-}
-
-// rotateKey load current private key to memory, rotate and save new public key in memory
-func (store *keyRotationStore) rotateKey(id []byte) error {
-	idStr := string(id)
-	privateKey, err := store.keystore.GetZonePrivateKey(id)
-	if err != nil {
-		log.WithError(err).Errorf("Can't load current private key of zone=%s", string(id))
-		return err
-	}
-	newPublicKey, err := store.keystore.RotateZoneKey(id)
-	if err != nil {
-		log.WithError(err).Errorf("Rotate private key of zone=%s", string(id))
-		return err
-	}
-	store.keys[idStr] = &keyPair{oldPrivatekey: privateKey, NewPublicKey: &keys.PublicKey{newPublicKey}}
-	return nil
-}
-
-// getPublicKey return new rotated public key of zone
-func (store *keyRotationStore) getPublicKey(id []byte) (*keys.PublicKey, error) {
-	idStr := string(id)
-	if keypair, ok := store.keys[idStr]; ok {
-		return keypair.NewPublicKey, nil
-	}
-	if err := store.rotateKey(id); err != nil {
-		return nil, err
-	}
-	keypair := store.keys[idStr]
-	return keypair.NewPublicKey, nil
-}
-
-// getPrivateKey return private key before rotation
-func (store *keyRotationStore) getPrivateKey(id []byte) (*keys.PrivateKey, error) {
-	idStr := string(id)
-	if keypair, ok := store.keys[idStr]; ok {
-		return keypair.oldPrivatekey, nil
-	}
-	if err := store.rotateKey(id); err != nil {
-		return nil, err
-	}
-	keypair := store.keys[idStr]
-	return keypair.oldPrivatekey, nil
-}
-
-func (store *keyRotationStore) clear() {
-	for _, keypair := range store.keys {
-		utils.FillSlice(0, keypair.oldPrivatekey.Value)
-	}
-}
-
 // rotateDb execute selectQuery to fetch AcraStructs with related zone ids, decrypt with rotated zone keys and
-func rotateDb(selectQuery, updateQuery string, db *sql.DB, keystore keystore.KeyStore, encoder utils.BinaryEncoder) bool {
+func rotateDb(selectQuery, updateQuery string, db *sql.DB, keystore keystore.KeyStore, encoder utils.BinaryEncoder, dryRun bool) bool {
+	rotator, err := newRotator(keystore)
+	if err != nil {
+		return false
+	}
+	defer rotator.clearKeys()
+
 	rows, err := db.Query(selectQuery)
 	if err != nil {
 		log.WithError(err).Errorf("Can't fetch result")
@@ -118,10 +49,6 @@ func rotateDb(selectQuery, updateQuery string, db *sql.DB, keystore keystore.Key
 		log.Errorln("Result has < 2 columns. Expected at least ZoneId and AcraStruct")
 		return false
 	}
-
-	keysStore := &keyRotationStore{keystore: keystore, keys: make(map[string]*keyPair)}
-	// zeroing private keys at end
-	defer keysStore.clear()
 
 	row := make([]interface{}, len(columns))
 	rowPointers := make([]interface{}, len(columns))
@@ -152,43 +79,36 @@ func rotateDb(selectQuery, updateQuery string, db *sql.DB, keystore keystore.Key
 			return false
 		}
 		logger := log.WithFields(log.Fields{"ZoneId": string(acraStructID)})
-		logger.Infof("Rotate AcraStruct with ZoneId=%s", string(acraStructID))
+		logger.Infof("Rotate AcraStruct")
 
 		// rotate
-		privateKey, err := keysStore.getPrivateKey(acraStructID)
-		if err != nil {
-			logger.WithField("acrastruct", hex.EncodeToString(acraStruct)).WithError(err).Errorln("Can't get private key")
-			return false
-		}
-		publicKey, err := keysStore.getPublicKey(acraStructID)
-		if err != nil {
-			logger.WithField("acrastruct", hex.EncodeToString(acraStruct)).WithError(err).Errorln("Can't load public key")
-			return false
-		}
-		decrypted, err := base.DecryptAcrastruct(acraStruct, privateKey, acraStructID)
-		if err != nil {
-			logger.WithField("acrastruct", hex.EncodeToString(acraStruct)).WithError(err).Errorln("Can't decrypt AcraStruct")
-			return false
-		}
-		rotated, err := acrawriter.CreateAcrastruct(decrypted, publicKey, acraStructID)
+		rotated, err := rotator.rotateAcrastruct(acraStructID, acraStruct)
 		if err != nil {
 			logger.WithField("acrastruct", hex.EncodeToString(acraStruct)).WithError(err).Errorln("Can't rotate data")
 			return false
 		}
-		utils.FillSlice(0, decrypted)
+
 		rotatedStr := encoder.Encode(rotated)
 		if len(rowPointers) > 2 {
 			extraArgs = append([]interface{}{rotatedStr}, row[:len(rowPointers)-2]...)
 		} else {
 			extraArgs = []interface{}{rotatedStr}
 		}
-		_, err = db.Exec(updateQuery, extraArgs...)
-		if err != nil {
-			logger.WithField("acrastruct", hex.EncodeToString(acraStruct)).WithError(err).Errorln("Can't update data in db via update query")
+		if !dryRun {
+			_, err = db.Exec(updateQuery, extraArgs...)
+			if err != nil {
+				logger.WithError(err).Errorln("Can't update data in db via update query")
+				return false
+			}
+		}
+	}
+	if !dryRun {
+		if err := rotator.saveRotatedKeys(); err != nil {
+			log.WithError(err).Errorln("Can't save rotated keys")
 			return false
 		}
 	}
-	jsonOutput, err := keysStore.Marshal()
+	jsonOutput, err := rotator.marshal()
 	if err != nil {
 		log.WithError(err).Errorln("Can't encode to json")
 		return false

--- a/cmd/acra-rotate/fileRotation.go
+++ b/cmd/acra-rotate/fileRotation.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"github.com/cossacklabs/acra/keystore"
@@ -71,7 +72,7 @@ func rotateFiles(fileMap ZoneIDFileMap, keyStore keystore.KeyStore, dryRun bool)
 
 			rotated, err := rotator.rotateAcrastruct(binZoneID, acraStruct)
 			if err != nil {
-				fileLogger.WithError(err).Errorln("Can't re-encrypt AcraStruct with rotated zone key")
+				fileLogger.WithField("acrastruct", hex.EncodeToString(acraStruct)).WithError(err).Errorln("Can't rotate data")
 				return nil, err
 			}
 			stat, err := os.Stat(path)

--- a/cmd/acra-rotate/rotator.go
+++ b/cmd/acra-rotate/rotator.go
@@ -57,12 +57,13 @@ func (rotator *keyRotator) rotateAcrastruct(zoneID, acrastruct []byte) ([]byte, 
 		logger.WithField("acrastruct", hex.EncodeToString(acrastruct)).WithError(err).Errorln("Can't get private key")
 		return nil, err
 	}
+	defer utils.FillSlice(0, privateKey.Value)
 	decrypted, err := base.DecryptAcrastruct(acrastruct, privateKey, zoneID)
 	if err != nil {
 		logger.WithField("acrastruct", hex.EncodeToString(acrastruct)).WithError(err).Errorln("Can't decrypt AcraStruct")
 		return nil, err
 	}
-	utils.FillSlice(0, privateKey.Value)
+	defer utils.FillSlice(0, decrypted)
 	publicKey, err := rotator.getRotatedPublicKey(zoneID)
 	if err != nil {
 		logger.WithField("acrastruct", hex.EncodeToString(acrastruct)).WithError(err).Errorln("Can't load public key")
@@ -73,7 +74,6 @@ func (rotator *keyRotator) rotateAcrastruct(zoneID, acrastruct []byte) ([]byte, 
 		logger.WithField("acrastruct", hex.EncodeToString(acrastruct)).WithError(err).Errorln("Can't rotate data")
 		return nil, err
 	}
-	utils.FillSlice(0, decrypted)
 	return rotated, nil
 }
 

--- a/cmd/acra-rotate/rotator.go
+++ b/cmd/acra-rotate/rotator.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2018, Cossack Labs Limited
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"github.com/cossacklabs/acra/acra-writer"
+	"github.com/cossacklabs/acra/decryptor/base"
+	"github.com/cossacklabs/acra/keystore"
+	"github.com/cossacklabs/acra/utils"
+	"github.com/cossacklabs/themis/gothemis/keys"
+	log "github.com/sirupsen/logrus"
+)
+
+type keyRotator struct {
+	keystore    keystore.KeyStore
+	newKeypairs map[string]*keys.Keypair
+}
+
+func newRotator(store keystore.KeyStore) (*keyRotator, error) {
+	return &keyRotator{keystore: store, newKeypairs: make(map[string]*keys.Keypair)}, nil
+}
+func (rotator *keyRotator) getRotatedPublicKey(zoneID []byte) (*keys.PublicKey, error) {
+	keypair, ok := rotator.newKeypairs[string(zoneID)]
+	if ok {
+		return keypair.Public, nil
+	}
+	newKeypair, err := keys.New(keys.KEYTYPE_EC)
+	if err != nil {
+		return nil, err
+	}
+	rotator.newKeypairs[string(zoneID)] = newKeypair
+	return newKeypair.Public, nil
+}
+
+func (rotator *keyRotator) rotateAcrastruct(zoneID, acrastruct []byte) ([]byte, error) {
+	logger := log.WithFields(log.Fields{"ZoneId": string(zoneID)})
+	logger.Infof("Rotate AcraStruct")
+	// rotate
+	privateKey, err := rotator.keystore.GetZonePrivateKey(zoneID)
+	if err != nil {
+		logger.WithField("acrastruct", hex.EncodeToString(acrastruct)).WithError(err).Errorln("Can't get private key")
+		return nil, err
+	}
+	decrypted, err := base.DecryptAcrastruct(acrastruct, privateKey, zoneID)
+	if err != nil {
+		logger.WithField("acrastruct", hex.EncodeToString(acrastruct)).WithError(err).Errorln("Can't decrypt AcraStruct")
+		return nil, err
+	}
+	utils.FillSlice(0, privateKey.Value)
+	publicKey, err := rotator.getRotatedPublicKey(zoneID)
+	if err != nil {
+		logger.WithField("acrastruct", hex.EncodeToString(acrastruct)).WithError(err).Errorln("Can't load public key")
+		return nil, err
+	}
+	rotated, err := acrawriter.CreateAcrastruct(decrypted, publicKey, zoneID)
+	if err != nil {
+		logger.WithField("acrastruct", hex.EncodeToString(acrastruct)).WithError(err).Errorln("Can't rotate data")
+		return nil, err
+	}
+	utils.FillSlice(0, decrypted)
+	return rotated, nil
+}
+
+func (rotator *keyRotator) saveRotatedKeys() error {
+	for zoneID, keypair := range rotator.newKeypairs {
+		if err := rotator.keystore.SaveZoneKeypair([]byte(zoneID), keypair); err != nil {
+			log.WithField("zoneID", zoneID).WithError(err).Errorln("Can't save rotated keypair")
+			return err
+		}
+	}
+	return nil
+}
+
+func (rotator *keyRotator) clearKeys() {
+	for _, keypair := range rotator.newKeypairs {
+		utils.FillSlice(0, keypair.Private.Value)
+	}
+}
+
+func (rotator *keyRotator) marshal() ([]byte, error) {
+	const PublicKey = "new_public_key"
+	output := make(map[string]map[string][]byte)
+	for id, keypair := range rotator.newKeypairs {
+		output[string(id)] = map[string][]byte{PublicKey: keypair.Public.Value}
+	}
+	return json.Marshal(output)
+}

--- a/cmd/acra-translator/grpc_api/api_test.go
+++ b/cmd/acra-translator/grpc_api/api_test.go
@@ -30,6 +30,18 @@ func (*testKeystore) GetPeerPublicKey(id []byte) (*keys.PublicKey, error) {
 	panic("implement me")
 }
 
+func (*testKeystore) SaveDataEncryptionKeys(id []byte, keypair *keys.Keypair) error {
+	panic("implement me")
+}
+func (*testKeystore) SaveTranslatorKeypair(id []byte, keypair *keys.Keypair) error {
+	panic("implement me")
+}
+func (*testKeystore) SaveServerKeypair(id []byte, keypair *keys.Keypair) error { panic("implement me") }
+func (*testKeystore) SaveConnectorKeypair(id []byte, keypair *keys.Keypair) error {
+	panic("implement me")
+}
+func (*testKeystore) SaveZoneKeypair(id []byte, keypair *keys.Keypair) error { panic("implement me") }
+
 var ErrKeyNotFound = errors.New("some error")
 
 func (keystore *testKeystore) GetZonePrivateKey(id []byte) (*keys.PrivateKey, error) {

--- a/cmd/acra-translator/http_api/mock_keystorage.go
+++ b/cmd/acra-translator/http_api/mock_keystorage.go
@@ -26,6 +26,18 @@ type testKeystore struct {
 	PoisonKeyPair *keys.Keypair
 }
 
+func (*testKeystore) SaveDataEncryptionKeys(id []byte, keypair *keys.Keypair) error {
+	panic("implement me")
+}
+func (*testKeystore) SaveTranslatorKeypair(id []byte, keypair *keys.Keypair) error {
+	panic("implement me")
+}
+func (*testKeystore) SaveServerKeypair(id []byte, keypair *keys.Keypair) error { panic("implement me") }
+func (*testKeystore) SaveConnectorKeypair(id []byte, keypair *keys.Keypair) error {
+	panic("implement me")
+}
+func (*testKeystore) SaveZoneKeypair(id []byte, keypair *keys.Keypair) error { panic("implement me") }
+
 func (*testKeystore) GetPrivateKey(id []byte) (*keys.PrivateKey, error) {
 	panic("implement me")
 }

--- a/cmd/acra-translator/server.go
+++ b/cmd/acra-translator/server.go
@@ -172,12 +172,11 @@ func (server *ReaderServer) HandleConnectionString(parentContext context.Context
 	select {
 	case <-parentContext.Done():
 		log.WithError(parentContext.Err()).Debugln("Exit from handling connection string. Close all connections")
+		outErr = parentContext.Err()
 	case outErr = <-errCh:
 		log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorTranslatorCantAcceptNewHTTPConnection).
 			Errorln("Error on accepting new connections")
 		server.Stop()
-		os.Exit(1)
-
 	}
 	return outErr
 }
@@ -220,6 +219,8 @@ func (server *ReaderServer) Start(parentContext context.Context) {
 			if err != nil {
 				log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorTranslatorCantHandleHTTPConnection).
 					Errorln("Took error on handling http requests")
+				server.Stop()
+				os.Exit(1)
 			}
 		}()
 	}

--- a/decryptor/mysql/decryptor_test.go
+++ b/decryptor/mysql/decryptor_test.go
@@ -59,6 +59,17 @@ func (keystore *testKeystore) GetAuthKey(remove bool) ([]byte, error) {
 	return nil, nil
 }
 func (keystore *testKeystore) Reset() {}
+func (*testKeystore) SaveDataEncryptionKeys(id []byte, keypair *keys.Keypair) error {
+	panic("implement me")
+}
+func (*testKeystore) SaveTranslatorKeypair(id []byte, keypair *keys.Keypair) error {
+	panic("implement me")
+}
+func (*testKeystore) SaveServerKeypair(id []byte, keypair *keys.Keypair) error { panic("implement me") }
+func (*testKeystore) SaveConnectorKeypair(id []byte, keypair *keys.Keypair) error {
+	panic("implement me")
+}
+func (*testKeystore) SaveZoneKeypair(id []byte, keypair *keys.Keypair) error { panic("implement me") }
 
 func getDecryptor(keystore keystore.KeyStore) *MySQLDecryptor {
 	dataDecryptor := binary.NewBinaryDecryptor()

--- a/keystore/keystore.go
+++ b/keystore/keystore.go
@@ -141,22 +141,34 @@ type SecureSessionKeyStore interface {
 // to encrypt and decrypt AcraStructs with and without Zones,
 // to find Poison records.
 // Moreover KeyStore can generate various Keys using ClientID.
+// Save*Keypair methods save or overwrite existing keypair with new
+// Genenerate*Keys - generate new keypair and save
 type KeyStore interface {
 	SecureSessionKeyStore
 	GetZonePrivateKey(id []byte) (*keys.PrivateKey, error)
 	HasZonePrivateKey(id []byte) bool
 	GetServerDecryptionPrivateKey(id []byte) (*keys.PrivateKey, error)
+
 	// return id, public key, error
 	GenerateZoneKey() ([]byte, []byte, error)
+	SaveZoneKeypair(id []byte, keypair *keys.Keypair) error
+
 	// return new_public_key, error
 	RotateZoneKey(zoneID []byte) ([]byte, error)
 
+	SaveConnectorKeypair(id []byte, keypair *keys.Keypair) error
 	GenerateConnectorKeys(id []byte) error
+
+	SaveServerKeypair(id []byte, keypair *keys.Keypair) error
 	GenerateServerKeys(id []byte) error
+
+	SaveTranslatorKeypair(id []byte, keypair *keys.Keypair) error
 	GenerateTranslatorKeys(id []byte) error
 
 	// generate key pair for data encryption/decryption
 	GenerateDataEncryptionKeys(id []byte) error
+	SaveDataEncryptionKeys(id []byte, keypair *keys.Keypair) error
+
 	GetPoisonKeyPair() (*keys.Keypair, error)
 
 	GetAuthKey(remove bool) ([]byte, error)

--- a/zone/zone_id_matcher_test.go
+++ b/zone/zone_id_matcher_test.go
@@ -70,6 +70,17 @@ func (keystore *TestKeyStore) GetAuthKey(remove bool) ([]byte, error) {
 	return nil, nil
 }
 func (storage *TestKeyStore) GetPoisonKeyPair() (*keys.Keypair, error) { return nil, nil }
+func (*TestKeyStore) SaveDataEncryptionKeys(id []byte, keypair *keys.Keypair) error {
+	panic("implement me")
+}
+func (*TestKeyStore) SaveTranslatorKeypair(id []byte, keypair *keys.Keypair) error {
+	panic("implement me")
+}
+func (*TestKeyStore) SaveServerKeypair(id []byte, keypair *keys.Keypair) error { panic("implement me") }
+func (*TestKeyStore) SaveConnectorKeypair(id []byte, keypair *keys.Keypair) error {
+	panic("implement me")
+}
+func (*TestKeyStore) SaveZoneKeypair(id []byte, keypair *keys.Keypair) error { panic("implement me") }
 
 func testZoneIDMatcher(t *testing.T) {
 	var keystorage keystore.KeyStore = &TestKeyStore{}


### PR DESCRIPTION
`acra-rotate` with flag `--dry-run` will fetch acrastructs (from files or database), decrypt, rotate in memory keys, encrypt with new public keys and print result json with new public keys without saving rotated keys and acrastructs (to filesystem or database)