### PR TITLE
log timestamp.Now only if not set

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
       - run: pip3 install -r $HOME/project/tests/requirements.txt
       # install from sources because pip install git+https://github.com/mysql/mysql-connector-python not support recursive submodules
       - run: git clone https://github.com/Lagovas/mysql-connector-python; cd mysql-connector-python; sudo python3 setup.py clean build_py install_lib
-      - run: cd $HOME && GOPATH=$HOME/$GOPATH_FOLDER go get -u -v github.com/golang/lint/golint
+      - run: cd $HOME && GOPATH=$HOME/$GOPATH_FOLDER go get -u -v golang.org/x/lint/golint
       - run: sudo ldconfig
     # testing
       # check that code formatted with gofmt

--- a/logging/log_formatters.go
+++ b/logging/log_formatters.go
@@ -154,7 +154,9 @@ var (
 // Note: the given entry is copied and not changed during the formatting process.
 func (f AcraJSONFormatter) Format(e *logrus.Entry) ([]byte, error) {
 	ne := copyEntry(e, f.Fields)
-	ne.Data[FieldKeyUnixTime] = unixTimeWithMilliseconds(e)
+	if _, ok := ne.Data[FieldKeyUnixTime]; !ok {
+		ne.Data[FieldKeyUnixTime] = unixTimeWithMilliseconds(e)
+	}
 	dataBytes, err := f.Formatter.Format(ne)
 	releaseEntry(ne)
 	return dataBytes, err
@@ -165,16 +167,22 @@ func (f AcraJSONFormatter) Format(e *logrus.Entry) ([]byte, error) {
 // Note: the given entry is copied and not changed during the formatting process.
 func (f AcraCEFFormatter) Format(e *logrus.Entry) ([]byte, error) {
 	ne := copyEntry(e, f.Fields)
-	ne.Data[FieldKeyUnixTime] = unixTimeWithMilliseconds(e)
+	if _, ok := ne.Data[FieldKeyUnixTime]; !ok {
+		ne.Data[FieldKeyUnixTime] = unixTimeWithMilliseconds(e)
+	}
 	dataBytes, err := f.CEFTextFormatter.Format(ne)
 	releaseEntry(ne)
 	return dataBytes, err
 }
 
-func unixTimeWithMilliseconds(e *logrus.Entry) string {
-	nanos := e.Time.UnixNano()
+// TimeToString return string representation of timestamp with milliseconds
+func TimeToString(t time.Time) string {
+	nanos := t.UnixNano()
 	millis := nanos / 1000000
 	millisf := float64(millis) / 1000.0
-
 	return fmt.Sprintf("%.3f", millisf)
+}
+
+func unixTimeWithMilliseconds(e *logrus.Entry) string {
+	return TimeToString(e.Time)
 }


### PR DESCRIPTION
check that entry hasn't timestamp and only then add it before logging to not override timestamp if it was set before

use case: code that collect some log entries with timestamps before export and periodically print/export it. so now if code collect log entries with correct timestamps then logger will override it