### PR TITLE
add tracing with opencensus

### DIFF
--- a/cmd/acra-connector/acra-connector.go
+++ b/cmd/acra-connector/acra-connector.go
@@ -151,7 +151,7 @@ func handleConnection(config *Config, connection net.Conn) {
 			Errorln("Can't wrap connection")
 		span.SetStatus(trace.Status{Code: trace.StatusCodeUnknown})
 		if err := acraConn.Close(); err != nil {
-			logger.WithError(err).Errorln("Error on closing connection with AcraServer")
+			logger.WithError(err).Errorf("Error on closing connection with %v", connector_mode.ModeToServiceName(config.Mode))
 		}
 		wrapSpan.End()
 		return

--- a/cmd/acra-connector/acra-connector.go
+++ b/cmd/acra-connector/acra-connector.go
@@ -217,6 +217,8 @@ type Config struct {
 }
 
 func main() {
+	log.Infof("Starting service %v", ServiceName)
+
 	loggingFormat := flag.String("logging_format", "plaintext", "Logging format: plaintext, json or CEF")
 	keysDir := flag.String("keys_dir", keystore.DefaultKeyDirShort, "Folder from which will be loaded keys")
 	clientID := flag.String("client_id", "", "Client ID")
@@ -263,9 +265,6 @@ func main() {
 			Errorln("Can't parse args")
 		os.Exit(1)
 	}
-
-	log.Infof("Starting service %v", ServiceName)
-	logging.CustomizeLogging(*loggingFormat, ServiceName)
 
 	// if log format was overridden
 	logging.CustomizeLogging(*loggingFormat, ServiceName)

--- a/cmd/acra-connector/acra-connector.go
+++ b/cmd/acra-connector/acra-connector.go
@@ -24,10 +24,13 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"flag"
 	"fmt"
 	log "github.com/sirupsen/logrus"
+	"go.opencensus.io/exporter/jaeger"
+	"go.opencensus.io/trace"
 	"io"
 	"net"
 	"os"
@@ -77,24 +80,36 @@ func handleApiConnection(config *Config, connection net.Conn) {
 }
 
 func handleConnection(config *Config, connection net.Conn) {
+	options := []trace.StartOption{trace.WithSpanKind(trace.SpanKindClient)}
+	ctx := logging.SetTraceStatus(context.Background(), config.TraceToLog)
+	if config.Tracing {
+		options = append(options, trace.WithSampler(trace.AlwaysSample()))
+	} else {
+		options = append(options, trace.WithSampler(trace.NeverSample()))
+	}
+	ctx, span := trace.StartSpan(ctx, "handleConnection", options...)
+	defer span.End()
+
+	logger := logging.NewLoggerWithTrace(ctx)
+
 	defer func() {
-		log.Infoln("Close connection with client")
+		logger.Infoln("Close connection with client")
 		if err := connection.Close(); err != nil {
-			log.WithError(err).Errorln("Error on closing client's connection")
+			logger.WithError(err).Errorln("Error on closing client's connection")
 		}
 	}()
 
 	if !(config.DisableUserCheck) {
 		host, port, err := net.SplitHostPort(connection.RemoteAddr().String())
 		if nil != err {
-			log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantStartConnection).
+			logger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantStartConnection).
 				Errorln("Can't parse client remote address")
 			return
 		}
 		if host == "127.0.0.1" {
 			netstat, err := exec.Command("sh", "-c", "netstat -atlnpe | awk '/:"+port+" */ {print $7}'").Output()
 			if nil != err {
-				log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantStartConnection).
+				logger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantStartConnection).
 					Errorln("Can't get owner UID of localhost client connection")
 				return
 			}
@@ -102,11 +117,11 @@ func handleConnection(config *Config, connection net.Conn) {
 			correctPeer := false
 			userID, err := user.Current()
 			if nil != err {
-				log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantStartConnection).
+				logger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantStartConnection).
 					Errorln("Can't get current user UID")
 				return
 			}
-			log.Infof("%v\ncur_user=%v", parsedNetstat, userID.Uid)
+			logger.Infof("%v\ncur_user=%v", parsedNetstat, userID.Uid)
 			for i := 0; i < len(parsedNetstat); i++ {
 				if _, err := strconv.Atoi(parsedNetstat[i]); err == nil && parsedNetstat[i] != userID.Uid {
 					correctPeer = true
@@ -114,7 +129,7 @@ func handleConnection(config *Config, connection net.Conn) {
 				}
 			}
 			if !correctPeer {
-				log.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantStartConnection).
+				logger.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantStartConnection).
 					Errorln("Client application and ssproxy need to be start from different users")
 				return
 			}
@@ -123,48 +138,66 @@ func handleConnection(config *Config, connection net.Conn) {
 
 	acraConn, err := network.Dial(config.OutgoingConnectionString)
 	if err != nil {
-		log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantStartConnection).
-			Errorln("Can't connect to AcraServer")
+		msg := "Can't connect to AcraServer"
+		logger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantStartConnection).
+			Errorln(msg)
+		span.SetStatus(trace.Status{Code: trace.StatusCodeUnknown, Message: msg})
 		return
 	}
-
-	acraConnWrapped, err := config.ConnectionWrapper.WrapClient(config.ClientID, acraConn)
+	_, wrapSpan := trace.StartSpan(ctx, "WrapClient")
+	acraConnWrapped, err := config.ConnectionWrapper.WrapClient(ctx, config.ClientID, acraConn)
 	if err != nil {
-		log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantWrapConnection).
+		logger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantWrapConnection).
 			Errorln("Can't wrap connection")
+		span.SetStatus(trace.Status{Code: trace.StatusCodeUnknown})
 		if err := acraConn.Close(); err != nil {
-			log.WithError(err).Errorln("Error on closing connection with AcraServer")
+			logger.WithError(err).Errorln("Error on closing connection with AcraServer")
 		}
+		wrapSpan.End()
+		return
+	}
+	wrapSpan.End()
+	defer func() {
+		if err := acraConnWrapped.Close(); err != nil {
+			logger.WithError(err).Errorln("Error on closing wrapped connection to Acra-Server")
+		}
+	}()
+
+	if err := network.SendTrace(ctx, acraConnWrapped); err != nil {
+		logger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorTracingCantSendTrace).
+			Errorln("Can't send trace data")
+		span.SetStatus(trace.Status{Code: trace.StatusCodeUnknown})
 		return
 	}
 
 	toAcraErrCh := make(chan error, 1)
 	fromAcraErrCh := make(chan error, 1)
-	go network.Proxy(connection, acraConnWrapped, toAcraErrCh)
-	go network.Proxy(acraConnWrapped, connection, fromAcraErrCh)
+	go network.ProxyWithTracing(ctx, connection, acraConnWrapped, toAcraErrCh)
+	go network.ProxyWithTracing(ctx, acraConnWrapped, connection, fromAcraErrCh)
 	select {
 	case err = <-toAcraErrCh:
-		log.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantStartConnection).
+		logger.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantStartConnection).
 			WithError(err).Errorln("Error from connection with client")
 	case err = <-fromAcraErrCh:
-		log.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantStartConnection).WithError(err).
+		logger.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantStartConnection).WithError(err).
 			Errorln("Error from connection with AcraServer")
 	}
 	if err != nil {
 		if err == io.EOF {
-			log.Debugln("Connection closed")
+			logger.Debugln("Connection closed")
 		} else {
-			log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantStartConnection).
+			logger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantStartConnection).
 				Errorln("Connector error")
+			span.SetStatus(trace.Status{Code: trace.StatusCodeUnknown})
 		}
 	}
-	log.Infoln("Close wrapped connection with AcraServer")
+	logger.Infoln("Close wrapped connection with AcraServer")
 	if err := acraConnWrapped.Close(); err != nil {
-		log.WithError(err).Errorf("Error on closing wrapped connection with %s", connector_mode.ModeToServiceName(config.Mode))
+		logger.WithError(err).Errorf("Error on closing wrapped connection with %s", connector_mode.ModeToServiceName(config.Mode))
 
 	}
 	if err := acraConn.Close(); err != nil {
-		log.WithError(err).Errorf("Error on closing connection with %s", connector_mode.ModeToServiceName(config.Mode))
+		logger.WithError(err).Errorf("Error on closing connection with %s", connector_mode.ModeToServiceName(config.Mode))
 	}
 }
 
@@ -179,13 +212,12 @@ type Config struct {
 	KeyStore                 keystore.SecureSessionKeyStore
 	ConnectionWrapper        network.ConnectionWrapper
 	Mode                     connector_mode.ConnectorMode
+	Tracing                  bool
+	TraceToLog               bool
 }
 
 func main() {
 	loggingFormat := flag.String("logging_format", "plaintext", "Logging format: plaintext, json or CEF")
-	logging.CustomizeLogging(*loggingFormat, ServiceName)
-	log.Infof("Starting service %v", ServiceName)
-
 	keysDir := flag.String("keys_dir", keystore.DefaultKeyDirShort, "Folder from which will be loaded keys")
 	clientID := flag.String("client_id", "", "Client ID")
 	acraServerHost := flag.String("acraserver_connection_host", "", "IP or domain to AcraServer daemon")
@@ -216,6 +248,12 @@ func main() {
 	acraTranslatorConnectionString := flag.String("acratranslator_connection_string", "", "Connection string to AcraTranslator like grpc://0.0.0.0:9696 or http://0.0.0.0:9595")
 	acraTranslatorID := flag.String("acratranslator_securesession_id", "acra_translator", "Expected id from AcraTranslator for Secure Session")
 
+	tracing := flag.Bool("tracing_enable", false, "Enable tracing")
+	traceToLog := flag.Bool("tracing_log_enable", false, "Export trace data to log")
+	traceToJaeger := flag.Bool("tracing_jaeger_enable", false, "Export trace data to jaeger")
+	jaegerAgentEndpoint := flag.String("jaeger_agent_endpoint", "127.0.0.1:6831", "Jaeger agent endpoint that will be used to export trace data")
+	jaegerEndpoint := flag.String("jaeger_endpoint", "http://localhost:14268", "Jaeger endpoint that will be used to export trace data")
+
 	verbose := flag.Bool("v", false, "Log to stderr all INFO, WARNING and ERROR logs")
 	debug := flag.Bool("d", false, "Log everything to stderr")
 
@@ -225,6 +263,9 @@ func main() {
 			Errorln("Can't parse args")
 		os.Exit(1)
 	}
+
+	log.Infof("Starting service %v", ServiceName)
+	logging.CustomizeLogging(*loggingFormat, ServiceName)
 
 	// if log format was overridden
 	logging.CustomizeLogging(*loggingFormat, ServiceName)
@@ -341,7 +382,7 @@ func main() {
 
 	// --------- Config  -----------
 	log.Infof("Configuring transport...")
-	config := &Config{KeyStore: keyStore, KeysDir: *keysDir, ClientID: []byte(*clientID), OutgoingConnectionString: outgoingConnectionString, IncomingConnectionString: *connectionString, OutgoingServiceID: []byte(outgoingSecureSessionID), DisableUserCheck: *disableUserCheck, Mode: connectorMode}
+	config := &Config{KeyStore: keyStore, KeysDir: *keysDir, ClientID: []byte(*clientID), OutgoingConnectionString: outgoingConnectionString, IncomingConnectionString: *connectionString, OutgoingServiceID: []byte(outgoingSecureSessionID), DisableUserCheck: *disableUserCheck, Mode: connectorMode, Tracing: *tracing, TraceToLog: *traceToLog}
 	listener, err := network.Listen(*connectionString)
 	if err != nil {
 		log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantStartListenConnections).
@@ -457,6 +498,26 @@ func main() {
 			log.Infoln("Stop prometheus http exporter")
 			prometheusHTTPServer.Close()
 		})
+	}
+
+	if *tracing {
+		if *traceToLog {
+			trace.RegisterExporter(&logging.LogSpanExporter{})
+		}
+
+		if *traceToJaeger {
+			jaegerEndpoint, err := jaeger.NewExporter(jaeger.Options{
+				AgentEndpoint: *jaegerAgentEndpoint,
+				Endpoint:      *jaegerEndpoint,
+				ServiceName:   ServiceName,
+			})
+			if err != nil {
+				log.Fatalf("Failed to create the Jaeger exporter: %v", err)
+				os.Exit(1)
+			}
+			// And now finally register it as a Trace Exporter
+			trace.RegisterExporter(jaegerEndpoint)
+		}
 	}
 
 	for {

--- a/cmd/acra-server/acra-server.go
+++ b/cmd/acra-server/acra-server.go
@@ -34,6 +34,8 @@ import (
 	"crypto/tls"
 	"errors"
 	"flag"
+	"go.opencensus.io/exporter/jaeger"
+	"go.opencensus.io/trace"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
@@ -67,11 +69,11 @@ const (
 	GRACEFUL_ENV                    = "GRACEFUL_RESTART"
 	DESCRIPTOR_ACRA                 = 3
 	DESCRIPTOR_API                  = 4
-	SERVICE_NAME                    = "acra-server"
+	ServiceName                     = "acra-server"
 )
 
 // DEFAULT_CONFIG_PATH relative path to config which will be parsed as default
-var DEFAULT_CONFIG_PATH = utils.GetConfigPathByName(SERVICE_NAME)
+var DEFAULT_CONFIG_PATH = utils.GetConfigPathByName(ServiceName)
 
 // ErrWaitTimeout error indicates that server was shutdown and waited N seconds while shutting down all connections.
 var ErrWaitTimeout = errors.New("timeout")
@@ -79,8 +81,8 @@ var ErrWaitTimeout = errors.New("timeout")
 func main() {
 	config := NewConfig()
 	loggingFormat := flag.String("logging_format", "plaintext", "Logging format: plaintext, json or CEF")
-	logging.CustomizeLogging(*loggingFormat, SERVICE_NAME)
-	log.Infof("Starting service %v", SERVICE_NAME)
+	logging.CustomizeLogging(*loggingFormat, ServiceName)
+	log.Infof("Starting service %v", ServiceName)
 
 	dbHost := flag.String("db_host", "", "Host to db")
 	dbPort := flag.Int("db_port", 5432, "Port to db")
@@ -128,18 +130,44 @@ func main() {
 	usePostgresql := flag.Bool("postgresql_enable", false, "Handle Postgresql connections (default true)")
 	censorConfig := flag.String("acracensor_config_file", "", "Path to AcraCensor configuration file")
 
+	tracing := flag.Bool("tracing_enable", false, "Enable tracing")
+	traceToLog := flag.Bool("tracing_log_enable", false, "Export trace data to log")
+	traceToJaeger := flag.Bool("tracing_jaeger_enable", false, "Export trace data to jaeger")
+	jaegerAgentEndpoint := flag.String("jaeger_agent_endpoint", "127.0.0.1:6831", "Jaeger agent endpoint that will be used to export trace data")
+	jaegerEndpoint := flag.String("jaeger_endpoint", "http://localhost:14268", "Jaeger endpoint that will be used to export trace data")
+
 	verbose := flag.Bool("v", false, "Log to stderr all INFO, WARNING and ERROR logs")
 	debug := flag.Bool("d", false, "Log everything to stderr")
 
-	err := cmd.Parse(DEFAULT_CONFIG_PATH, SERVICE_NAME)
+	err := cmd.Parse(DEFAULT_CONFIG_PATH, ServiceName)
 	if err != nil {
 		log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantReadServiceConfig).
 			Errorln("Can't parse args")
 		os.Exit(1)
 	}
 
+	config.TraceToLog = *traceToLog
+	if *tracing {
+		if *traceToLog {
+			trace.RegisterExporter(&logging.LogSpanExporter{})
+		}
+		if *traceToJaeger {
+			jaegerEndpoint, err := jaeger.NewExporter(jaeger.Options{
+				AgentEndpoint: *jaegerAgentEndpoint,
+				Endpoint:      *jaegerEndpoint,
+				ServiceName:   ServiceName,
+			})
+			if err != nil {
+				log.Fatalf("Failed to create the Jaeger exporter: %v", err)
+				os.Exit(1)
+			}
+			// And now finally register it as a Trace Exporter
+			trace.RegisterExporter(jaegerEndpoint)
+		}
+	}
+
 	// if log format was overridden
-	logging.CustomizeLogging(*loggingFormat, SERVICE_NAME)
+	logging.CustomizeLogging(*loggingFormat, ServiceName)
 
 	log.Infof("Validating service configuration...")
 	cmd.ValidateClientID(*secureSessionID)
@@ -176,6 +204,7 @@ func main() {
 	}
 
 	// now it's stub as default values
+	config.SetTracing(*tracing)
 	config.SetDetectPoisonRecords(*detectPoisonRecords)
 	config.SetStopOnPoison(*stopOnPoison)
 	config.SetScriptOnPoison(*scriptOnPoison)
@@ -247,6 +276,7 @@ func main() {
 			os.Exit(1)
 		}
 	} else if *noEncryptionTransport {
+		config.SetWithConnector(false)
 		if *clientID == "" && !*withZone {
 			log.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorTransportConfiguration).
 				Errorln("Configuration error: without zone mode and without encryption you must set <client_id> which will be used to connect from AcraConnector to AcraServer")
@@ -285,7 +315,7 @@ func main() {
 	server, err = NewServer(config, keyStore, errorSignalChannel, restartSignalsChannel)
 	if err != nil {
 		log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantStartService).
-			Errorf("System error: can't start %s", SERVICE_NAME)
+			Errorf("System error: can't start %s", ServiceName)
 		panic(err)
 	}
 
@@ -371,7 +401,7 @@ func main() {
 			Files: []uintptr{os.Stdin.Fd(), os.Stdout.Fd(), os.Stderr.Fd(), fdACRA, fdAPI},
 		}
 
-		log.Debugf("Forking new process of %s", SERVICE_NAME)
+		log.Debugf("Forking new process of %s", ServiceName)
 
 		// Fork new process
 		var fork, err = syscall.ForkExec(os.Args[0], os.Args, execSpec)
@@ -379,7 +409,7 @@ func main() {
 			log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantForkProcess).
 				Fatalln("System error: failed to fork new process", err)
 		}
-		log.Infof("%s process forked to PID: %v", SERVICE_NAME, fork)
+		log.Infof("%s process forked to PID: %v", ServiceName, fork)
 
 		// Wait a maximum of N seconds for existing connections to finish
 		err = server.WaitWithTimeout(time.Duration(*closeConnectionTimeout) * time.Second)

--- a/cmd/acra-server/acra-server.go
+++ b/cmd/acra-server/acra-server.go
@@ -81,7 +81,6 @@ var ErrWaitTimeout = errors.New("timeout")
 func main() {
 	config := NewConfig()
 	loggingFormat := flag.String("logging_format", "plaintext", "Logging format: plaintext, json or CEF")
-	logging.CustomizeLogging(*loggingFormat, ServiceName)
 	log.Infof("Starting service %v", ServiceName)
 
 	dbHost := flag.String("db_host", "", "Host to db")
@@ -146,6 +145,8 @@ func main() {
 		os.Exit(1)
 	}
 
+	logging.CustomizeLogging(*loggingFormat, ServiceName)
+
 	config.TraceToLog = *traceToLog
 	if *tracing {
 		if *traceToLog {
@@ -165,9 +166,6 @@ func main() {
 			trace.RegisterExporter(jaegerEndpoint)
 		}
 	}
-
-	// if log format was overridden
-	logging.CustomizeLogging(*loggingFormat, ServiceName)
 
 	log.Infof("Validating service configuration...")
 	cmd.ValidateClientID(*secureSessionID)

--- a/cmd/acra-server/config.go
+++ b/cmd/acra-server/config.go
@@ -83,7 +83,7 @@ func NewConfig() *Config {
 // ErrTwoDBSetup shows that AcraServer can connects only to one database at the same time
 var ErrTwoDBSetup = errors.New("only one db supported at one time")
 
-// WithConnector show that acra-server will or not accept connections from acra-connector. Default: true
+// WithConnector shows that AcraServer expects connections from AcraConnector
 func (config *Config) WithConnector() bool {
 	return config.withConnector
 }

--- a/cmd/acra-server/config.go
+++ b/cmd/acra-server/config.go
@@ -59,6 +59,9 @@ type Config struct {
 	debug                   bool
 	censor                  acracensor.AcraCensorInterface
 	tlsConfig               *tls.Config
+	tracing                 bool
+	withConnector           bool
+	TraceToLog              bool
 }
 
 // UIEditableConfig describes which parts of AcraServer configuration can be changed from AcraWebconfig page
@@ -74,11 +77,31 @@ type UIEditableConfig struct {
 
 // NewConfig returns new Config object
 func NewConfig() *Config {
-	return &Config{withZone: false, stopOnPoison: false, wholeMatch: true, mysql: false, postgresql: false}
+	return &Config{withZone: false, stopOnPoison: false, wholeMatch: true, mysql: false, postgresql: false, withConnector: true}
 }
 
 // ErrTwoDBSetup shows that AcraServer can connects only to one database at the same time
 var ErrTwoDBSetup = errors.New("only one db supported at one time")
+
+// WithConnector show that acra-server will or not accept connections from acra-connector. Default: true
+func (config *Config) WithConnector() bool {
+	return config.withConnector
+}
+
+// SetWithConnector set that acra-server will or not accept connections from acra-connector
+func (config *Config) SetWithConnector(v bool) {
+	config.withConnector = v
+}
+
+// GetTracing status on/off
+func (config *Config) GetTracing() bool {
+	return config.tracing
+}
+
+// SetTracing status on/off
+func (config *Config) SetTracing(v bool) {
+	config.tracing = v
+}
 
 // SetCensor creates AcraCensor and sets its configuration
 func (config *Config) SetCensor(censorConfigPath string) error {

--- a/cmd/acra-server/prometheus.go
+++ b/cmd/acra-server/prometheus.go
@@ -21,6 +21,8 @@ import (
 	"sync"
 )
 
+type connectionType string
+
 const (
 	connectionTypeLabel = "connection_type"
 	apiConnectionType   = "api"

--- a/cmd/acra-translator/acra-translator.go
+++ b/cmd/acra-translator/acra-translator.go
@@ -51,7 +51,6 @@ var DEFAULT_CONFIG_PATH = utils.GetConfigPathByName(ServiceName)
 func main() {
 	config := NewConfig()
 	loggingFormat := flag.String("logging_format", "plaintext", "Logging format: plaintext, json or CEF")
-	logging.CustomizeLogging(*loggingFormat, ServiceName)
 	log.Infof("Starting service %v", ServiceName)
 
 	incomingConnectionHTTPString := flag.String("incoming_connection_http_string", "", "Connection string for HTTP transport like http://0.0.0.0:9595")
@@ -86,7 +85,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	// if log format was overridden
 	logging.CustomizeLogging(*loggingFormat, ServiceName)
 
 	log.Infof("Validating service configuration...")

--- a/cmd/acra-translator/config.go
+++ b/cmd/acra-translator/config.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"github.com/cossacklabs/acra/network"
+	"go.opencensus.io/trace"
 )
 
 // AcraTranslatorConfig stores keys, poison record settings, connection attributes.
@@ -32,11 +33,31 @@ type AcraTranslatorConfig struct {
 	ConnectionWrapper            network.ConnectionWrapper
 	configPath                   string
 	debug                        bool
+	traceToLog                   bool
+	tracing                      bool
 }
 
 // NewConfig creates new AcraTranslatorConfig.
 func NewConfig() *AcraTranslatorConfig {
 	return &AcraTranslatorConfig{stopOnPoison: false}
+}
+
+// SetTracing if should export trace data
+func (a *AcraTranslatorConfig) SetTracing(v bool) {
+	a.tracing = v
+}
+
+// SetTraceToLog true if want to log trace data otherwise false
+func (a *AcraTranslatorConfig) SetTraceToLog(v bool) {
+	a.traceToLog = v
+}
+
+// GetTraceOptions for opencensus trace
+func (a *AcraTranslatorConfig) GetTraceOptions() []trace.StartOption {
+	if a.tracing {
+		return []trace.StartOption{trace.WithSampler(trace.AlwaysSample()), trace.WithSpanKind(trace.SpanKindServer)}
+	}
+	return []trace.StartOption{trace.WithSampler(trace.NeverSample()), trace.WithSpanKind(trace.SpanKindServer)}
 }
 
 // KeysDir returns keys directory.

--- a/decryptor/mysql/decryptor.go
+++ b/decryptor/mysql/decryptor.go
@@ -285,8 +285,6 @@ func (decryptor *MySQLDecryptor) decryptInlineBlock(block []byte) ([]byte, error
 		return block, nil
 	}
 	for index < len(block) {
-		decryptor.log.Debugf("Index=%v", index)
-		decryptor.log.Debugf("Index: %v", index)
 		beginTagIndex, tagLength := decryptor.BeginTagIndex(block[index:])
 		if beginTagIndex == utils.NotFound {
 			output.Write(block[index:])

--- a/decryptor/mysql/response_proxy.go
+++ b/decryptor/mysql/response_proxy.go
@@ -17,9 +17,11 @@ limitations under the License.
 package mysql
 
 import (
+	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"go.opencensus.io/trace"
 	"io"
 	"net"
 	"time"
@@ -149,10 +151,12 @@ type MysqlHandler struct {
 	tlsConfig              *tls.Config
 	clientID               []byte
 	logger                 *logrus.Entry
+	ctx                    context.Context
 }
 
 // NewMysqlHandler returns new MysqlHandler
-func NewMysqlHandler(clientID []byte, decryptor base.Decryptor, dbConnection, clientConnection net.Conn, tlsConfig *tls.Config, censor acracensor.AcraCensorInterface) (*MysqlHandler, error) {
+func NewMysqlHandler(ctx context.Context, clientID []byte, decryptor base.Decryptor, dbConnection, clientConnection net.Conn, tlsConfig *tls.Config, censor acracensor.AcraCensorInterface) (*MysqlHandler, error) {
+	logger := logging.NewLoggerWithTrace(ctx)
 	var newTLSConfig *tls.Config
 	if tlsConfig != nil {
 		// use less secure protocol versions because some drivers and db images doesn't support secure and modern options
@@ -169,7 +173,8 @@ func NewMysqlHandler(clientID []byte, decryptor base.Decryptor, dbConnection, cl
 		clientConnection:       clientConnection,
 		dbConnection:           dbConnection,
 		tlsConfig:              newTLSConfig,
-		logger:                 logrus.WithField("client_id", string(clientID))}, nil
+		ctx:                    ctx,
+		logger:                 logger.WithField("client_id", string(clientID))}, nil
 }
 
 func (handler *MysqlHandler) setQueryHandler(callback ResponseHandler) {
@@ -185,12 +190,31 @@ func (handler *MysqlHandler) getResponseHandler() ResponseHandler {
 
 // ClientToDbConnector connects to database, writes data and executes DB commands
 func (handler *MysqlHandler) ClientToDbConnector(errCh chan<- error) {
+	ctx, span := trace.StartSpan(handler.ctx, "ClientToDbConnector")
+	defer span.End()
 	clientLog := handler.logger.WithField("proxy", "client")
 	clientLog.Debugln("Start proxy client's requests")
 	firstPacket := true
 	prometheusLabels := []string{base.DecryptionDBMysql}
+	// use pointers to function where should be stored some function that should be called if code return error and interrupt loop
+	// default value empty func to avoid != nil check
+	var timerObserveFunc = func() {}
+	var packetSpanEndFunc = func() {}
+	var censorSpanEndFunc = func() {}
+	defer func() {
+		timerObserveFunc()
+		packetSpanEndFunc()
+	}()
 	for {
+		censorSpanEndFunc()
+		timerObserveFunc()
 		timer := prometheus.NewTimer(prometheus.ObserverFunc(base.RequestProcessingTimeHistogram.WithLabelValues(prometheusLabels...).Observe))
+		timerObserveFunc = timer.ObserveDuration
+
+		packetSpanEndFunc()
+		packetSpanCtx, packetSpan := trace.StartSpan(ctx, "ClientToDbConnectorLoop")
+		packetSpanEndFunc = packetSpan.End
+
 		packet, err := ReadPacket(handler.clientConnection)
 		if err != nil {
 			handler.logger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorResponseConnectorCantReadFromClient).
@@ -242,14 +266,13 @@ func (handler *MysqlHandler) ClientToDbConnector(errCh chan<- error) {
 				select {
 				case <-handler.dbTLSHandshakeFinished:
 					handler.logger.Debugln("Switch to tls complete on client proxy side")
-					timer.ObserveDuration()
+
 					continue
 				case <-time.NewTicker(time.Second * ClientWaitDbTLSHandshake).C:
 					clientLog.Errorln("Timeout on tls handshake with db")
 					errCh <- errors.New("handshake timeout")
 					return
 				}
-				timer.ObserveDuration()
 				continue
 			}
 		}
@@ -269,6 +292,7 @@ func (handler *MysqlHandler) ClientToDbConnector(errCh chan<- error) {
 			errCh <- io.EOF
 			return
 		case COM_QUERY, COM_STMT_EXECUTE:
+			_, censorSpan := trace.StartSpan(packetSpanCtx, "censor")
 			query := string(data)
 
 			// log query with hidden values for debug mode
@@ -282,6 +306,7 @@ func (handler *MysqlHandler) ClientToDbConnector(errCh chan<- error) {
 			}
 
 			if err := handler.acracensor.HandleQuery(query); err != nil {
+				censorSpan.End()
 				clientLog.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCensorQueryIsNotAllowed).Errorln("Error on AcraCensor check")
 				errPacket := NewQueryInterruptedError(handler.clientProtocol41)
 				packet.SetData(errPacket)
@@ -292,6 +317,7 @@ func (handler *MysqlHandler) ClientToDbConnector(errCh chan<- error) {
 				continue
 			}
 			handler.setQueryHandler(handler.QueryResponseHandler)
+			censorSpan.End()
 			break
 		case COM_STMT_PREPARE, COM_STMT_CLOSE, COM_STMT_SEND_LONG_DATA, COM_STMT_RESET:
 			fallthrough
@@ -304,7 +330,6 @@ func (handler *MysqlHandler) ClientToDbConnector(errCh chan<- error) {
 			errCh <- err
 			return
 		}
-		timer.ObserveDuration()
 	}
 }
 
@@ -608,6 +633,8 @@ func (handler *MysqlHandler) QueryResponseHandler(packet *MysqlPacket, dbConnect
 
 // DbToClientConnector handles connection from database, returns data to client
 func (handler *MysqlHandler) DbToClientConnector(errCh chan<- error) {
+	ctx, span := trace.StartSpan(handler.ctx, "DbToClientConnector")
+	defer span.End()
 	serverLog := handler.logger.WithField("proxy", "server")
 	serverLog.Debugln("Start proxy db responses")
 	firstPacket := true
@@ -618,8 +645,23 @@ func (handler *MysqlHandler) DbToClientConnector(errCh chan<- error) {
 	} else {
 		prometheusLabels = append(prometheusLabels, base.DecryptionModeInline)
 	}
+	// use pointers to function where should be stored some function that should be called if code return error and interrupt loop
+	// default value empty func to avoid != nil check
+	var packetSpanEndFunc = func() {}
+	var timerObserveFunc = func() {}
+	defer func() {
+		timerObserveFunc()
+		packetSpanEndFunc()
+	}()
 	for {
+		packetSpanEndFunc()
+		_, packetSpan := trace.StartSpan(ctx, "DbToClientConnectorLoop")
+		packetSpanEndFunc = packetSpan.End
+
+		timerObserveFunc()
 		timer := prometheus.NewTimer(prometheus.ObserverFunc(base.ResponseProcessingTimeHistogram.WithLabelValues(prometheusLabels...).Observe))
+		timerObserveFunc = timer.ObserveDuration
+
 		packet, err := ReadPacket(handler.dbConnection)
 		if err != nil {
 			if netErr, ok := err.(net.Error); ok {
@@ -636,7 +678,6 @@ func (handler *MysqlHandler) DbToClientConnector(errCh chan<- error) {
 					handler.logger.Debugln("Switched to tls with db")
 					handler.dbConnection = tlsConnection
 					handler.dbTLSHandshakeFinished <- true
-					timer.ObserveDuration()
 					continue
 				}
 			}
@@ -664,6 +705,5 @@ func (handler *MysqlHandler) DbToClientConnector(errCh chan<- error) {
 			errCh <- err
 			return
 		}
-		timer.ObserveDuration()
 	}
 }

--- a/decryptor/postgresql/packet_handler.go
+++ b/decryptor/postgresql/packet_handler.go
@@ -27,24 +27,23 @@ type PacketHandler struct {
 }
 
 // NewClientSidePacketHandler return new PacketHandler with initialized own logger for client's packets
-func NewClientSidePacketHandler(reader io.Reader, writer *bufio.Writer) (*PacketHandler, error) {
-	return &PacketHandler{
-		descriptionBuf:       bytes.NewBuffer(make([]byte, OutputDefaultSize)),
-		descriptionLengthBuf: make([]byte, 4),
-		reader:               reader,
-		writer:               writer,
-		logger:               logrus.WithField("proxy", "client_side"),
-	}, nil
+func NewClientSidePacketHandler(reader io.Reader, writer *bufio.Writer, logger *logrus.Entry) (*PacketHandler, error) {
+	return newPacketHandlerWithLogger(reader, writer, logger.WithField("proxy", "client_side"))
 }
 
 // NewDbSidePacketHandler return new PacketHandler with initialized own logger for databases's packets
-func NewDbSidePacketHandler(reader io.Reader, writer *bufio.Writer) (*PacketHandler, error) {
+func NewDbSidePacketHandler(reader io.Reader, writer *bufio.Writer, logger *logrus.Entry) (*PacketHandler, error) {
+	return newPacketHandlerWithLogger(reader, writer, logger.WithField("proxy", "db_side"))
+}
+
+// newPacketHandlerWithLogger return new PacketHandler with specific logger
+func newPacketHandlerWithLogger(reader io.Reader, writer *bufio.Writer, logger *logrus.Entry) (*PacketHandler, error) {
 	return &PacketHandler{
 		descriptionBuf:       bytes.NewBuffer(make([]byte, OutputDefaultSize)),
 		descriptionLengthBuf: make([]byte, 4),
 		reader:               reader,
 		writer:               writer,
-		logger:               logrus.WithField("proxy", "db_side"),
+		logger:               logger,
 	}, nil
 }
 

--- a/decryptor/postgresql/packet_handler_test.go
+++ b/decryptor/postgresql/packet_handler_test.go
@@ -20,6 +20,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/hex"
+	"github.com/sirupsen/logrus"
 	"testing"
 )
 
@@ -31,7 +32,7 @@ func TestClientUnknownCommand(t *testing.T) {
 	reader := bytes.NewReader(packet)
 	output := make([]byte, 8)
 	writer := bufio.NewWriter(bytes.NewBuffer(output[:0]))
-	packetHander, err := NewClientSidePacketHandler(reader, writer)
+	packetHander, err := NewClientSidePacketHandler(reader, writer, logrus.NewEntry(logrus.StandardLogger()))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -64,7 +65,7 @@ func TestClientSpecialMessageTypes(t *testing.T) {
 		reader := bytes.NewReader(packet)
 		output := make([]byte, 8)
 		writer := bufio.NewWriter(bytes.NewBuffer(output[:0]))
-		packetHander, err := NewClientSidePacketHandler(reader, writer)
+		packetHander, err := NewClientSidePacketHandler(reader, writer, logrus.NewEntry(logrus.StandardLogger()))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -98,7 +99,7 @@ func TestClientStartupMessageWithData(t *testing.T) {
 	reader := bytes.NewReader(packet)
 	output := &bytes.Buffer{}
 	writer := bufio.NewWriter(output)
-	packetHander, err := NewClientSidePacketHandler(reader, writer)
+	packetHander, err := NewClientSidePacketHandler(reader, writer, logrus.NewEntry(logrus.StandardLogger()))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/decryptor/postgresql/pg_decryptor.go
+++ b/decryptor/postgresql/pg_decryptor.go
@@ -20,9 +20,11 @@ package postgresql
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"crypto/tls"
 	"encoding/binary"
 	"errors"
+	"go.opencensus.io/trace"
 	"net"
 	"time"
 
@@ -84,31 +86,50 @@ type PgProxy struct {
 	clientConnection net.Conn
 	dbConnection     net.Conn
 	TLSCh            chan bool
+	ctx              context.Context
 }
 
 // NewPgProxy returns new PgProxy
-func NewPgProxy(clientConnection, dbConnection net.Conn) (*PgProxy, error) {
-	return &PgProxy{clientConnection: clientConnection, dbConnection: dbConnection, TLSCh: make(chan bool)}, nil
+func NewPgProxy(ctx context.Context, clientConnection, dbConnection net.Conn) (*PgProxy, error) {
+	return &PgProxy{clientConnection: clientConnection, dbConnection: dbConnection, TLSCh: make(chan bool), ctx: ctx}, nil
 }
 
 // PgProxyClientRequests checks every client request using AcraCensor,
 // if request is allowed, sends it to the Pg database
 func (proxy *PgProxy) PgProxyClientRequests(acraCensor acracensor.AcraCensorInterface, dbConnection, clientConnection net.Conn, errCh chan<- error) {
-	logger := log.WithField("proxy", "pg_client")
+	ctx, span := trace.StartSpan(proxy.ctx, "PgProxyClientRequests")
+	defer span.End()
+	logger := logging.NewLoggerWithTrace(ctx).WithField("proxy", "pg_client")
 	logger.Debugln("Pg client proxy")
 	writer := bufio.NewWriter(dbConnection)
 
 	reader := bufio.NewReader(clientConnection)
-	packet, err := NewClientSidePacketHandler(reader, writer)
+	packet, err := NewClientSidePacketHandler(reader, writer, logger)
 	if err != nil {
 		logger.WithError(err).Errorln("Can't initialize DataRow object")
 		errCh <- err
 		return
 	}
 	prometheusLabels := []string{base.DecryptionDBPostgresql}
+	// use pointers to function where should be stored some function that should be called if code return error and interrupt loop
+	// default value empty func to avoid != nil check
+	var spanEndFunc = func() {}
+	var timerObserveFunc = func() {}
+	// always call span.End for case if was error
+	defer func() {
+		spanEndFunc()
+		timerObserveFunc()
+	}()
 	for {
+		timerObserveFunc()
 		timer := prometheus.NewTimer(prometheus.ObserverFunc(base.RequestProcessingTimeHistogram.WithLabelValues(prometheusLabels...).Observe))
+		timerObserveFunc = timer.ObserveDuration
+
 		packet.Reset()
+
+		spanEndFunc()
+		packetSpanCtx, packetSpan := trace.StartSpan(ctx, "PgProxyClientRequestsLoop")
+		spanEndFunc = packetSpan.End
 
 		if err := packet.ReadClientPacket(); err != nil {
 			logger.WithError(err).Errorln("Can't read packet from client to database")
@@ -123,22 +144,24 @@ func (proxy *PgProxy) PgProxyClientRequests(acraCensor acracensor.AcraCensorInte
 				errCh <- err
 				return
 			}
-			timer.ObserveDuration()
 			continue
 		}
+		_, censorSpan := trace.StartSpan(packetSpanCtx, "censor")
+
 		query := string(packet.descriptionBuf.Bytes()[:packet.dataLength-1])
 
 		// log query with hidden values for debug mode
 		if logging.GetLogLevel() == logging.LogDebug {
 			_, queryWithHiddenValues, err := handlers.NormalizeAndRedactSQLQuery(query)
 			if err == handlers.ErrQuerySyntaxError {
-				log.WithError(err).Infof("Parsing error on query: %s", queryWithHiddenValues)
+				logger.WithError(err).Infof("Parsing error on query: %s", queryWithHiddenValues)
 			} else {
-				log.WithField("sql", queryWithHiddenValues).Debugln("New query")
+				logger.WithField("sql", queryWithHiddenValues).Debugln("New query")
 			}
 		}
 
 		if censorErr := acraCensor.HandleQuery(query); censorErr != nil {
+			censorSpan.End()
 			logger.WithError(censorErr).Errorln("AcraCensor blocked query")
 			errorMessage, err := NewPgError("AcraCensor blocked this query")
 			if err != nil {
@@ -156,29 +179,28 @@ func (proxy *PgProxy) PgProxyClientRequests(acraCensor acracensor.AcraCensorInte
 				errCh <- err
 				return
 			}
-			timer.ObserveDuration()
 			continue
 		}
+		censorSpan.End()
 
 		if err := packet.sendPacket(); err != nil {
 			logger.WithError(err).Errorln("Can't send packet")
 			errCh <- err
 			return
 		}
-		timer.ObserveDuration()
 	}
 }
 
 // handlePoisonCheckResult return error err != nil, if can't check on poison record or any callback on poison record
 // return error
-func handlePoisonCheckResult(decryptor base.Decryptor, poisoned bool, err error) error {
+func handlePoisonCheckResult(decryptor base.Decryptor, poisoned bool, err error, logger *log.Entry) error {
 	if err != nil {
-		log.WithError(err).Errorln("Can't check on poison record")
+		logger.WithError(err).Errorln("Can't check on poison record")
 		return err
 	}
 
 	if poisoned {
-		log.Warningln("Recognized poison record")
+		logger.Warningln("Recognized poison record")
 		callbacks := decryptor.GetPoisonCallbackStorage()
 		if callbacks.HasCallbacks() {
 			return callbacks.Call()
@@ -219,7 +241,7 @@ func checkWholePoisonRecord(block []byte, decryptor base.Decryptor, logger *log.
 		return nil
 	}
 	poisoned, checkErr := decryptor.CheckPoisonRecord(bytes.NewReader(skippedBegin))
-	if innerErr := handlePoisonCheckResult(decryptor, poisoned, checkErr); err != nil {
+	if innerErr := handlePoisonCheckResult(decryptor, poisoned, checkErr, logger); err != nil {
 		logger.WithError(innerErr).Errorln("Error on poison record check")
 		return innerErr
 	}
@@ -227,10 +249,12 @@ func checkWholePoisonRecord(block []byte, decryptor base.Decryptor, logger *log.
 }
 
 // processWholeBlockDecryption try to decrypt data of column as whole AcraStruct and replace with decrypted data on success
-func (proxy *PgProxy) processWholeBlockDecryption(packet *PacketHandler, column *ColumnData, decryptor base.Decryptor, logger *log.Entry) error {
+func (proxy *PgProxy) processWholeBlockDecryption(ctx context.Context, packet *PacketHandler, column *ColumnData, decryptor base.Decryptor, logger *log.Entry) error {
+	span := trace.FromContext(ctx)
 	decryptor.Reset()
 	decrypted, err := decryptor.DecryptBlock(column.Data)
 	if err != nil {
+		span.AddAttributes(trace.BoolAttribute("failed_decryption", true))
 		// check poison records on failed decryption
 		logger.WithError(err).Errorln("Can't decrypt possible AcraStruct")
 		base.AcrastructDecryptionCounter.WithLabelValues(base.DecryptionTypeFail).Inc()
@@ -251,7 +275,7 @@ func (proxy *PgProxy) processWholeBlockDecryption(packet *PacketHandler, column 
 func (proxy *PgProxy) handleSSLRequest(packet *PacketHandler, tlsConfig *tls.Config, clientConnection, dbConnection net.Conn, logger *log.Entry) (net.Conn, net.Conn, error) {
 	// if server allow SSLRequest than we wrap our connections with tls
 	if tlsConfig == nil {
-		logger.Errorln("To support TLS connections you must pass TLS key and certificate for AcraServer that will be used" +
+		logger.Errorln("To support TLS connections you must pass TLS key and certificate for AcraServer that will be used " +
 			"for connections AcraServer->Database and CA certificate which will be used to verify certificate " +
 			"from database")
 		return nil, nil, network.ErrEmptyTLSConfig
@@ -303,7 +327,8 @@ func (proxy *PgProxy) handleSSLRequest(packet *PacketHandler, tlsConfig *tls.Con
 	return tlsClientConnection, dbTLSConnection, nil
 }
 
-func (proxy *PgProxy) processInlineBlockDecryption(packet *PacketHandler, column *ColumnData, decryptor base.Decryptor, logger *log.Entry) error {
+func (proxy *PgProxy) processInlineBlockDecryption(ctx context.Context, packet *PacketHandler, column *ColumnData, decryptor base.Decryptor, logger *log.Entry) error {
+	span := trace.FromContext(ctx)
 	// inline mode
 	currentIndex := 0
 	endIndex := column.Length()
@@ -326,10 +351,10 @@ func (proxy *PgProxy) processInlineBlockDecryption(packet *PacketHandler, column
 		if err != nil {
 			logger.WithError(err).Warningln("Can't read private key")
 			if decryptor.IsPoisonRecordCheckOn() {
-				log.Infoln("Check poison records")
+				logger.Infoln("Check poison records")
 				blockReader := bytes.NewReader(column.Data[beginTagIndex+tagLength:])
 				poisoned, err := decryptor.CheckPoisonRecord(blockReader)
-				err = handlePoisonCheckResult(decryptor, poisoned, err)
+				err = handlePoisonCheckResult(decryptor, poisoned, err, logger)
 				if err != nil {
 					logger.WithError(err).Errorln("Error on poison record processing")
 					return err
@@ -341,13 +366,14 @@ func (proxy *PgProxy) processInlineBlockDecryption(packet *PacketHandler, column
 		blockReader := bytes.NewReader(column.Data[beginTagIndex+tagLength:])
 		symKey, _, err := decryptor.ReadSymmetricKey(key, blockReader)
 		if err != nil {
+			span.AddAttributes(trace.BoolAttribute("failed_decryption", true))
 			base.AcrastructDecryptionCounter.WithLabelValues(base.DecryptionTypeFail).Inc()
 			logger.WithError(err).Warningln("Can't unwrap symmetric key")
 			if decryptor.IsPoisonRecordCheckOn() {
-				log.Infoln("Check poison records")
+				logger.Infoln("Check poison records")
 				blockReader = bytes.NewReader(column.Data[beginTagIndex+tagLength:])
 				poisoned, err := decryptor.CheckPoisonRecord(blockReader)
-				err = handlePoisonCheckResult(decryptor, poisoned, err)
+				err = handlePoisonCheckResult(decryptor, poisoned, err, logger)
 				if err != nil {
 					logger.WithError(err).Errorln("Error on poison record processing")
 					return err
@@ -361,6 +387,7 @@ func (proxy *PgProxy) processInlineBlockDecryption(packet *PacketHandler, column
 		}
 		decryptedData, err := decryptor.ReadData(symKey, decryptor.GetMatchedZoneID(), blockReader)
 		if err != nil {
+			span.AddAttributes(trace.BoolAttribute("failed_decryption", true))
 			base.AcrastructDecryptionCounter.WithLabelValues(base.DecryptionTypeFail).Inc()
 			logger.WithError(err).Warningln("Can't decrypt data with unwrapped symmetric key")
 			// write current read byte to not process him in next iteration
@@ -386,7 +413,9 @@ func (proxy *PgProxy) processInlineBlockDecryption(packet *PacketHandler, column
 
 // PgDecryptStream process data rows from database
 func (proxy *PgProxy) PgDecryptStream(censor acracensor.AcraCensorInterface, decryptor base.Decryptor, tlsConfig *tls.Config, dbConnection net.Conn, clientConnection net.Conn, errCh chan<- error) {
-	logger := log.WithField("proxy", "db_side")
+	ctx, span := trace.StartSpan(proxy.ctx, "PgDecryptStream")
+	defer span.End()
+	logger := logging.NewLoggerWithTrace(ctx).WithField("proxy", "db_side")
 	if decryptor.IsWholeMatch() {
 		logger = logger.WithField("decrypt_mode", "wholecell")
 	} else {
@@ -397,7 +426,7 @@ func (proxy *PgProxy) PgDecryptStream(censor acracensor.AcraCensorInterface, dec
 	writer := bufio.NewWriter(clientConnection)
 
 	reader := bufio.NewReader(dbConnection)
-	packetHandler, err := NewDbSidePacketHandler(reader, writer)
+	packetHandler, err := NewDbSidePacketHandler(reader, writer, logger)
 	if err != nil {
 		errCh <- err
 		return
@@ -410,15 +439,27 @@ func (proxy *PgProxy) PgDecryptStream(censor acracensor.AcraCensorInterface, dec
 		prometheusLabels = append(prometheusLabels, base.DecryptionModeInline)
 	}
 	firstByte := true
+	// use pointer to function where should be stored some function that should be called if code return error and interrupt loop
+	// default value empty func to avoid != nil check
+	var endLoopSpanFunc = func() {}
+	defer func() {
+		endLoopSpanFunc()
+	}()
 	for {
+		// end span of previous iteration
+		endLoopSpanFunc()
+		packetCtx, packetSpan := trace.StartSpan(ctx, "PgDecryptStreamLoop")
+		endLoopSpanFunc = packetSpan.End
+
 		packetHandler.Reset()
 		if firstByte {
+			packetSpan.AddAttributes(trace.BoolAttribute("startup", true))
 			timer := prometheus.NewTimer(prometheus.ObserverFunc(base.ResponseProcessingTimeHistogram.WithLabelValues(prometheusLabels...).Observe))
 			// https://www.postgresql.org/docs/9.1/static/protocol-flow.html#AEN92112
 			// we should know that we shouldn't read anymore bytes
 			// first response from server may contain only one byte of response on SSLRequest
 			firstByte = false
-			log.Debugln("Read startup message")
+			logger.Debugln("Read startup message")
 			if err := packetHandler.readMessageType(); err != nil {
 				logger.WithError(err).Errorln("Can't read first message type")
 				errCh <- err
@@ -452,7 +493,7 @@ func (proxy *PgProxy) PgDecryptStream(censor acracensor.AcraCensorInterface, dec
 				timer.ObserveDuration()
 				continue
 			}
-			log.Debugln("Non-ssl request start up message")
+			logger.Debugln("Non-ssl request start up message")
 			// if it is not ssl request than we just forward it to client
 			if err := packetHandler.readData(true); err != nil {
 				logger.WithError(err).Errorln("Can't read data of packet")
@@ -511,10 +552,12 @@ func (proxy *PgProxy) PgDecryptStream(censor acracensor.AcraCensorInterface, dec
 			// try to skip small piece of data that can't be valuable for us
 			if (decryptor.IsWithZone() && column.Length() >= zone.ZoneIDBlockLength) || column.Length() >= base.KeyBlockLength {
 				decryptor.Reset()
+				packetSpan.AddAttributes(trace.BoolAttribute("decryption", true))
 
 				// Zone anyway should be passed as whole block
 				// so try to match before any operations if we process with ZoneMode on
 				if decryptor.IsWithZone() && !decryptor.IsMatchedZone() {
+					packetSpan.AddAttributes(trace.BoolAttribute("match_zone", true))
 					// try to match zone
 					decryptor.MatchZoneBlock(column.Data)
 					if decryptor.IsWholeMatch() {
@@ -534,16 +577,16 @@ func (proxy *PgProxy) PgDecryptStream(censor acracensor.AcraCensorInterface, dec
 				}
 
 				if decryptor.IsWholeMatch() {
-					err := proxy.processWholeBlockDecryption(packetHandler, column, decryptor, logger)
+					err := proxy.processWholeBlockDecryption(packetCtx, packetHandler, column, decryptor, logger)
 					if err != nil {
-						log.WithError(err).Errorln("Can't process whole block")
+						logger.WithError(err).Errorln("Can't process whole block")
 						errCh <- err
 						return
 					}
 				} else {
-					err := proxy.processInlineBlockDecryption(packetHandler, column, decryptor, logger)
+					err := proxy.processInlineBlockDecryption(packetCtx, packetHandler, column, decryptor, logger)
 					if err != nil {
-						log.WithError(err).Errorln("Can't process block with inline mode")
+						logger.WithError(err).Errorln("Can't process block with inline mode")
 						errCh <- err
 						return
 					}
@@ -553,7 +596,6 @@ func (proxy *PgProxy) PgDecryptStream(censor acracensor.AcraCensorInterface, dec
 			}
 		}
 		packetHandler.updateDataFromColumns()
-		logger.Debugln("send packet")
 		if err := packetHandler.sendPacket(); err != nil {
 			logger.WithError(err).Errorln("Can't send packet")
 			errCh <- err

--- a/keystore/filesystem/server_keystore.go
+++ b/keystore/filesystem/server_keystore.go
@@ -74,7 +74,7 @@ func newFilesystemKeyStore(privateKeyFolder, publicKeyFolder string, encryptor k
 	}
 	fi, err := os.Stat(directory)
 	if nil == err && runtime.GOOS == "linux" && fi.Mode().Perm().String() != "-rwx------" {
-		log.Errorln(" key store folder has an incorrect permissions")
+		log.Errorln("Key store folder has an incorrect permissions")
 		return nil, errors.New("key store folder has an incorrect permissions")
 	}
 	if privateKeyFolder != publicKeyFolder {
@@ -227,7 +227,7 @@ func (store *FilesystemKeyStore) getPrivateKeyByFilename(id []byte, filename str
 	if err != nil {
 		return nil, err
 	}
-	log.Debugf("load key from fs: %s", filename)
+	log.Debugf("Load key from fs: %s", filename)
 	store.cache.Add(filename, encryptedKey)
 	return &keys.PrivateKey{Value: decryptedKey}, nil
 }
@@ -270,14 +270,14 @@ func (store *FilesystemKeyStore) GetPeerPublicKey(id []byte) (*keys.PublicKey, e
 	defer store.lock.Unlock()
 	key, ok := store.cache.Get(fname)
 	if ok {
-		log.Debugf("load cached key: %s", fname)
+		log.Debugf("Load cached key: %s", fname)
 		return &keys.PublicKey{Value: key}, nil
 	}
 	publicKey, err := utils.LoadPublicKey(store.getPublicKeyFilePath(fname))
 	if err != nil {
 		return nil, err
 	}
-	log.Debugf("load key from fs: %s", fname)
+	log.Debugf("Load key from fs: %s", fname)
 	store.cache.Add(fname, publicKey.Value)
 	return publicKey, nil
 }

--- a/logging/event_codes.go
+++ b/logging/event_codes.go
@@ -116,4 +116,6 @@ const (
 	EventCodeErrorTranslatorCantWrapConnectionToSS      = 711
 	EventCodeErrorTranslatorCantAcceptNewHTTPConnection = 712
 	EventCodeErrorTranslatorCantHandleGRPCConnection    = 713
+
+	EventCodeErrorTracingCantSendTrace = 800
 )

--- a/logging/log_formatters.go
+++ b/logging/log_formatters.go
@@ -177,7 +177,10 @@ func (f AcraCEFFormatter) Format(e *logrus.Entry) ([]byte, error) {
 
 // TimeToString return string representation of timestamp with milliseconds
 func TimeToString(t time.Time) string {
-	nanos := t.UnixNano()
+	return nanosecondsToMillisecondsString(t.UnixNano())
+}
+
+func nanosecondsToMillisecondsString(nanos int64) string {
 	millis := nanos / 1000000
 	millisf := float64(millis) / 1000.0
 	return fmt.Sprintf("%.3f", millisf)

--- a/logging/log_formatters.go
+++ b/logging/log_formatters.go
@@ -154,7 +154,7 @@ var (
 // Note: the given entry is copied and not changed during the formatting process.
 func (f AcraJSONFormatter) Format(e *logrus.Entry) ([]byte, error) {
 	ne := copyEntry(e, f.Fields)
-	if _, ok := ne.Data[FieldKeyUnixTime]; !ok {
+	if value, ok := ne.Data[FieldKeyUnixTime]; !ok || value == 0 {
 		ne.Data[FieldKeyUnixTime] = unixTimeWithMilliseconds(e)
 	}
 	dataBytes, err := f.Formatter.Format(ne)
@@ -167,7 +167,7 @@ func (f AcraJSONFormatter) Format(e *logrus.Entry) ([]byte, error) {
 // Note: the given entry is copied and not changed during the formatting process.
 func (f AcraCEFFormatter) Format(e *logrus.Entry) ([]byte, error) {
 	ne := copyEntry(e, f.Fields)
-	if _, ok := ne.Data[FieldKeyUnixTime]; !ok {
+	if value, ok := ne.Data[FieldKeyUnixTime]; !ok || value == 0 {
 		ne.Data[FieldKeyUnixTime] = unixTimeWithMilliseconds(e)
 	}
 	dataBytes, err := f.CEFTextFormatter.Format(ne)

--- a/logging/trace.go
+++ b/logging/trace.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2018, Cossack Labs Limited
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logging
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	log "github.com/sirupsen/logrus"
+	"go.opencensus.io/trace"
+	"regexp"
+)
+
+// reZero provides a simple way to detect an empty ID
+// took from go.opencensus.io/examples/exporter/exporter.go
+var reZero = regexp.MustCompile(`^0+$`)
+
+// LogSpanExporter exporter for opencensus that print all spans with logger
+type LogSpanExporter struct{}
+
+// ExportSpan log the trace span
+func (e *LogSpanExporter) ExportSpan(vd *trace.SpanData) {
+	// todo use some lru cache for hex values of traceID/SpanID
+	var (
+		traceID      = hex.EncodeToString(vd.SpanContext.TraceID[:])
+		spanID       = hex.EncodeToString(vd.SpanContext.SpanID[:])
+		parentSpanID = hex.EncodeToString(vd.ParentSpanID[:])
+	)
+	logger := log.WithFields(log.Fields{"trace_id": traceID, "span_id": spanID, "span_name": vd.Name, "duration": nanosecondsToMillisecondsString(int64(vd.EndTime.Sub(vd.StartTime)))})
+	if vd.Status.Code != trace.StatusCodeOK {
+		logger = logger.WithFields(log.Fields{"status_message": vd.Status.Message, "status_code": vd.Status.Code})
+	}
+
+	if !reZero.MatchString(parentSpanID) {
+		logger = logger.WithField("parent_span_id", parentSpanID)
+	}
+
+	linkFields := log.Fields{}
+	for i, link := range vd.Links {
+		linkFields[fmt.Sprintf("link_trace_id_%v", i)] = link.TraceID
+		linkFields[fmt.Sprintf("link_span_id_%v", i)] = link.SpanID
+		linkFields[fmt.Sprintf("link_span_type_%v", i)] = link.Type
+		// TODO handle link.Attributes
+	}
+	logger = logger.WithFields(linkFields)
+
+	if len(vd.Attributes) > 0 {
+		attributes := log.Fields{}
+		for k, v := range vd.Attributes {
+			attributes[k] = v
+		}
+		logger = logger.WithFields(attributes)
+	}
+
+	if len(vd.Annotations) > 0 {
+		for _, item := range vd.Annotations {
+			annotations := log.Fields{FieldKeyUnixTime: TimeToString(item.Time)}
+			for k, v := range item.Attributes {
+				annotations[k] = v
+			}
+			logger.WithFields(annotations).Infoln(item.Message)
+		}
+	}
+	logger.Infoln("span end")
+}
+
+// LoggerWithTrace return logger with added span_id/trace_id fields from context
+func LoggerWithTrace(context context.Context, logger *log.Entry) *log.Entry {
+	span := trace.FromContext(context)
+	spanContext := span.SpanContext()
+	if getTraceStatus(context) {
+		return logger.WithFields(log.Fields{"span_id": spanContext.SpanID, "trace_id": spanContext.TraceID})
+	}
+	return logger
+
+}
+
+// NewLoggerWithTrace return logger with trace_id/span_id fields
+func NewLoggerWithTrace(context context.Context) *log.Entry {
+	return LoggerWithTrace(context, log.NewEntry(log.StandardLogger()))
+}
+
+// traceStatusKey used as key for context value
+type traceStatusKey struct{}
+
+// SetTraceStatus to context
+func SetTraceStatus(ctx context.Context, isOn bool) context.Context {
+	return context.WithValue(ctx, traceStatusKey{}, isOn)
+}
+
+// getTraceStatus return status of tracing or false if not set
+func getTraceStatus(ctx context.Context) bool {
+	value := ctx.Value(traceStatusKey{})
+	if v, ok := value.(bool); ok {
+		return v
+	}
+	return false
+}

--- a/network/connection_wrapper.go
+++ b/network/connection_wrapper.go
@@ -17,6 +17,7 @@ limitations under the License.
 package network
 
 import (
+	"context"
 	"net"
 )
 
@@ -27,6 +28,6 @@ type ConnectionTimeoutWrapper interface {
 
 // ConnectionWrapper interface
 type ConnectionWrapper interface {
-	WrapClient(id []byte, conn net.Conn) (net.Conn, error)
-	WrapServer(conn net.Conn) (net.Conn, []byte, error) // conn, ClientID, error
+	WrapClient(ctx context.Context, id []byte, conn net.Conn) (net.Conn, error)
+	WrapServer(ctx context.Context, conn net.Conn) (net.Conn, []byte, error) // conn, ClientID, error
 }

--- a/network/connection_wrapper_test.go
+++ b/network/connection_wrapper_test.go
@@ -17,6 +17,7 @@ package network
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"net"
 	"os"
@@ -65,7 +66,7 @@ func testWrapper(clientWrapper, serverWrapper ConnectionWrapper, t *testing.T) {
 			return
 		}
 		t.Log("wrap server")
-		conn, clientID, err := serverWrapper.WrapServer(conn)
+		conn, clientID, err := serverWrapper.WrapServer(context.TODO(), conn)
 		if err != nil {
 			conn.Close()
 			t.Fatal(err)
@@ -108,7 +109,7 @@ func testWrapper(clientWrapper, serverWrapper ConnectionWrapper, t *testing.T) {
 	}
 	defer connection.Close()
 	t.Log("wrap client")
-	connection, err = clientWrapper.WrapClient(TestClientID, connection)
+	connection, err = clientWrapper.WrapClient(context.TODO(), TestClientID, connection)
 	if err != nil {
 		connection.Close()
 		t.Fatal(err)
@@ -291,7 +292,7 @@ func testTLSConfig(serverWrapper *TLSConnectionWrapper, t *testing.T) {
 		t.Fatal(err)
 	}
 	go func() {
-		_, _, err := serverWrapper.WrapServer(serverConn)
+		_, _, err := serverWrapper.WrapServer(context.TODO(), serverConn)
 		if err != nil {
 			if err.Error() != "tls: no cipher suite supported by both client and server" {
 				t.Fatal("Expected error with unsupported ciphersuits")
@@ -302,7 +303,7 @@ func testTLSConfig(serverWrapper *TLSConnectionWrapper, t *testing.T) {
 		t.Fatal("expected error")
 	}()
 	go func() {
-		_, err := clientWrapper.WrapClient([]byte("some client"), clientConn)
+		_, err := clientWrapper.WrapClient(context.TODO(), []byte("some client"), clientConn)
 		if err != nil {
 			if err.Error() != "remote error: tls: handshake failure" {
 				t.Fatal("Expected with handshake failure")
@@ -341,7 +342,7 @@ func testTLSConfig(serverWrapper *TLSConnectionWrapper, t *testing.T) {
 		t.Fatal(err)
 	}
 	go func() {
-		_, _, err := serverWrapper.WrapServer(serverConn)
+		_, _, err := serverWrapper.WrapServer(context.TODO(), serverConn)
 		if err != nil {
 			// error has concatenated protocol version at end of string and we doesn't need to compare as equality
 			if !strings.HasPrefix(err.Error(), "tls: client offered an unsupported, maximum protocol version of") {
@@ -353,7 +354,7 @@ func testTLSConfig(serverWrapper *TLSConnectionWrapper, t *testing.T) {
 		t.Fatal("expected error")
 	}()
 	go func() {
-		_, err := clientWrapper.WrapClient([]byte("some client"), clientConn)
+		_, err := clientWrapper.WrapClient(context.TODO(), []byte("some client"), clientConn)
 		if err != nil {
 			if err.Error() != "remote error: tls: protocol version not supported" {
 				t.Fatal("Expected incorrect protocol version error")

--- a/network/raw_wrapper.go
+++ b/network/raw_wrapper.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package network
 
-import "net"
+import (
+	"context"
+	"net"
+)
 
 // RawConnectionWrapper doesn't add any encryption above connection
 type RawConnectionWrapper struct {
@@ -25,13 +28,13 @@ type RawConnectionWrapper struct {
 }
 
 // WrapClient returns RawConnectionWrapper above client connection
-func (wrapper *RawConnectionWrapper) WrapClient(id []byte, conn net.Conn) (net.Conn, error) {
+func (wrapper *RawConnectionWrapper) WrapClient(ctx context.Context, id []byte, conn net.Conn) (net.Conn, error) {
 	wrapper.Conn = conn
 	return conn, nil
 }
 
 // WrapServer returns RawConnectionWrapper above server connection
-func (wrapper *RawConnectionWrapper) WrapServer(conn net.Conn) (net.Conn, []byte, error) {
+func (wrapper *RawConnectionWrapper) WrapServer(ctx context.Context, conn net.Conn) (net.Conn, []byte, error) {
 	wrapper.Conn = conn
 	return conn, wrapper.ClientID, nil
 }

--- a/network/tls_wrapper.go
+++ b/network/tls_wrapper.go
@@ -17,6 +17,7 @@ limitations under the License.
 package network
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
@@ -52,7 +53,7 @@ func NewTLSConnectionWrapper(clientID []byte, config *tls.Config) (*TLSConnectio
 }
 
 // WrapClient wraps client connection into TLS
-func (wrapper *TLSConnectionWrapper) WrapClient(id []byte, conn net.Conn) (net.Conn, error) {
+func (wrapper *TLSConnectionWrapper) WrapClient(ctx context.Context, id []byte, conn net.Conn) (net.Conn, error) {
 	conn.SetDeadline(time.Now().Add(DefaultNetworkTimeout))
 	tlsConn := tls.Client(conn, wrapper.config)
 	err := tlsConn.Handshake()
@@ -65,7 +66,7 @@ func (wrapper *TLSConnectionWrapper) WrapClient(id []byte, conn net.Conn) (net.C
 }
 
 // WrapServer wraps server connection into TLS
-func (wrapper *TLSConnectionWrapper) WrapServer(conn net.Conn) (net.Conn, []byte, error) {
+func (wrapper *TLSConnectionWrapper) WrapServer(ctx context.Context, conn net.Conn) (net.Conn, []byte, error) {
 	conn.SetDeadline(time.Now().Add(DefaultNetworkTimeout))
 	tlsConn := tls.Server(conn, wrapper.config)
 	err := tlsConn.Handshake()

--- a/network/trace.go
+++ b/network/trace.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2018, Cossack Labs Limited
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package network
+
+import (
+	"context"
+	"errors"
+	"github.com/cossacklabs/acra/utils"
+	log "github.com/sirupsen/logrus"
+	"go.opencensus.io/trace"
+	"go.opencensus.io/trace/propagation"
+	"net"
+)
+
+// ErrContextWithoutTrace error if context.Context hasn't any trace.Span
+var ErrContextWithoutTrace = errors.New("context hasn't any trace")
+
+// SendTrace fetch span from context and propagate it to conn as binary data. If context doesn't contain trace then ErrContextWithoutTrace return
+func SendTrace(ctx context.Context, conn net.Conn) error {
+	log.Infoln("Send trace")
+	span := trace.FromContext(ctx)
+	if span == nil {
+		return ErrContextWithoutTrace
+	}
+	binContext := propagation.Binary(span.SpanContext())
+	return utils.SendData(binContext, conn)
+}
+
+// ReadTrace read trace from conn and return
+func ReadTrace(conn net.Conn) (trace.SpanContext, error) {
+	log.Infoln("Read trace")
+	binContext, err := utils.ReadData(conn)
+	if err != nil {
+		return trace.SpanContext{}, err
+	}
+	spanContext, _ := propagation.FromBinary(binContext)
+	return spanContext, nil
+}


### PR DESCRIPTION
* extend connection wrapper with new context.Context parameter
* use specific logger instead global when it exists
* send trace data from connector to server/translator
* receive trace data on translator for http requests (grpc now unsupported because need deeper integration)
* receive trace data on server side and use it to create next spans
* add log exporter of traces
* add parameters for jaeger exporter