### PR TITLE
remove default endpoints for jaeger trace exporter

### DIFF
--- a/cmd/jaeger.go
+++ b/cmd/jaeger.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cmd
 
 import (
+	"errors"
 	"flag"
 	"go.opencensus.io/exporter/jaeger"
 )
@@ -25,6 +26,7 @@ var options = jaeger.Options{
 	AgentEndpoint:     "",
 	CollectorEndpoint: "",
 }
+var ErrInvalidJaegerExporterEndpoint = errors.New("empty jaeger_agent_endpoint and jaeger_collector_endpoint")
 
 // RegisterJaegerCmdParameters register cli parameters with flag for jaeger options
 func RegisterJaegerCmdParameters() {
@@ -37,4 +39,12 @@ func RegisterJaegerCmdParameters() {
 // GetJaegerCmdParameters return jaeger.Options parsed from config/cmd parameters
 func GetJaegerCmdParameters() jaeger.Options {
 	return options
+}
+
+// ValidateJaegerCmdParameters validate cli parameters
+func ValidateJaegerCmdParameters() error {
+	if options.AgentEndpoint == "" && options.CollectorEndpoint == "" {
+		return ErrInvalidJaegerExporterEndpoint
+	}
+	return nil
 }

--- a/cmd/jaeger.go
+++ b/cmd/jaeger.go
@@ -22,14 +22,14 @@ import (
 )
 
 var options = jaeger.Options{
-	AgentEndpoint:     "127.0.0.1:6831",
-	CollectorEndpoint: "127.0.0.1:14268",
+	AgentEndpoint:     "",
+	CollectorEndpoint: "",
 }
 
 // RegisterJaegerCmdParameters register cli parameters with flag for jaeger options
 func RegisterJaegerCmdParameters() {
-	flag.StringVar(&options.AgentEndpoint, "jaeger_agent_endpoint", options.AgentEndpoint, "Jaeger agent endpoint that will be used to export trace data")
-	flag.StringVar(&options.CollectorEndpoint, "jaeger_collector_endpoint", options.CollectorEndpoint, "Jaeger endpoint that will be used to export trace data")
+	flag.StringVar(&options.AgentEndpoint, "jaeger_agent_endpoint", options.AgentEndpoint, "Jaeger agent endpoint (for example, localhost:6831) that will be used to export trace data")
+	flag.StringVar(&options.CollectorEndpoint, "jaeger_collector_endpoint", options.CollectorEndpoint, "Jaeger endpoint (for example, http://localhost:14268/api/traces) that will be used to export trace data")
 	flag.StringVar(&options.Username, "jaeger_basic_auth_username", "", "Username used for basic auth (optional) to jaeger")
 	flag.StringVar(&options.Password, "jaeger_basic_auth_password", "", "Password used for basic auth (optional) to jaeger")
 }

--- a/cmd/tracing.go
+++ b/cmd/tracing.go
@@ -50,6 +50,10 @@ func SetupTracing(serviceName string) {
 		trace.RegisterExporter(&logging.LogSpanExporter{})
 	}
 	if IsTraceToJaegerOn() {
+		if err := ValidateJaegerCmdParameters(); err != nil {
+			log.WithError(err).Errorln("Invalid jaeger parameters")
+			os.Exit(1)
+		}
 		jaegerOptions := GetJaegerCmdParameters()
 		jaegerOptions.ServiceName = serviceName
 		jaegerEndpoint, err := jaeger.NewExporter(jaegerOptions)

--- a/configs/acra-connector.yaml
+++ b/configs/acra-connector.yaml
@@ -67,8 +67,8 @@ incoming_connection_prometheus_metrics_string:
 # Connection string like tcp://x.x.x.x:yyyy or unix:///path/to/socket
 incoming_connection_string: tcp://127.0.0.1:9494/
 
-# Jaeger agent endpoint that will be used to export trace data
-jaeger_agent_endpoint: 127.0.0.1:6831
+# Jaeger agent endpoint (for example, localhost:6831) that will be used to export trace data
+jaeger_agent_endpoint: 
 
 # Password used for basic auth (optional) to jaeger
 jaeger_basic_auth_password: 
@@ -76,8 +76,8 @@ jaeger_basic_auth_password:
 # Username used for basic auth (optional) to jaeger
 jaeger_basic_auth_username: 
 
-# Jaeger endpoint that will be used to export trace data
-jaeger_collector_endpoint: 127.0.0.1:14268
+# Jaeger endpoint (for example, http://localhost:14268/api/traces) that will be used to export trace data
+jaeger_collector_endpoint: 
 
 # Folder from which will be loaded keys
 keys_dir: .acrakeys

--- a/configs/acra-server.yaml
+++ b/configs/acra-server.yaml
@@ -64,8 +64,8 @@ incoming_connection_prometheus_metrics_string:
 # Connection string like tcp://x.x.x.x:yyyy or unix:///path/to/socket
 incoming_connection_string: tcp://0.0.0.0:9393/
 
-# Jaeger agent endpoint that will be used to export trace data
-jaeger_agent_endpoint: 127.0.0.1:6831
+# Jaeger agent endpoint (for example, localhost:6831) that will be used to export trace data
+jaeger_agent_endpoint: 
 
 # Password used for basic auth (optional) to jaeger
 jaeger_basic_auth_password: 
@@ -73,8 +73,8 @@ jaeger_basic_auth_password:
 # Username used for basic auth (optional) to jaeger
 jaeger_basic_auth_username: 
 
-# Jaeger endpoint that will be used to export trace data
-jaeger_collector_endpoint: 127.0.0.1:14268
+# Jaeger endpoint (for example, http://localhost:14268/api/traces) that will be used to export trace data
+jaeger_collector_endpoint: 
 
 # Folder from which will be loaded keys
 keys_dir: .acrakeys

--- a/configs/acra-translator.yaml
+++ b/configs/acra-translator.yaml
@@ -22,8 +22,8 @@ incoming_connection_http_string:
 # URL which will be used to expose Prometheus metrics (use <URL>/metrics address to pull metrics)
 incoming_connection_prometheus_metrics_string: 
 
-# Jaeger agent endpoint that will be used to export trace data
-jaeger_agent_endpoint: 127.0.0.1:6831
+# Jaeger agent endpoint (for example, localhost:6831) that will be used to export trace data
+jaeger_agent_endpoint: 
 
 # Password used for basic auth (optional) to jaeger
 jaeger_basic_auth_password: 
@@ -31,8 +31,8 @@ jaeger_basic_auth_password:
 # Username used for basic auth (optional) to jaeger
 jaeger_basic_auth_username: 
 
-# Jaeger endpoint that will be used to export trace data
-jaeger_collector_endpoint: 127.0.0.1:14268
+# Jaeger endpoint (for example, http://localhost:14268/api/traces) that will be used to export trace data
+jaeger_collector_endpoint: 
 
 # Folder from which will be loaded keys
 keys_dir: .acrakeys


### PR DESCRIPTION
to avoid misconfiguration we with @shadinua decided that would be better to remove default values and require the explicit setup of this params