### PR TITLE
test prepared statements with acra-censor

### DIFF
--- a/acra-censor/handlers/blacklist_handler.go
+++ b/acra-censor/handlers/blacklist_handler.go
@@ -55,7 +55,7 @@ func (handler *BlacklistHandler) CheckQuery(query string) (bool, error) {
 	if len(handler.tables) != 0 {
 		parsedQuery, err := sqlparser.Parse(query)
 		if err != nil {
-			handler.logger.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCensorQueryParseError).WithError(ErrQuerySyntaxError).Errorln("Query has been blocked by blacklist [tables]. Parsing error")
+			handler.logger.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCensorQueryParseError).WithError(err).Errorln("Query has been blocked by blacklist [tables]. Parsing error")
 			return false, ErrQuerySyntaxError
 		}
 		switch parsedQuery := parsedQuery.(type) {

--- a/acra-censor/handlers/queryignore_handler.go
+++ b/acra-censor/handlers/queryignore_handler.go
@@ -54,7 +54,7 @@ func (handler *QueryIgnoreHandler) AddQueries(queries []string) {
 	for _, query := range queries {
 		normalizedQuery, _, err := NormalizeAndRedactSQLQuery(query)
 		if err != nil {
-			logrus.WithError(err).Warningln("Can't add query to QuieryIgnoreHandler in normalized form, added as is")
+			logrus.WithError(err).Warningln("Can't add query to QueryIgnoreHandler in normalized form, added as is")
 			// add as is
 			handler.ignoredQueries[query] = true
 			continue

--- a/acra-censor/handlers/queryignore_handler.go
+++ b/acra-censor/handlers/queryignore_handler.go
@@ -52,7 +52,8 @@ func (handler *QueryIgnoreHandler) AddQueries(queries []string) {
 	for _, query := range queries {
 		normalizedQuery, _, err := NormalizeAndRedactSQLQuery(query)
 		if err != nil {
-			continue
+			// add as is
+			handler.ignoredQueries[query] = true
 		}
 		handler.ignoredQueries[normalizedQuery] = true
 	}

--- a/acra-censor/handlers/queryignore_handler.go
+++ b/acra-censor/handlers/queryignore_handler.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package handlers
 
+import "github.com/sirupsen/logrus"
+
 // QueryIgnoreHandler allows to ignore any query
 type QueryIgnoreHandler struct {
 	ignoredQueries map[string]bool
@@ -52,8 +54,10 @@ func (handler *QueryIgnoreHandler) AddQueries(queries []string) {
 	for _, query := range queries {
 		normalizedQuery, _, err := NormalizeAndRedactSQLQuery(query)
 		if err != nil {
+			logrus.WithError(err).Warningln("Can't add query to QuieryIgnoreHandler in normalized form, added as is")
 			// add as is
 			handler.ignoredQueries[query] = true
+			continue
 		}
 		handler.ignoredQueries[normalizedQuery] = true
 	}

--- a/acra-censor/handlers/whitelist_handler.go
+++ b/acra-censor/handlers/whitelist_handler.go
@@ -55,7 +55,7 @@ func (handler *WhitelistHandler) CheckQuery(query string) (bool, error) {
 	if len(handler.tables) != 0 {
 		parsedQuery, err := sqlparser.Parse(query)
 		if err != nil {
-			handler.logger.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCensorQueryParseError).WithError(ErrQuerySyntaxError).Errorln("Query has been blocked by whitelist [tables]. Parsing error")
+			handler.logger.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCensorQueryParseError).WithError(err).Errorln("Query has been blocked by whitelist [tables]. Parsing error")
 			return false, ErrQuerySyntaxError
 		}
 		switch parsedQuery := parsedQuery.(type) {

--- a/decryptor/mysql/response_proxy.go
+++ b/decryptor/mysql/response_proxy.go
@@ -307,7 +307,7 @@ func (handler *MysqlHandler) ClientToDbConnector(errCh chan<- error) {
 				if err == handlers.ErrQuerySyntaxError {
 					clientLog.WithError(err).Infof("Parsing error on query: %s", queryWithHiddenValues)
 				} else {
-					clientLog.WithField("sql", queryWithHiddenValues).Debugln("Com_query")
+					clientLog.WithFields(logrus.Fields{"sql": queryWithHiddenValues, "command": cmd}).Debugln("Query command")
 				}
 			}
 

--- a/tests/acra-censor_configs/acra-censor_blacklist.yaml
+++ b/tests/acra-censor_configs/acra-censor_blacklist.yaml
@@ -15,6 +15,8 @@ handlers:
       - SELECT CAST('test collated returns' AS CHAR CHARACTER SET utf8mb4) COLLATE utf8mb4_bin AS anon_1
       - select 1
       - SET AUTOCOMMIT = 0
+      - SET NAMES 'ascii' COLLATE 'ascii_general_ci'
+      - SET @@session.autocommit = OFF
       #postgres
       - BEGIN
       - "SELECT t.oid, typarray\nFROM pg_type t JOIN pg_namespace ns\n    ON typnamespace = ns.oid\nWHERE typname = 'hstore';\n"

--- a/tests/acra-censor_configs/acra-censor_whitelist.yaml
+++ b/tests/acra-censor_configs/acra-censor_whitelist.yaml
@@ -15,6 +15,8 @@ handlers:
       - SELECT CAST('test collated returns' AS CHAR CHARACTER SET utf8mb4) COLLATE utf8mb4_bin AS anon_1
       - select 1
       - SET AUTOCOMMIT = 0
+      - SET NAMES 'ascii' COLLATE 'ascii_general_ci'
+      - SET @@session.autocommit = OFF
       #postgres
       - BEGIN
       - "SELECT t.oid, typarray\nFROM pg_type t JOIN pg_namespace ns\n    ON typnamespace = ns.oid\nWHERE typname = 'hstore';\n"

--- a/tests/test.py
+++ b/tests/test.py
@@ -455,8 +455,7 @@ class ProcessStub(object):
 
 ConnectionArgs = collections.namedtuple(
     "ConnectionArgs", ["user", "password", "host", "port", "dbname",
-                       "ssl_ca", "ssl_key", "ssl_cert"],
-    defaults={'ssl_ca': None, 'ssl_key': None, 'ssl_cert': None})
+                       "ssl_ca", "ssl_key", "ssl_cert"])
 
 
 class QueryExecutor(object):
@@ -2682,7 +2681,10 @@ class TestMysqlTextPreparedStatement(BasePrepareStatementMixin, BaseTestCase):
         return PyMysqlExecutor(
             ConnectionArgs(host=get_db_host(), port=self.CONNECTOR_PORT_1,
                            user=DB_USER, password=DB_USER_PASSWORD,
-                           dbname=DB_NAME)).execute_prepared_statement(query)
+                           dbname=DB_NAME, ssl_ca='tests/server.crt',
+                           ssl_key='tests/client.key',
+                           ssl_cert='tests/client.crt')
+        ).execute_prepared_statement(query)
 
 
 class TestMysqlBinaryPreparedStatement(BasePrepareStatementMixin, BaseTestCase):
@@ -2708,7 +2710,10 @@ class TestPostgresqlTextPreparedStatement(BasePrepareStatementMixin, BaseTestCas
     def executePreparedStatement(self, query):
         return Psycopg2Executor(ConnectionArgs(host=get_db_host(), port=self.CONNECTOR_PORT_1,
                            user=DB_USER, password=DB_USER_PASSWORD,
-                           dbname=DB_NAME)).execute_prepared_statement(query)
+                           dbname=DB_NAME, ssl_ca='tests/server.crt',
+                           ssl_key='tests/client.key',
+                           ssl_cert='tests/client.crt')
+                                ).execute_prepared_statement(query)
 
 
 class TestPostgresqlBinaryPreparedStatement(BasePrepareStatementMixin,
@@ -2721,7 +2726,9 @@ class TestPostgresqlBinaryPreparedStatement(BasePrepareStatementMixin,
         return AsyncpgExecutor(
             ConnectionArgs(host=get_db_host(), port=self.CONNECTOR_PORT_1,
                            user=DB_USER, password=DB_USER_PASSWORD,
-                           dbname=DB_NAME)
+                           dbname=DB_NAME, ssl_ca='tests/server.crt',
+                           ssl_key='tests/client.key',
+                           ssl_cert='tests/client.crt')
         ).execute_prepared_statement(query)
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -20,6 +20,12 @@ def clean_test_data():
         shutil.rmtree(folder)
 
 
+def safe_string(str_or_bytes, encoding='utf-8'):
+    if isinstance(str_or_bytes, str):
+        return str_or_bytes
+    return str_or_bytes.decode(encoding)
+
+
 def get_random_data_files():
     folder = os.environ.get(TEMP_DATA_FOLDER_VARNAME)
     if not folder:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -40,7 +40,7 @@ def get_random_data_files():
     if not os.path.exists(folder) or len(os.listdir(folder)) == 0:
         command = ['python', 'tests/generate_random_data.py']
         print('call {}'.format(' '.join(command)))
-        subprocess.check_call(command, env=os.environ)
+        subprocess.check_call(command, env=os.environ, cwd=os.getcwd())
     return [os.path.join(folder, i) for i in os.listdir(folder)]
 
 


### PR DESCRIPTION
* add usage of prepared statements in acra-censor tests and refactored connections to re-use the same code (connections with different drivers and text/binary prepared statements per db type) in several places 
* add query as is if can't normalize to QueryIgnore handler to allow ignore queries that can't parse