### PR TITLE
use newer version of pyyaml due to CVE-2017-18342

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -7,7 +7,9 @@ semver==2.7.9
 requests
 # driver with binary prepared statements support
 #mysql-connector-python==8.0.11
-PyYAML==3.13
+# stable release now 3.13 which has vulnerability
+# https://github.com/yaml/pyyaml/issues/243
+git+https://github.com/yaml/pyyaml@release/4.2
 
 # https://grpc.io/docs/quickstart/python.html
 grpcio==1.13.0

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -92,7 +92,7 @@ def decrypt_private_key(private_key, key_id, master_key):
 
 def prepare_encryptor_config(zone_id):
     with open(ENCRYPTOR_DEFAULT_CONFIG, 'r') as f:
-        config = yaml.load(f)
+        config = yaml.safe_load(f)
     for table in config['schemas']:
         for column in table['encrypted']:
             if 'zone_id' in column:


### PR DESCRIPTION
pyyaml uploaded to PYPI only 3.13 version so changed dependency to use directly sources from github instead PYPI until they update their package in PYPI
anyway we use this library only for tests and parse our static file from our repo and this fix just to hide alert from github : )