### PR TITLE
drop go18 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
     environment:
       GOTHEMIS_IMPORT: github.com/cossacklabs/themis/gothemis
       FILEPATH_ERROR_FLAG: /tmp/test_fail
-      VERSIONS: 1.8 1.8.7 1.9.4 1.10 1.10.3
+      VERSIONS: 1.9.7 1.10.5 1.11.2
       TEST_DB_PORT: 5432
       GOPATH_FOLDER: gopath
       TEST_RANDOM_DATA_FOLDER: /tmp/test_data
@@ -52,7 +52,7 @@ jobs:
     environment:
       GOTHEMIS_IMPORT: github.com/cossacklabs/themis/gothemis
       FILEPATH_ERROR_FLAG: /tmp/test_fail
-      VERSIONS: 1.8 1.8.7 1.9.4 1.10 1.10.3
+      VERSIONS: 1.9.7 1.10.5 1.11.2
       TEST_MYSQL: true
       TEST_DB_PORT: 3306
       GOPATH_FOLDER: gopath
@@ -93,7 +93,7 @@ jobs:
     environment:
       GOTHEMIS_IMPORT: github.com/cossacklabs/themis/gothemis
       FILEPATH_ERROR_FLAG: /tmp/test_fail
-      VERSIONS: 1.8 1.8.7 1.9.4 1.10 1.10.3
+      VERSIONS: 1.9.7 1.10.5 1.11.2
       TEST_MYSQL: true
       TEST_DB_PORT: 3306
       GOPATH_FOLDER: gopath


### PR DESCRIPTION
grpc-go removed support of go 1.6-1.8 - https://github.com/grpc/grpc-go/commit/59a2cfbdf9272f6334fe4856b6e7c8d212845b3d
and after that, we have failed tests