### PR TITLE
Update version of cppcodec for AcraWriter C++ example project

### DIFF
--- a/examples/cpp/Readme.md
+++ b/examples/cpp/Readme.md
@@ -50,8 +50,7 @@ vector<uint8_t> pub_key = base64::decode("VUVDMgAAAC1SGS5iAprH9f1sf7GR4OZ/J1YEn8
 Create AcraStructs from data-to-encrypt and Acra public storage key (don't forget to update key to your AcraServer's key):
 
 ```cpp
-#include <cppcodec/base64_default_rfc4648.hpp>
-#include <cppcodec/hex_default_lower.hpp>
+#include <cppcodec/base64_rfc4648.hpp>
 
 #include "acrawriter.hpp"
 
@@ -77,8 +76,7 @@ acra::acrastruct as = acrawriter.create_acrastruct(message_vector, pub_key);
 Create AcraStructs from data-to-encrypt, ZoneID and Acra public zone key (don't forget to update key to your AcraServer's key):
 
 ```cpp
-#include <cppcodec/base64_default_rfc4648.hpp>
-#include <cppcodec/hex_default_lower.hpp>
+#include <cppcodec/base64_rfc4648.hpp>
 
 #include "acrawriter.hpp"
 

--- a/examples/cpp/libs/cppcodec/base32_hex.hpp
+++ b/examples/cpp/libs/cppcodec/base32_hex.hpp
@@ -31,7 +31,7 @@ namespace cppcodec {
 
 namespace detail {
 
-// RFC 4648 uses a simple alphabet: A-Z starting at index 0, then 2-7 starting at index 26.
+// RFC 4648 also specifies a hex encoding system which uses 0-9, then A-V.
 static constexpr const char base32_hex_alphabet[] = {
     '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
     'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K',

--- a/examples/cpp/libs/cppcodec/data/raw_result_buffer.hpp
+++ b/examples/cpp/libs/cppcodec/data/raw_result_buffer.hpp
@@ -41,10 +41,9 @@ public:
     {
     }
 
-    char last() const { return *(m_ptr - 1); }
-    void push_back(char c) { *m_ptr = c; ++m_ptr; }
-    size_t size() const { return m_ptr - m_begin; }
-    void resize(size_t size) { m_ptr = m_begin + size; }
+    CPPCODEC_ALWAYS_INLINE void push_back(char c) { *m_ptr = c; ++m_ptr; }
+    CPPCODEC_ALWAYS_INLINE size_t size() const { return m_ptr - m_begin; }
+    CPPCODEC_ALWAYS_INLINE void resize(size_t size) { m_ptr = m_begin + size; }
 
 private:
     char* m_ptr;
@@ -56,7 +55,7 @@ template <> inline void init<raw_result_buffer>(
         raw_result_buffer& result, empty_result_state&, size_t capacity)
 {
     // This version of init() doesn't do a reserve(), and instead checks whether the
-    // initial size (capacity) is enough before resizing to 0.
+    // initial size (capacity) is enough before resetting m_ptr to m_begin.
     // The codec is expected not to exceed this capacity.
     if (capacity > result.size()) {
         abort();

--- a/examples/cpp/main.cpp
+++ b/examples/cpp/main.cpp
@@ -1,7 +1,7 @@
 #include <iostream>
 
-#include <cppcodec/base64_default_rfc4648.hpp>
-#include <cppcodec/hex_default_lower.hpp>
+#include <cppcodec/base64_rfc4648.hpp>
+#include <cppcodec/hex_lower.hpp>
 
 #include "acrawriter.hpp"
 

--- a/examples/cpp/main_tests.cpp
+++ b/examples/cpp/main_tests.cpp
@@ -5,8 +5,8 @@
 #include <random>
 
 #include <catch.hpp>
-#include <cppcodec/base64_default_rfc4648.hpp>
-#include <cppcodec/hex_default_lower.hpp>
+#include <cppcodec/base64_rfc4648.hpp>
+#include <cppcodec/hex_lower.hpp>
 
 #include "acrawriter.hpp"
 #include <themis/themis.h>


### PR DESCRIPTION
As next step of #289 I've update the source code of cppcodec as well. We link cppcodec as source code in AcraWriter C++ example, so I've updated the entire "libs/cppcodec" folder.

Thank you @jpetso!