### PR TITLE
process queries in prepared statements in binary protocol (pgsql)

### DIFF
--- a/decryptor/mysql/response_proxy.go
+++ b/decryptor/mysql/response_proxy.go
@@ -322,10 +322,15 @@ func (handler *MysqlHandler) ClientToDbConnector(errCh chan<- error) {
 				}
 				continue
 			}
-			handler.setQueryHandler(handler.QueryResponseHandler)
+			if cmd == COM_QUERY {
+				handler.setQueryHandler(handler.QueryResponseHandler)
+			}
 			censorSpan.End()
 			break
-		case COM_STMT_EXECUTE, COM_STMT_CLOSE, COM_STMT_SEND_LONG_DATA, COM_STMT_RESET:
+		case COM_STMT_EXECUTE:
+			handler.setQueryHandler(handler.QueryResponseHandler)
+			break
+		case COM_STMT_CLOSE, COM_STMT_SEND_LONG_DATA, COM_STMT_RESET:
 			fallthrough
 		default:
 			clientLog.Debugf("Command %d not supported now", cmd)

--- a/decryptor/mysql/response_proxy.go
+++ b/decryptor/mysql/response_proxy.go
@@ -297,7 +297,7 @@ func (handler *MysqlHandler) ClientToDbConnector(errCh chan<- error) {
 			handler.dbConnection.Close()
 			errCh <- io.EOF
 			return
-		case COM_QUERY, COM_STMT_EXECUTE:
+		case COM_QUERY, COM_STMT_PREPARE:
 			_, censorSpan := trace.StartSpan(packetSpanCtx, "censor")
 			query := string(data)
 
@@ -325,7 +325,7 @@ func (handler *MysqlHandler) ClientToDbConnector(errCh chan<- error) {
 			handler.setQueryHandler(handler.QueryResponseHandler)
 			censorSpan.End()
 			break
-		case COM_STMT_PREPARE, COM_STMT_CLOSE, COM_STMT_SEND_LONG_DATA, COM_STMT_RESET:
+		case COM_STMT_EXECUTE, COM_STMT_CLOSE, COM_STMT_SEND_LONG_DATA, COM_STMT_RESET:
 			fallthrough
 		default:
 			clientLog.Debugf("Command %d not supported now", cmd)

--- a/decryptor/postgresql/utils.go
+++ b/decryptor/postgresql/utils.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2018, Cossack Labs Limited
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package postgresql
+
+import (
+	"bytes"
+	"errors"
+)
+
+var terminator = []byte{0}
+var ErrTerminatorNotFound = errors.New("invalid string, terminator not found")
+
+// FetchQueryFromParse return Query value from Parse packet payload (without message type and length of packet)
+//
+// Find first null terminator as end of prepared statement name and find next which terminate query string
+// Parse packet has next structure: 'P' + int32 (length of packet) + NullTerminatedString (prepared statement name) +
+// + NullTerminatedString (query) + int16 (number of next int32 parameters) + int32[n] (parameters)
+// https://www.postgresql.org/docs/9.3/protocol-message-formats.html
+func FetchQueryFromParse(data []byte) ([]byte, error) {
+	startIndex := bytes.Index(data, terminator)
+	if startIndex == -1 {
+		return nil, ErrTerminatorNotFound
+	}
+	// skip terminator of previous field
+	startIndex += 1
+	endIndex := bytes.Index(data[startIndex:], terminator)
+	if endIndex == -1 {
+		return nil, ErrTerminatorNotFound
+	}
+	// convert to absolute
+	endIndex += startIndex
+	return data[startIndex : endIndex+1], nil
+}

--- a/decryptor/postgresql/utils_test.go
+++ b/decryptor/postgresql/utils_test.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2018, Cossack Labs Limited
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package postgresql
+
+import (
+	"encoding/hex"
+	"testing"
+)
+
+// parsePacketQuery contain query that used in parsePacketHex
+// took from wireshark
+var parsePacketQuery = "Select 1 from test where data=$1"
+var parsePacketHex = "5000000029310053656c65637420312066726f6d207465737420776865726520646174613d2431000000"
+
+func TestFetchQueryFromParse(t *testing.T) {
+	parsePacket, err := hex.DecodeString(parsePacketHex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	query, err := FetchQueryFromParse(parsePacket[5:])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(query) != len(parsePacketQuery)+1 {
+		t.Fatal("Incorrect query length")
+	}
+	if string(query[:len(query)-1]) != parsePacketQuery {
+		t.Fatal("Incorrect query string")
+	}
+}

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,6 @@
 pythemis
 psycopg2
+asyncpg
 sqlalchemy
 PyMySQL==0.8.0
 semver==2.7.9


### PR DESCRIPTION
noticed that now we don't process queries from prepared statements in binary protocol to postgresql with acra-censor (decryption worked before)
but can't add good integration tests now, because python hasn't good libraries to work with postgresql with binary protocol. psycopg2 (most popular) use text protocol for prepared statements (that we test too). found asyncpg, but tests with it unstable in my local environment (tests fail on closing connection or unexpected empty result without any errors)

now tested it manually before push and check that branch of fetching query from Parse packet works as expected and leave tests with asyncpg which can be used by commenting `self.skipTest` in `checkSkip` function