### PR TITLE
Adapt cppcodec usage to current recommendations

### DIFF
--- a/examples/cpp/Readme.md
+++ b/examples/cpp/Readme.md
@@ -50,8 +50,7 @@ vector<uint8_t> pub_key = base64::decode("VUVDMgAAAC1SGS5iAprH9f1sf7GR4OZ/J1YEn8
 Create AcraStructs from data-to-encrypt and Acra public storage key (don't forget to update key to your AcraServer's key):
 
 ```cpp
-#include <cppcodec/base64_default_rfc4648.hpp>
-#include <cppcodec/hex_default_lower.hpp>
+#include <cppcodec/base64_rfc4648.hpp>
 
 #include "acrawriter.hpp"
 
@@ -77,8 +76,7 @@ acra::acrastruct as = acrawriter.create_acrastruct(message_vector, pub_key);
 Create AcraStructs from data-to-encrypt, ZoneID and Acra public zone key (don't forget to update key to your AcraServer's key):
 
 ```cpp
-#include <cppcodec/base64_default_rfc4648.hpp>
-#include <cppcodec/hex_default_lower.hpp>
+#include <cppcodec/base64_rfc4648.hpp>
 
 #include "acrawriter.hpp"
 

--- a/examples/cpp/main.cpp
+++ b/examples/cpp/main.cpp
@@ -1,7 +1,7 @@
 #include <iostream>
 
-#include <cppcodec/base64_default_rfc4648.hpp>
-#include <cppcodec/hex_default_lower.hpp>
+#include <cppcodec/base64_rfc4648.hpp>
+#include <cppcodec/hex_lower.hpp>
 
 #include "acrawriter.hpp"
 

--- a/examples/cpp/main_tests.cpp
+++ b/examples/cpp/main_tests.cpp
@@ -5,8 +5,8 @@
 #include <random>
 
 #include <catch.hpp>
-#include <cppcodec/base64_default_rfc4648.hpp>
-#include <cppcodec/hex_default_lower.hpp>
+#include <cppcodec/base64_rfc4648.hpp>
+#include <cppcodec/hex_lower.hpp>
 
 #include "acrawriter.hpp"
 #include <themis/themis.h>


### PR DESCRIPTION
Hi there, cppcodec maintainer here. Thanks for using my library!

I released the 0.2 version a few months ago, which include a note that `*_default_*.hpp` includes are not recommended anymore and may be discontinued in the future. Not sure how popular your software is, but if you're going through the trouble of writing tutorials of your own, I think maybe I should try to update your examples, so people adopt the "right" way of doing things after looking at your README.

The good news is that you've already been using your own alias statements, like here:
```
using base64 = cppcodec::base64_rfc4648;
using hex = cppcodec::hex_lower;
```
The types on the right hand are provided by the header files of the same name, no `*_default_*` ones are required and the only change I'd make is adapting the actual include lines.

(I also took out the hex include from your README because you didn't use it in the example code. Let me know if this is wrong.)

Here's a patch to do this. The patch is trivial enough that I don't believe any of my copyright applies to it. (You look like you may be a commercial entity, so let's just get this out of the way.) I haven't built your software, but I'm pretty confident that it should continue working.

Cheers, and good luck with your project!