### PR TITLE
fix most of golint warnings

### DIFF
--- a/.circleci/check_golint.sh
+++ b/.circleci/check_golint.sh
@@ -4,7 +4,7 @@
 # golint print issues it found in source files
 # count lines with wc and check that N lines was in output
 result=$($GOPATH/bin/golint ./... | wc -l)
-if [[ $result -gt 142 ]]; then
+if [[ $result -gt 10 ]]; then
   # too many golint issues
   echo "Too many golint issues: $result"
   exit 1;

--- a/acra-censor/acra-censor_test.go
+++ b/acra-censor/acra-censor_test.go
@@ -149,7 +149,7 @@ func TestAllowTables(t *testing.T) {
 	// now we should allow query that access EMPLOYEE or Customers tables and deny all others
 	queryIndexesToPass := []int{1, 4, 5}
 	for _, i := range queryIndexesToPass {
-		err := censor.HandleQuery(testQueries[i])
+		err = censor.HandleQuery(testQueries[i])
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -857,7 +857,7 @@ func TestDenyTables(t *testing.T) {
 	//acracensor should block these queries
 	queryIndexesToBlock := []int{0, 2, 4, 5, 6}
 	for _, i := range queryIndexesToBlock {
-		err := censor.HandleQuery(testQueries[i])
+		err = censor.HandleQuery(testQueries[i])
 		if err != common.ErrDenyByTableError {
 			t.Fatal(err)
 		}
@@ -865,7 +865,7 @@ func TestDenyTables(t *testing.T) {
 	//acracensor should not block these queries
 	queryIndexesToPass := []int{1, 3}
 	for _, i := range queryIndexesToPass {
-		err := censor.HandleQuery(testQueries[i])
+		err = censor.HandleQuery(testQueries[i])
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -915,7 +915,7 @@ func TestDenySelectPattern(t *testing.T) {
 	}
 	//Queries that should be blocked by specified pattern have indexes: [0 .. 12] (all select queries)
 	for i, query := range testQueries {
-		err := censor.HandleQuery(query)
+		err = censor.HandleQuery(query)
 		if strings.HasPrefix(strings.ToLower(query), "select") {
 			if err != common.ErrDenyByPatternError {
 				t.Fatal(err, "Blacklist pattern passed query. \nPattern:", blacklistPattern+"\nQuery:", testQueries[i])
@@ -1464,7 +1464,7 @@ func TestQueryIgnoring(t *testing.T) {
 	acraCensor.AddHandler(blacklist)
 	//should not block
 	for _, query := range testQueries {
-		err := acraCensor.HandleQuery(query)
+		err = acraCensor.HandleQuery(query)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/acra-censor/common/logging_logic_test.go
+++ b/acra-censor/common/logging_logic_test.go
@@ -116,7 +116,7 @@ func TestSerializationOnSameQueries(t *testing.T) {
 
 	defer func() {
 		writer.Free()
-		err = os.Remove(tmpFile.Name())
+		err := os.Remove(tmpFile.Name())
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/benchmarks/cmd/read/direct/direct.go
+++ b/benchmarks/cmd/read/direct/direct.go
@@ -32,8 +32,8 @@ func main() {
 	}
 	fmt.Println("Start benchmark")
 	startTime := time.Now()
-	for i := 0; i < config.REQUEST_COUNT; i++ {
-		id := rand.Intn(config.ROW_COUNT)
+	for i := 0; i < config.RequestCount; i++ {
+		id := rand.Intn(config.RowCount)
 		rows, err := db.Query("SELECT id, data FROM test_raw WHERE id=$1;", &id)
 		if err != nil {
 			panic(err)

--- a/benchmarks/cmd/read/onekey_acrastruct/onekey_acrastruct.go
+++ b/benchmarks/cmd/read/onekey_acrastruct/onekey_acrastruct.go
@@ -37,8 +37,8 @@ func main() {
 	startTime := time.Now()
 	var rowID int
 	var data []byte
-	for i := 0; i < config.REQUEST_COUNT; i++ {
-		id := rand.Intn(config.ROW_COUNT)
+	for i := 0; i < config.RequestCount; i++ {
+		id := rand.Intn(config.RowCount)
 		err := db.QueryRow("SELECT id, data FROM test_without_zone WHERE id=$1+1;", &id).Scan(&rowID, &data)
 		if err != nil {
 			panic(err)

--- a/benchmarks/cmd/read/onekey_without_acrastruct/onekey_without_acrastruct.go
+++ b/benchmarks/cmd/read/onekey_without_acrastruct/onekey_without_acrastruct.go
@@ -37,8 +37,8 @@ func main() {
 	startTime := time.Now()
 	var rowID int
 	var data []byte
-	for i := 0; i < config.REQUEST_COUNT; i++ {
-		id := rand.Intn(config.ROW_COUNT)
+	for i := 0; i < config.RequestCount; i++ {
+		id := rand.Intn(config.RowCount)
 		err := db.QueryRow("SELECT id, data FROM test_raw WHERE id=$1+1;", &id).Scan(&rowID, &data)
 		if err != nil {
 			panic(err)

--- a/benchmarks/cmd/read/zone_acrastruct/zone_acrastruct.go
+++ b/benchmarks/cmd/read/zone_acrastruct/zone_acrastruct.go
@@ -38,8 +38,8 @@ func main() {
 	startTime := time.Now()
 	var rowID int
 	var zone, data []byte
-	for i := 0; i < config.REQUEST_COUNT; i++ {
-		id := rand.Intn(config.ROW_COUNT)
+	for i := 0; i < config.RequestCount; i++ {
+		id := rand.Intn(config.RowCount)
 		err := db.QueryRow("SELECT id, zone, data FROM test_with_zone WHERE id=$1+1;", &id).Scan(&rowID, &zone, &data)
 		if err != nil {
 			panic(err)

--- a/benchmarks/cmd/read/zone_without_acrastruct/zone_without_acrastruct.go
+++ b/benchmarks/cmd/read/zone_without_acrastruct/zone_without_acrastruct.go
@@ -38,8 +38,8 @@ func main() {
 	startTime := time.Now()
 	var rowID int
 	var zone, data []byte
-	for i := 0; i < config.REQUEST_COUNT; i++ {
-		id := rand.Intn(config.ROW_COUNT)
+	for i := 0; i < config.RequestCount; i++ {
+		id := rand.Intn(config.RowCount)
 		err := db.QueryRow("SELECT id, '1111111111111111111', data FROM test_raw WHERE id=$1+1;", &id).Scan(&rowID, &zone, &data)
 		if err != nil {
 			panic(err)

--- a/benchmarks/common/db.go
+++ b/benchmarks/common/db.go
@@ -99,7 +99,7 @@ func RunScripts(scripts []string, db *sql.DB) {
 func IsExistsData(tablename string, db *sql.DB) bool {
 	var count int
 	db.QueryRow(fmt.Sprintf("SELECT count(*) FROM %s;", tablename)).Scan(&count)
-	if count == config.ROW_COUNT {
+	if count == config.RowCount {
 		fmt.Printf("Data in table '%s' already exists\n", tablename)
 		return true
 	}

--- a/benchmarks/common/utils.go
+++ b/benchmarks/common/utils.go
@@ -26,9 +26,9 @@ import (
 	"path/filepath"
 )
 
-// GenerateData generates random data with MAX_DATA_LENGTH
+// GenerateData generates random data with MaxDataLength
 func GenerateData() ([]byte, error) {
-	length := rand.Intn(config.MAX_DATA_LENGTH)
+	length := rand.Intn(config.MaxDataLength)
 	data := make([]byte, length)
 	_, err := data_rand.Read(data)
 	return data, err
@@ -45,13 +45,13 @@ func GetServerOneKeyPublic() *keys.PublicKey {
 
 // ZoneData stores zone: zoneID and PublicKey
 type ZoneData struct {
-	Id        []byte
+	ID        []byte
 	PublicKey []byte
 }
 
 // JSONData stores JSON zone: zoneID and PublicKey
 type JSONData struct {
-	Id        string
+	ID        string
 	PublicKey []byte
 }
 
@@ -61,7 +61,7 @@ func LoadZones() []*ZoneData {
 	if err != nil {
 		panic(err)
 	}
-	zones := make([]*ZoneData, config.ZONE_COUNT)
+	zones := make([]*ZoneData, config.ZoneCount)
 	dumpedZoneData, err := ioutil.ReadFile(fmt.Sprintf("%v/public_keys.txt", absDir))
 	if err != nil {
 		panic(err)
@@ -72,7 +72,7 @@ func LoadZones() []*ZoneData {
 		if err != nil {
 			panic(err)
 		}
-		zones[i] = &ZoneData{PublicKey: jsonData.PublicKey, Id: []byte(jsonData.Id)}
+		zones[i] = &ZoneData{PublicKey: jsonData.PublicKey, ID: []byte(jsonData.ID)}
 	}
 	return zones
 }

--- a/benchmarks/config/consts.go
+++ b/benchmarks/config/consts.go
@@ -15,12 +15,12 @@
 package config
 
 const (
-	// ROW_COUNT num of rows that will be generated in each write benchmark
-	ROW_COUNT = 10000
-	// REQUEST_COUNT num of requests that will be done in each read benchmark
-	REQUEST_COUNT = 10000
-	// ZONE_COUNT num of zones which will be generated and used
-	ZONE_COUNT = 100
-	// MAX_DATA_LENGTH size of test random data that will be generated and inserted to db (before encrypting)
-	MAX_DATA_LENGTH = 100 * 1024 // 100 kb
+	// RowCount num of rows that will be generated in each write benchmark
+	RowCount = 10000
+	// RequestCount num of requests that will be done in each read benchmark
+	RequestCount = 10000
+	// ZoneCount num of zones which will be generated and used
+	ZoneCount = 100
+	// MaxDataLength size of test random data that will be generated and inserted to db (before encrypting)
+	MaxDataLength = 100 * 1024 // 100 kb
 )

--- a/benchmarks/write/write.go
+++ b/benchmarks/write/write.go
@@ -58,10 +58,10 @@ func GetPublicOneKey() *keys.PublicKey {
 	return publicKey
 }
 
-// GenerateAcrastructRowsOneKey generate ROW_COUNT acrastructs with random data
+// GenerateAcrastructRowsOneKey generate RowCount acrastructs with random data
 // using <onekey_storage.pub> and insert to db
 func GenerateAcrastructRowsOneKey(publicKey *keys.PublicKey, db *sql.DB) {
-	for count := 0; count < config.ROW_COUNT; count++ {
+	for count := 0; count < config.RowCount; count++ {
 		data, err := common.GenerateData()
 		if err != nil {
 			panic(err)
@@ -78,9 +78,9 @@ func GenerateAcrastructRowsOneKey(publicKey *keys.PublicKey, db *sql.DB) {
 	}
 }
 
-// GenerateDataRows generate ROW_COUNT raw random data and insert to db
+// GenerateDataRows generate RowCount raw random data and insert to db
 func GenerateDataRows(db *sql.DB) {
-	for count := 0; count < config.ROW_COUNT; count++ {
+	for count := 0; count < config.RowCount; count++ {
 		data, err := common.GenerateData()
 		if err != nil {
 			panic(err)
@@ -92,22 +92,22 @@ func GenerateDataRows(db *sql.DB) {
 	}
 }
 
-// GenerateAcrastructWithZone generate ROW_COUNT acrastructs using sequentially
-// all ZONE_COUNT zones
+// GenerateAcrastructWithZone generate RowCount acrastructs using sequentially
+// all ZoneCount zones
 func GenerateAcrastructWithZone(db *sql.DB) {
 	zones := common.LoadZones()
-	for count := 0; count < config.ROW_COUNT; count++ {
+	for count := 0; count < config.RowCount; count++ {
 		data, err := common.GenerateData()
 		if err != nil {
 			panic(err)
 		}
 
-		zoneData := zones[count%config.ZONE_COUNT]
-		acrastruct, err := acrawriter.CreateAcrastruct(data, &keys.PublicKey{Value: zoneData.PublicKey}, zoneData.Id)
+		zoneData := zones[count%config.ZoneCount]
+		acrastruct, err := acrawriter.CreateAcrastruct(data, &keys.PublicKey{Value: zoneData.PublicKey}, zoneData.ID)
 		if err != nil {
 			panic(err)
 		}
-		_, err = db.Exec("INSERT INTO test_with_zone(zone, data) VALUES ($1, $2);", &zoneData.Id, &acrastruct)
+		_, err = db.Exec("INSERT INTO test_with_zone(zone, data) VALUES ($1, $2);", &zoneData.ID, &acrastruct)
 		if err != nil {
 			panic(err)
 		}

--- a/cmd/acra-addzone/acra-addzone.go
+++ b/cmd/acra-addzone/acra-addzone.go
@@ -44,9 +44,9 @@ import (
 
 // Constants used by AcraAddZone util.
 var (
-	// DEFAULT_CONFIG_PATH relative path to config which will be parsed as default
-	DEFAULT_CONFIG_PATH = utils.GetConfigPathByName("acra-addzone")
-	SERVICE_NAME        = "acra-addzone"
+	// defaultConfigPath relative path to config which will be parsed as default
+	defaultConfigPath = utils.GetConfigPathByName("acra-addzone")
+	serviceName       = "acra-addzone"
 )
 
 func main() {
@@ -55,12 +55,12 @@ func main() {
 
 	logging.SetLogLevel(logging.LogVerbose)
 
-	err := cmd.Parse(DEFAULT_CONFIG_PATH, SERVICE_NAME)
+	err := cmd.Parse(defaultConfigPath, serviceName)
 	if err != nil {
 		log.WithError(err).Errorln("can't parse args")
 		os.Exit(1)
 	}
-	//LoadFromConfig(DEFAULT_CONFIG_PATH)
+	//LoadFromConfig(defaultConfigPath)
 	//iniflags.Parse()
 
 	output, err := filepath.Abs(*outputDir)

--- a/cmd/acra-authmanager/acra_authmanager.go
+++ b/cmd/acra-authmanager/acra_authmanager.go
@@ -41,8 +41,8 @@ type HashedPasswords map[string]string
 
 // Constants used by AcraAuthManager
 var (
-	DEFAULT_CONFIG_PATH = utils.GetConfigPathByName("acra-authmanager")
-	SERVICE_NAME        = "acra-authmanager"
+	defaultConfigPath = utils.GetConfigPathByName("acra-authmanager")
+	serviceName       = "acra-authmanager"
 )
 
 // Constants used for Argon password manager
@@ -65,7 +65,7 @@ func (hp HashedPasswords) Bytes() (passwordBytes []byte) {
 }
 
 // WriteToFile writes encrypted names and password hashes to file
-func (hp HashedPasswords) WriteToFile(file string, keystore *filesystem.FilesystemKeyStore) error {
+func (hp HashedPasswords) WriteToFile(file string, keystore *filesystem.KeyStore) error {
 	key, err := keystore.GetAuthKey(false)
 	if err != nil {
 		return err
@@ -97,7 +97,7 @@ func (hp HashedPasswords) SetPassword(name, password string) (err error) {
 	return nil
 }
 
-func parseHtpasswdFile(file string, keystore *filesystem.FilesystemKeyStore) (passwords HashedPasswords, err error) {
+func parseHtpasswdFile(file string, keystore *filesystem.KeyStore) (passwords HashedPasswords, err error) {
 	htpasswdBytes, err := ioutil.ReadFile(file)
 	if err != nil {
 		return
@@ -140,7 +140,7 @@ func parseHtpasswd(htpasswdBytes []byte) (passwords HashedPasswords, err error) 
 	return
 }
 
-func removeUser(file, user string, keystore *filesystem.FilesystemKeyStore) error {
+func removeUser(file, user string, keystore *filesystem.KeyStore) error {
 	passwords, err := parseHtpasswdFile(file, keystore)
 	if err != nil {
 		return err
@@ -153,7 +153,7 @@ func removeUser(file, user string, keystore *filesystem.FilesystemKeyStore) erro
 	return passwords.WriteToFile(file, keystore)
 }
 
-func setPassword(file, name, password string, keystore *filesystem.FilesystemKeyStore) error {
+func setPassword(file, name, password string, keystore *filesystem.KeyStore) error {
 	_, err := os.Stat(file)
 	passwords := HashedPasswords(map[string]string{})
 	if err == nil {
@@ -174,11 +174,11 @@ func main() {
 	remove := flag.Bool("remove", false, "Remove user")
 	user := flag.String("user", "", "User")
 	password := flag.String("password", "", "Password")
-	filePath := flag.String("file", cmd.DEFAULT_ACRA_AUTH_PATH, "Auth file")
+	filePath := flag.String("file", cmd.DefaultAcraServerAuthPath, "Auth file")
 	keysDir := flag.String("keys_dir", keystore.DefaultKeyDirShort, "Folder from which will be loaded keys")
 	debug := flag.Bool("d", false, "Turn on debug logging")
 
-	if err := cmd.Parse(DEFAULT_CONFIG_PATH, SERVICE_NAME); err != nil {
+	if err := cmd.Parse(defaultConfigPath, serviceName); err != nil {
 		log.WithError(err).Errorln("can't parse cmd arguments")
 		os.Exit(1)
 	}

--- a/cmd/acra-connector/acra-connector.go
+++ b/cmd/acra-connector/acra-connector.go
@@ -72,7 +72,7 @@ func handleClientConnection(config *Config, connection net.Conn) {
 	timer.ObserveDuration()
 }
 
-func handleApiConnection(config *Config, connection net.Conn) {
+func handleAPIConnection(config *Config, connection net.Conn) {
 	timer := prometheus.NewTimer(prometheus.ObserverFunc(connectionProcessingTimeHistogram.WithLabelValues(apiConnectionType).Observe))
 	handleConnection(config, connection)
 	timer.ObserveDuration()
@@ -145,7 +145,7 @@ func handleConnection(config *Config, connection net.Conn) {
 		logger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantWrapConnection).
 			Errorln("Can't wrap connection")
 		span.SetStatus(trace.Status{Code: trace.StatusCodeUnknown})
-		if err := acraConn.Close(); err != nil {
+		if err = acraConn.Close(); err != nil {
 			logger.WithError(err).Errorf("Error on closing connection with %v", connector_mode.ModeToServiceName(config.Mode))
 		}
 		wrapSpan.End()
@@ -214,12 +214,12 @@ func main() {
 	keysDir := flag.String("keys_dir", keystore.DefaultKeyDirShort, "Folder from which will be loaded keys")
 	clientID := flag.String("client_id", "", "Client ID")
 	acraServerHost := flag.String("acraserver_connection_host", "", "IP or domain to AcraServer daemon")
-	acraServerAPIPort := flag.Int("acraserver_api_connection_port", cmd.DEFAULT_ACRASERVER_API_PORT, "Port of Acra HTTP API")
-	acraServerPort := flag.Int("acraserver_connection_port", cmd.DEFAULT_ACRASERVER_PORT, "Port of AcraServer daemon")
+	acraServerAPIPort := flag.Int("acraserver_api_connection_port", cmd.DefaultAcraServerAPIPort, "Port of Acra HTTP API")
+	acraServerPort := flag.Int("acraserver_connection_port", cmd.DefaultAcraServerPort, "Port of AcraServer daemon")
 	acraServerID := flag.String("acraserver_securesession_id", "acra_server", "Expected id from AcraServer for Secure Session")
 
-	acraConnectorPort := flag.Int("incoming_connection_port", cmd.DEFAULT_ACRACONNECTOR_PORT, "Port to AcraConnector")
-	acraConnectorAPIPort := flag.Int("incoming_connection_api_port", cmd.DEFAULT_ACRACONNECTOR_API_PORT, "Port for AcraConnector HTTP API")
+	acraConnectorPort := flag.Int("incoming_connection_port", cmd.DefaultAcraConnectorPort, "Port to AcraConnector")
+	acraConnectorAPIPort := flag.Int("incoming_connection_api_port", cmd.DefaultAcraConnectorAPIPort, "Port for AcraConnector HTTP API")
 	acraServerEnableHTTPAPI := flag.Bool("http_api_enable", false, "Enable connection to AcraServer via HTTP API")
 	disableUserCheck := flag.Bool("user_check_disable", false, "Disable checking that connections from app running from another user")
 	useTLS := flag.Bool("acraserver_tls_transport_enable", false, "Use tls to encrypt transport between AcraServer and AcraConnector/client")
@@ -229,15 +229,15 @@ func main() {
 	tlsAcraserverSNI := flag.String("tls_acraserver_sni", "", "Expected Server Name (SNI) from AcraServer")
 	tlsAuthType := flag.Int("tls_auth", int(tls.RequireAndVerifyClientCert), "Set authentication mode that will be used in TLS connection with AcraServer/AcraTranslator. Values in range 0-4 that set auth type (https://golang.org/pkg/crypto/tls/#ClientAuthType). Default is tls.RequireAndVerifyClientCert")
 	noEncryptionTransport := flag.Bool("acraserver_transport_encryption_disable", false, "Use raw transport (tcp/unix socket) between acraserver and acraproxy/client (don't use this flag if you not connect to database with ssl/tls")
-	connectionString := flag.String("incoming_connection_string", network.BuildConnectionString(cmd.DEFAULT_ACRACONNECTOR_CONNECTION_PROTOCOL, cmd.DEFAULT_ACRACONNECTOR_HOST, cmd.DEFAULT_ACRACONNECTOR_PORT, ""), "Connection string like tcp://x.x.x.x:yyyy or unix:///path/to/socket")
-	connectionAPIString := flag.String("incoming_connection_api_string", network.BuildConnectionString(cmd.DEFAULT_ACRACONNECTOR_CONNECTION_PROTOCOL, cmd.DEFAULT_ACRACONNECTOR_HOST, cmd.DEFAULT_ACRACONNECTOR_API_PORT, ""), "Connection string like tcp://x.x.x.x:yyyy or unix:///path/to/socket")
+	connectionString := flag.String("incoming_connection_string", network.BuildConnectionString(cmd.DefaultAcraConnectorConnectionProtocol, cmd.DefaultAcraConnectorHost, cmd.DefaultAcraConnectorPort, ""), "Connection string like tcp://x.x.x.x:yyyy or unix:///path/to/socket")
+	connectionAPIString := flag.String("incoming_connection_api_string", network.BuildConnectionString(cmd.DefaultAcraConnectorConnectionProtocol, cmd.DefaultAcraConnectorHost, cmd.DefaultAcraConnectorAPIPort, ""), "Connection string like tcp://x.x.x.x:yyyy or unix:///path/to/socket")
 	acraServerConnectionString := flag.String("acraserver_connection_string", "", "Connection string to AcraServer like tcp://x.x.x.x:yyyy or unix:///path/to/socket")
 	acraServerAPIConnectionString := flag.String("acraserver_api_connection_string", "", "Connection string to Acra's API like tcp://x.x.x.x:yyyy or unix:///path/to/socket")
 	prometheusAddress := flag.String("incoming_connection_prometheus_metrics_string", "", "URL which will be used to expose Prometheus metrics (use <URL>/metrics address to pull metrics)")
 
 	connectorModeString := flag.String("mode", "AcraServer", "Expected mode of connection. Possible values are: AcraServer or AcraTranslator. Corresponded connection host/port/string/session_id will be used.")
-	acraTranslatorHost := flag.String("acratranslator_connection_host", cmd.DEFAULT_ACRATRANSLATOR_GRPC_HOST, "IP or domain to AcraTranslator daemon")
-	acraTranslatorPort := flag.Int("acratranslator_connection_port", cmd.DEFAULT_ACRATRANSLATOR_GRPC_PORT, "Port of AcraTranslator daemon")
+	acraTranslatorHost := flag.String("acratranslator_connection_host", cmd.DefaultAcraTranslatorGRPCHost, "IP or domain to AcraTranslator daemon")
+	acraTranslatorPort := flag.Int("acratranslator_connection_port", cmd.DefaultAcraTranslatorGRPCPort, "Port of AcraTranslator daemon")
 	acraTranslatorConnectionString := flag.String("acratranslator_connection_string", "", "Connection string to AcraTranslator like grpc://0.0.0.0:9696 or http://0.0.0.0:9595")
 	acraTranslatorID := flag.String("acratranslator_securesession_id", "acra_translator", "Expected id from AcraTranslator for Secure Session")
 
@@ -258,7 +258,7 @@ func main() {
 	logging.CustomizeLogging(*loggingFormat, ServiceName)
 	log.Infof("Validating service configuration...")
 
-	if err := checkDependencies(); err != nil {
+	if err = checkDependencies(); err != nil {
 		log.Infoln(err.Error())
 		os.Exit(1)
 	}
@@ -282,8 +282,8 @@ func main() {
 				Errorln("Configuration error: you must pass acratranslator_connection_host or acratranslator_connection_string parameter")
 			os.Exit(1)
 		}
-		if *acraTranslatorPort != cmd.DEFAULT_ACRATRANSLATOR_GRPC_PORT {
-			*acraTranslatorConnectionString = network.BuildConnectionString(cmd.DEFAULT_ACRACONNECTOR_CONNECTION_PROTOCOL, *acraTranslatorHost, *acraTranslatorPort, "")
+		if *acraTranslatorPort != cmd.DefaultAcraTranslatorGRPCPort {
+			*acraTranslatorConnectionString = network.BuildConnectionString(cmd.DefaultAcraConnectorConnectionProtocol, *acraTranslatorHost, *acraTranslatorPort, "")
 		}
 		outgoingConnectionString = *acraTranslatorConnectionString
 		outgoingSecureSessionID = *acraTranslatorID
@@ -291,11 +291,11 @@ func main() {
 
 	// if AcraServer
 	if connectorMode == connector_mode.AcraServerMode {
-		if *acraConnectorPort != cmd.DEFAULT_ACRACONNECTOR_PORT {
-			*connectionString = network.BuildConnectionString(cmd.DEFAULT_ACRACONNECTOR_CONNECTION_PROTOCOL, cmd.DEFAULT_ACRACONNECTOR_HOST, *acraConnectorPort, "")
+		if *acraConnectorPort != cmd.DefaultAcraConnectorPort {
+			*connectionString = network.BuildConnectionString(cmd.DefaultAcraConnectorConnectionProtocol, cmd.DefaultAcraConnectorHost, *acraConnectorPort, "")
 		}
-		if *acraConnectorAPIPort != cmd.DEFAULT_ACRACONNECTOR_API_PORT {
-			*connectionAPIString = network.BuildConnectionString(cmd.DEFAULT_ACRACONNECTOR_CONNECTION_PROTOCOL, cmd.DEFAULT_ACRACONNECTOR_HOST, *acraConnectorAPIPort, "")
+		if *acraConnectorAPIPort != cmd.DefaultAcraConnectorAPIPort {
+			*connectionAPIString = network.BuildConnectionString(cmd.DefaultAcraConnectorConnectionProtocol, cmd.DefaultAcraConnectorHost, *acraConnectorAPIPort, "")
 		}
 
 		if *acraServerHost == "" && *acraServerConnectionString == "" {
@@ -304,7 +304,7 @@ func main() {
 			os.Exit(1)
 		}
 		if *acraServerHost != "" {
-			*acraServerConnectionString = network.BuildConnectionString(cmd.DEFAULT_ACRA_CONNECTION_PROTOCOL, *acraServerHost, *acraServerPort, "")
+			*acraServerConnectionString = network.BuildConnectionString(cmd.DefaultAcraServerConnectionProtocol, *acraServerHost, *acraServerPort, "")
 		}
 		if *acraServerEnableHTTPAPI {
 			if *acraServerHost == "" && *acraServerAPIConnectionString == "" {
@@ -313,7 +313,7 @@ func main() {
 				os.Exit(1)
 			}
 			if *acraServerHost != "" {
-				*acraServerAPIConnectionString = network.BuildConnectionString(cmd.DEFAULT_ACRA_CONNECTION_PROTOCOL, *acraServerHost, *acraServerAPIPort, "")
+				*acraServerAPIConnectionString = network.BuildConnectionString(cmd.DefaultAcraServerConnectionProtocol, *acraServerHost, *acraServerAPIPort, "")
 			}
 		}
 
@@ -454,7 +454,7 @@ func main() {
 					} else {
 						log.Infof("Got new connection to http API: %v", connection.RemoteAddr())
 					}
-					go handleApiConnection(&commandsConfig, connection)
+					go handleAPIConnection(&commandsConfig, connection)
 				}
 			}()
 		}

--- a/cmd/acra-keymaker/acra-keymaker.go
+++ b/cmd/acra-keymaker/acra-keymaker.go
@@ -35,9 +35,9 @@ import (
 
 // Constants used by AcraKeymaker
 var (
-	// DEFAULT_CONFIG_PATH relative path to config which will be parsed as default
-	DEFAULT_CONFIG_PATH = utils.GetConfigPathByName("acra-keymaker")
-	SERVICE_NAME        = "acra-keymaker"
+	// defaultConfigPath relative path to config which will be parsed as default
+	defaultConfigPath = utils.GetConfigPathByName("acra-keymaker")
+	serviceName       = "acra-keymaker"
 )
 
 func main() {
@@ -53,7 +53,7 @@ func main() {
 
 	logging.SetLogLevel(logging.LogVerbose)
 
-	err := cmd.Parse(DEFAULT_CONFIG_PATH, SERVICE_NAME)
+	err := cmd.Parse(defaultConfigPath, serviceName)
 	if err != nil {
 		log.WithError(err).Errorln("Can't parse args")
 		os.Exit(1)

--- a/cmd/acra-poisonrecordmaker/acra-poisonrecordmaker.go
+++ b/cmd/acra-poisonrecordmaker/acra-poisonrecordmaker.go
@@ -40,9 +40,9 @@ import (
 
 // Constants used by AcraPoisonRecordsMaker
 var (
-	// DEFAULT_CONFIG_PATH relative path to config which will be parsed as default
-	DEFAULT_CONFIG_PATH = utils.GetConfigPathByName("acra-poisonrecordmaker")
-	SERVICE_NAME        = "acra-poisonrecordmaker"
+	// defaultConfigPath relative path to config which will be parsed as default
+	defaultConfigPath = utils.GetConfigPathByName("acra-poisonrecordmaker")
+	serviceName       = "acra-poisonrecordmaker"
 )
 
 func main() {
@@ -51,7 +51,7 @@ func main() {
 
 	logging.SetLogLevel(logging.LogDiscard)
 
-	err := cmd.Parse(DEFAULT_CONFIG_PATH, SERVICE_NAME)
+	err := cmd.Parse(defaultConfigPath, serviceName)
 	if err != nil {
 		log.WithError(err).Errorln("can't parse args")
 		os.Exit(1)

--- a/cmd/acra-rollback/acra-rollback.go
+++ b/cmd/acra-rollback/acra-rollback.go
@@ -47,9 +47,9 @@ import (
 
 // Constants used by AcraRollback
 var (
-	// DEFAULT_CONFIG_PATH relative path to config which will be parsed as default
-	DEFAULT_CONFIG_PATH = utils.GetConfigPathByName("acra-rollback")
-	SERVICE_NAME        = "acra-rollback"
+	// defaultConfigPath relative path to config which will be parsed as default
+	defaultConfigPath = utils.GetConfigPathByName("acra-rollback")
+	serviceName       = "acra-rollback"
 )
 
 // ErrorExit prints error and exits.
@@ -169,7 +169,7 @@ func main() {
 
 	logging.SetLogLevel(logging.LogVerbose)
 
-	err := cmd.Parse(DEFAULT_CONFIG_PATH, SERVICE_NAME)
+	err := cmd.Parse(defaultConfigPath, serviceName)
 	if err != nil {
 		log.WithError(err).Errorln("Can't parse args")
 		os.Exit(1)

--- a/cmd/acra-rotate/dbRotation.go
+++ b/cmd/acra-rotate/dbRotation.go
@@ -103,7 +103,7 @@ func rotateDb(selectQuery, updateQuery string, db *sql.DB, keystore keystore.Key
 		}
 	}
 	if !dryRun {
-		if err := rotator.saveRotatedKeys(); err != nil {
+		if err = rotator.saveRotatedKeys(); err != nil {
 			log.WithError(err).Errorln("Can't save rotated keys")
 			return false
 		}

--- a/cmd/acra-server/client_commands_session.go
+++ b/cmd/acra-server/client_commands_session.go
@@ -157,7 +157,7 @@ func (clientSession *ClientCommandsSession) HandleSession() {
 		logger.Debugln("Got /setConfig request")
 		decoder := json.NewDecoder(req.Body)
 		var configFromUI UIEditableConfig
-		err := decoder.Decode(&configFromUI)
+		err = decoder.Decode(&configFromUI)
 		if err != nil {
 			logger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorGeneral).
 				Warningln("Can't convert config from incoming")

--- a/cmd/acra-server/config.go
+++ b/cmd/acra-server/config.go
@@ -228,7 +228,7 @@ func (config *Config) SetWholeMatch(value bool) {
 
 // GetConfigPath returns AcraServer config path
 func (config *Config) GetConfigPath() string {
-	return DEFAULT_CONFIG_PATH
+	return defaultConfigPath
 }
 
 // ToJSON AcraServer editable config in JSON format

--- a/cmd/acra-server/listener.go
+++ b/cmd/acra-server/listener.go
@@ -82,14 +82,14 @@ func (server *SServer) Close() {
 			if err2 != nil {
 				log.WithError(err2).Warningln("UnixListener.Close  url_.Parse")
 			}
-			if _, err := os.Stat(url.Path); err == nil {
+			if _, err = os.Stat(url.Path); err == nil {
 				err3 := os.Remove(url.Path)
 				if err3 != nil {
 					log.WithError(err3).Warningf("UnixListener.Close  file.Remove(%s)", url.Path)
 				}
 			}
 		default:
-			if err := listener.Close(); err != nil {
+			if err = listener.Close(); err != nil {
 				log.WithError(err).Warningln("Error on closing listener")
 			}
 		}

--- a/cmd/acra-translator/acra-translator.go
+++ b/cmd/acra-translator/acra-translator.go
@@ -39,12 +39,12 @@ import (
 
 // Constants handy for AcraTranslator.
 const (
-	ServiceName          = "acra-translator"
-	DEFAULT_WAIT_TIMEOUT = 10
+	ServiceName        = "acra-translator"
+	defaultWaitTimeout = 10
 )
 
-// DEFAULT_CONFIG_PATH relative path to config which will be parsed as default
-var DEFAULT_CONFIG_PATH = utils.GetConfigPathByName(ServiceName)
+// DefaultConfigPath relative path to config which will be parsed as default
+var DefaultConfigPath = utils.GetConfigPathByName(ServiceName)
 
 func main() {
 	config := NewConfig()
@@ -63,7 +63,7 @@ func main() {
 	stopOnPoison := flag.Bool("poison_shutdown_enable", false, "On detecting poison record: log about poison record detection, stop and shutdown")
 	scriptOnPoison := flag.String("poison_run_script_file", "", "On detecting poison record: log about poison record detection, execute script, return decrypted data")
 
-	closeConnectionTimeout := flag.Int("incoming_connection_close_timeout", DEFAULT_WAIT_TIMEOUT, "Time that AcraTranslator will wait (in seconds) on stop signal before closing all connections")
+	closeConnectionTimeout := flag.Int("incoming_connection_close_timeout", defaultWaitTimeout, "Time that AcraTranslator will wait (in seconds) on stop signal before closing all connections")
 
 	prometheusAddress := flag.String("incoming_connection_prometheus_metrics_string", "", "URL which will be used to expose Prometheus metrics (use <URL>/metrics address to pull metrics)")
 
@@ -73,7 +73,7 @@ func main() {
 	verbose := flag.Bool("v", false, "Log to stderr all INFO, WARNING and ERROR logs")
 	debug := flag.Bool("d", false, "Log everything to stderr")
 
-	err := cmd.Parse(DEFAULT_CONFIG_PATH, ServiceName)
+	err := cmd.Parse(DefaultConfigPath, ServiceName)
 	if err != nil {
 		log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantReadServiceConfig).
 			Errorln("Can't parse args")
@@ -86,7 +86,7 @@ func main() {
 	cmd.ValidateClientID(*secureSessionID)
 
 	if len(*incomingConnectionHTTPString) == 0 && len(*incomingConnectionGRPCString) == 0 {
-		*incomingConnectionGRPCString = network.BuildConnectionString(network.GRPC_SCHEME, cmd.DEFAULT_ACRATRANSLATOR_GRPC_HOST, cmd.DEFAULT_ACRATRANSLATOR_GRPC_PORT, "")
+		*incomingConnectionGRPCString = network.BuildConnectionString(network.GRPCScheme, cmd.DefaultAcraTranslatorGRPCHost, cmd.DefaultAcraTranslatorGRPCPort, "")
 		log.Infof("No incoming connection string is set: by default gRPC connections are being listen %v", *incomingConnectionGRPCString)
 	}
 
@@ -98,7 +98,7 @@ func main() {
 	config.SetServerID([]byte(*secureSessionID))
 	config.SetIncomingConnectionHTTPString(*incomingConnectionHTTPString)
 	config.SetIncomingConnectionGRPCString(*incomingConnectionGRPCString)
-	config.SetConfigPath(DEFAULT_CONFIG_PATH)
+	config.SetConfigPath(DefaultConfigPath)
 	config.SetDebug(*debug)
 	config.SetTraceToLog(cmd.IsTraceToLogOn())
 

--- a/cmd/acra-webconfig/acra-webconfig.go
+++ b/cmd/acra-webconfig/acra-webconfig.go
@@ -67,33 +67,33 @@ var ErrGetAuthDataFromAcraServer = errors.New("wrong status for loadAuthData")
 
 // Connection timeout secs
 const (
-	HTTP_TIMEOUT = 5
+	HTTPTimeout = 5
 )
 
 // Argon2 parameters
 const (
-	LINE_SEPARATOR = "\n"
+	LineSeparator = "\n"
 
-	AUTH_FIELD_SEPARATOR   = ":"
-	AUTH_FIELD_COUNT       = 4
-	AUTH_USER_NAME_IDX     = 0
-	AUTH_SALT_IDX          = 1
-	AUTH_ARGON2_PARAMS_IDX = 2
-	AUTH_HASH_IDX          = 3
+	AuthFieldSeparator  = ":"
+	AuthFieldCount      = 4
+	AuthUsernameIDX     = 0
+	AuthSaltIDX         = 1
+	AuthArgon2ParamsIDX = 2
+	AuthHashIDX         = 3
 
-	ARGON2_PARAM_SEPARATOR = ","
-	ARGON2_PARAM_COUNT     = 4
-	ARGON2_TIME_IDX        = 0
-	ARGON2_MEMORY_IDX      = 1
-	ARGON2_THREADS_IDX     = 2
-	ARGON2_LENGTH_IDX      = 3
+	Argon2ParamSeparator = ","
+	Argon2ParamCount     = 4
+	Argon2TimeIDX        = 0
+	Argon2MemoryIDX      = 1
+	Argon2ThreadsIDX     = 2
+	Argon2LengthIDX      = 3
 
-	ARGON2_TIME_INT    = 32
-	ARGON2_MEMORY_INT  = 32
-	ARGON2_THREADS_INT = 8
-	ARGON2_LENGTH_INT  = 32
+	Argon2TimeInt    = 32
+	Argon2MemoryInt  = 32
+	Argon2ThreadsInt = 8
+	Argon2LengthInt  = 32
 
-	UINT_BASE = 10
+	UIntBase = 10
 )
 
 var authUsers = make(map[string]cmd.UserAuth)
@@ -219,7 +219,7 @@ func index(w http.ResponseWriter, r *http.Request) {
 
 	// get current config
 	var netClient = &http.Client{
-		Timeout: time.Second * HTTP_TIMEOUT,
+		Timeout: time.Second * HTTPTimeout,
 	}
 	serverResponse, err := netClient.Get(fmt.Sprintf("http://%v:%v/getConfig", *destinationHost, *destinationPort))
 	if err != nil {
@@ -310,46 +310,46 @@ func basicAuthHandler(handler http.HandlerFunc) http.HandlerFunc {
 
 func parseArgon2Params(authDataSting []byte) {
 	line := 0
-	for _, authString := range strings.Split(string(authDataSting), LINE_SEPARATOR) {
-		authItem := strings.Split(authString, AUTH_FIELD_SEPARATOR)
+	for _, authString := range strings.Split(string(authDataSting), LineSeparator) {
+		authItem := strings.Split(authString, AuthFieldSeparator)
 		line++
-		if len(authItem) == AUTH_FIELD_COUNT {
-			decoded, err := base64.StdEncoding.DecodeString(string(authItem[AUTH_HASH_IDX]))
+		if len(authItem) == AuthFieldCount {
+			decoded, err := base64.StdEncoding.DecodeString(string(authItem[AuthHashIDX]))
 			if err != nil {
-				log.WithError(err).Errorf("line[%v] DecodeString, user: %v", line, authItem[AUTH_USER_NAME_IDX])
+				log.WithError(err).Errorf("line[%v] DecodeString, user: %v", line, authItem[AuthUsernameIDX])
 				continue
 			}
-			argon2P := strings.Split(authItem[AUTH_ARGON2_PARAMS_IDX], ARGON2_PARAM_SEPARATOR)
-			if len(authItem) != ARGON2_PARAM_COUNT {
+			argon2P := strings.Split(authItem[AuthArgon2ParamsIDX], Argon2ParamSeparator)
+			if len(authItem) != Argon2ParamCount {
 				log.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantParseAuthData).
-					Errorf("line[%v] wrong number of argon2 params: got %v, expected %v", line, len(authItem), ARGON2_PARAM_COUNT)
+					Errorf("line[%v] wrong number of argon2 params: got %v, expected %v", line, len(authItem), Argon2ParamCount)
 				continue
 			}
-			Time, err := strconv.ParseUint(argon2P[ARGON2_TIME_IDX], UINT_BASE, ARGON2_TIME_INT)
+			Time, err := strconv.ParseUint(argon2P[Argon2TimeIDX], UIntBase, Argon2TimeInt)
 			if err != nil {
 				log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantParseAuthData).
-					Errorf("line[%v] argon2 strconv.ParseUint(%v), user: %v", line, "Time", authItem[AUTH_USER_NAME_IDX])
+					Errorf("line[%v] argon2 strconv.ParseUint(%v), user: %v", line, "Time", authItem[AuthUsernameIDX])
 				continue
 			}
-			Memory, err := strconv.ParseUint(argon2P[ARGON2_MEMORY_IDX], UINT_BASE, ARGON2_MEMORY_INT)
+			Memory, err := strconv.ParseUint(argon2P[Argon2MemoryIDX], UIntBase, Argon2MemoryInt)
 			if err != nil {
 				log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantParseAuthData).
-					Errorf("line[%v] argon2 strconv.ParseUint(%v), user: %v", line, "Memory", authItem[AUTH_USER_NAME_IDX])
+					Errorf("line[%v] argon2 strconv.ParseUint(%v), user: %v", line, "Memory", authItem[AuthUsernameIDX])
 				continue
 			}
-			Threads, err := strconv.ParseUint(argon2P[ARGON2_THREADS_IDX], UINT_BASE, ARGON2_THREADS_INT)
+			Threads, err := strconv.ParseUint(argon2P[Argon2ThreadsIDX], UIntBase, Argon2ThreadsInt)
 			if err != nil {
 				log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantParseAuthData).
-					Errorf("line[%v] argon2 strconv.ParseUint(%v), user: %v", line, "Threads", authItem[AUTH_USER_NAME_IDX])
+					Errorf("line[%v] argon2 strconv.ParseUint(%v), user: %v", line, "Threads", authItem[AuthUsernameIDX])
 				continue
 			}
-			Length, err := strconv.ParseUint(argon2P[ARGON2_LENGTH_IDX], UINT_BASE, ARGON2_LENGTH_INT)
+			Length, err := strconv.ParseUint(argon2P[Argon2LengthIDX], UIntBase, Argon2LengthInt)
 			if err != nil {
 				log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantParseAuthData).
-					Errorf("line[%v] argon2 strconv.ParseUint(%v), user: %v", line, "Length", authItem[AUTH_USER_NAME_IDX])
+					Errorf("line[%v] argon2 strconv.ParseUint(%v), user: %v", line, "Length", authItem[AuthUsernameIDX])
 				continue
 			}
-			authUsers[authItem[AUTH_USER_NAME_IDX]] = cmd.UserAuth{Salt: authItem[AUTH_SALT_IDX], Hash: decoded, Argon2Params: cmd.Argon2Params{
+			authUsers[authItem[AuthUsernameIDX]] = cmd.UserAuth{Salt: authItem[AuthSaltIDX], Hash: decoded, Argon2Params: cmd.Argon2Params{
 				Time:    uint32(Time),
 				Memory:  uint32(Memory),
 				Threads: uint8(Threads),
@@ -361,7 +361,7 @@ func parseArgon2Params(authDataSting []byte) {
 
 func loadAuthData() (err error) {
 	var netClient = &http.Client{
-		Timeout: time.Second * HTTP_TIMEOUT,
+		Timeout: time.Second * HTTPTimeout,
 	}
 	serverResponse, err := netClient.Get(fmt.Sprintf("http://%v:%v/loadAuthData", *destinationHost, *destinationPort))
 	if err != nil {
@@ -386,16 +386,16 @@ func loadAuthData() (err error) {
 }
 
 func main() {
-	host = flag.String("incoming_connection_host", cmd.DEFAULT_ACRAWEBCONFIG_HOST, "Host for AcraWebconfig HTTP endpoint")
-	port = flag.Int("incoming_connection_port", cmd.DEFAULT_ACRAWEBCONFIG_PORT, "Port for AcraWebconfig HTTP endpoint")
+	host = flag.String("incoming_connection_host", cmd.DefaultWebConfigHost, "Host for AcraWebconfig HTTP endpoint")
+	port = flag.Int("incoming_connection_port", cmd.DefaultWebConfigPort, "Port for AcraWebconfig HTTP endpoint")
 	loggingFormat := flag.String("logging_format", "plaintext", "Logging format: plaintext, json or CEF")
 	logging.CustomizeLogging(*loggingFormat, ServiceName)
 	log.Infof("Starting service %v [pid=%v]", ServiceName, os.Getpid())
 	destinationHost = flag.String("destination_host", "localhost", "Host for AcraServer HTTP endpoint or AcraConnector")
-	destinationPort = flag.Int("destination_port", cmd.DEFAULT_ACRACONNECTOR_API_PORT, "Port for AcraServer HTTP endpoint or AcraConnector")
-	staticPath = flag.String("static_path", cmd.DEFAULT_ACRAWEBCONFIG_STATIC, "Path to static content")
+	destinationPort = flag.Int("destination_port", cmd.DefaultAcraConnectorAPIPort, "Port for AcraServer HTTP endpoint or AcraConnector")
+	staticPath = flag.String("static_path", cmd.DefaultWebConfigStatic, "Path to static content")
 	debug = flag.Bool("d", false, "Turn on debug logging")
-	authMode = flag.String("http_auth_mode", cmd.DEFAULT_ACRAWEBCONFIG_AUTH_MODE, "Mode for basic auth. Possible values: auth_on|auth_off_local|auth_off")
+	authMode = flag.String("http_auth_mode", cmd.DefaultWebConfigAuthMode, "Mode for basic auth. Possible values: auth_on|auth_off_local|auth_off")
 	err := cmd.Parse(DefaultConfigPath, ServiceName)
 	if err != nil {
 		log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantReadServiceConfig).

--- a/cmd/constants.go
+++ b/cmd/constants.go
@@ -18,25 +18,23 @@ package cmd
 
 // Acra component constants: default port, host, names, path.
 const (
-	DEFAULT_ACRACONNECTOR_PORT                = 9494
-	DEFAULT_ACRACONNECTOR_API_PORT            = 9191
-	DEFAULT_ACRACONNECTOR_CONNECTION_PROTOCOL = "tcp"
-	DEFAULT_ACRACONNECTOR_HOST                = "127.0.0.1"
-	DEFAULT_ACRA_HOST                         = "0.0.0.0"
-	DEFAULT_ACRASERVER_PORT                   = 9393
-	DEFAULT_ACRASERVER_API_PORT               = 9090
-	DEFAULT_ACRA_AUTH_PATH                    = "configs/auth.keys"
-	DEFAULT_ACRA_CONNECTION_PROTOCOL          = "tcp"
-	DEFAULT_ACRAWEBCONFIG_HOST                = "127.0.0.1"
-	DEFAULT_ACRAWEBCONFIG_PORT                = 8000
-	DEFAULT_ACRAWEBCONFIG_STATIC              = "cmd/acra-webconfig/static"
-	DEFAULT_ACRAWEBCONFIG_AUTH_MODE           = "auth_on"
-	ACRAWEBCONFIG_AUTH_ARGON2_LENGTH          = 32
-	ACRAWEBCONFIG_AUTH_ARGON2_MEMORY          = 8 * 1024
-	ACRAWEBCONFIG_AUTH_ARGON2_TIME            = 3
-	ACRAWEBCONFIG_AUTH_ARGON2_THREADS         = 2
-	DEFAULT_ACRATRANSLATOR_HTTP_HOST          = "0.0.0.0"
-	DEFAULT_ACRATRANSLATOR_HTTP_PORT          = 9595
-	DEFAULT_ACRATRANSLATOR_GRPC_HOST          = "0.0.0.0"
-	DEFAULT_ACRATRANSLATOR_GRPC_PORT          = 9696
+	DefaultAcraConnectorPort               = 9494
+	DefaultAcraConnectorAPIPort            = 9191
+	DefaultAcraConnectorConnectionProtocol = "tcp"
+	DefaultAcraConnectorHost               = "127.0.0.1"
+	DefaultAcraServerHost                  = "0.0.0.0"
+	DefaultAcraServerPort                  = 9393
+	DefaultAcraServerAPIPort               = 9090
+	DefaultAcraServerAuthPath              = "configs/auth.keys"
+	DefaultAcraServerConnectionProtocol    = "tcp"
+	DefaultWebConfigHost                   = "127.0.0.1"
+	DefaultWebConfigPort                   = 8000
+	DefaultWebConfigStatic                 = "cmd/acra-webconfig/static"
+	DefaultWebConfigAuthMode               = "auth_on"
+	DefaultWebConfigAuthArgon2Length       = 32
+	DefaultWebConfigAuthArgon2Memory       = 8 * 1024
+	DefaultWebConfigAuthArgon2Time         = 3
+	DefaultWebConfigAuthArgon2Threads      = 2
+	DefaultAcraTranslatorGRPCHost          = "0.0.0.0"
+	DefaultAcraTranslatorGRPCPort          = 9696
 )

--- a/cmd/jaeger.go
+++ b/cmd/jaeger.go
@@ -26,6 +26,8 @@ var options = jaeger.Options{
 	AgentEndpoint:     "",
 	CollectorEndpoint: "",
 }
+
+// ErrInvalidJaegerExporterEndpoint incorrect endpoint for jaeger
 var ErrInvalidJaegerExporterEndpoint = errors.New("empty jaeger_agent_endpoint and jaeger_collector_endpoint")
 
 // RegisterJaegerCmdParameters register cli parameters with flag for jaeger options

--- a/cmd/utils_argon2.go
+++ b/cmd/utils_argon2.go
@@ -21,10 +21,10 @@ import "golang.org/x/crypto/argon2"
 // InitArgon2Params returns default Argon2 params
 func InitArgon2Params() Argon2Params {
 	var p Argon2Params
-	p.Time = uint32(ACRAWEBCONFIG_AUTH_ARGON2_TIME)
-	p.Memory = uint32(ACRAWEBCONFIG_AUTH_ARGON2_MEMORY)
-	p.Threads = uint8(ACRAWEBCONFIG_AUTH_ARGON2_THREADS)
-	p.Length = uint32(ACRAWEBCONFIG_AUTH_ARGON2_LENGTH)
+	p.Time = uint32(DefaultWebConfigAuthArgon2Time)
+	p.Memory = uint32(DefaultWebConfigAuthArgon2Memory)
+	p.Threads = uint8(DefaultWebConfigAuthArgon2Threads)
+	p.Length = uint32(DefaultWebConfigAuthArgon2Length)
 	return p
 }
 

--- a/decryptor/base/decryptor.go
+++ b/decryptor/base/decryptor.go
@@ -110,8 +110,8 @@ type Decryptor interface {
 	SetPoisonCallbackStorage(*PoisonCallbackStorage)
 	// get current storage of callbacks for detected poison records
 	GetPoisonCallbackStorage() *PoisonCallbackStorage
-	SetZoneMatcher(*zone.ZoneIDMatcher)
-	GetZoneMatcher() *zone.ZoneIDMatcher
+	SetZoneMatcher(*zone.Matcher)
+	GetZoneMatcher() *zone.Matcher
 	GetMatchedZoneID() []byte
 	MatchZone(byte) bool
 	IsWithZone() bool

--- a/decryptor/mysql/decryptor_test.go
+++ b/decryptor/mysql/decryptor_test.go
@@ -75,7 +75,7 @@ func (*testKeystore) GetClientIDEncryptionPublicKey(clientID []byte) (*keys.Publ
 }
 func (*testKeystore) GetZonePublicKey(zoneID []byte) (*keys.PublicKey, error) { panic("implement me") }
 
-func getDecryptor(keystore keystore.KeyStore) *MySQLDecryptor {
+func getDecryptor(keystore keystore.KeyStore) *Decryptor {
 	dataDecryptor := binary.NewBinaryDecryptor()
 	clientID := []byte("some id")
 	pgDecryptor := postgresql.NewPgDecryptor(clientID, dataDecryptor, false, keystore)
@@ -96,10 +96,10 @@ func TestMySQLDecryptor_CheckPoisonRecord_Inline(t *testing.T) {
 
 	part1 := make([]byte, 1024)
 	part2 := make([]byte, 1024)
-	if _, err := rand.Read(part1); err != nil {
+	if _, err = rand.Read(part1); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := rand.Read(part2); err != nil {
+	if _, err = rand.Read(part2); err != nil {
 		t.Fatal(err)
 	}
 

--- a/decryptor/mysql/packet.go
+++ b/decryptor/mysql/packet.go
@@ -67,45 +67,45 @@ func (array ByteArrayDump) Dump() []byte {
 	return array
 }
 
-// MysqlPacket struct that store header and payload, reads it from connection
-type MysqlPacket struct {
+// Packet struct that store header and payload, reads it from connection
+type Packet struct {
 	header []byte
 	data   []byte
 }
 
-// NewMysqlPacket returns new MysqlPacket
-func NewMysqlPacket() *MysqlPacket {
+// NewPacket returns new Packet
+func NewPacket() *Packet {
 	// https://dev.mysql.com/doc/internals/en/mysql-packet.html#idm140406396409840
 	// 3 bytes payload length and 1 byte of sequence_id
-	return &MysqlPacket{header: make([]byte, PacketHeaderSize)}
+	return &Packet{header: make([]byte, PacketHeaderSize)}
 }
 
 // GetPacketPayloadLength returns payload length from first 3 bytes of header
-func (packet *MysqlPacket) GetPacketPayloadLength() int {
+func (packet *Packet) GetPacketPayloadLength() int {
 	// first 3 bytes of header
 	// https://dev.mysql.com/doc/internals/en/mysql-packet.html#idm140406396409840
 	return int(uint32(packet.header[0]) | uint32(packet.header[1])<<8 | uint32(packet.header[2])<<16)
 }
 
 // GetSequenceNumber returned as byte
-func (packet *MysqlPacket) GetSequenceNumber() byte {
+func (packet *Packet) GetSequenceNumber() byte {
 	return packet.header[SequenceIDIndex]
 }
 
 // GetData returns packet payload
-func (packet *MysqlPacket) GetData() []byte {
+func (packet *Packet) GetData() []byte {
 	return packet.data
 }
 
 // SetData replace packet data with newData and update payload length in header
-func (packet *MysqlPacket) SetData(newData []byte) {
+func (packet *Packet) SetData(newData []byte) {
 	packet.data = newData
 	newSize := len(newData)
 	packet.updatePacketSize(newSize)
 }
 
 // updatePacketSize in header
-func (packet *MysqlPacket) updatePacketSize(newSize int) {
+func (packet *Packet) updatePacketSize(newSize int) {
 	// update payload size, first 3 bytes of header
 	// https://dev.mysql.com/doc/internals/en/mysql-packet.html#idm140406396409840
 	packet.header[0] = byte(newSize)
@@ -114,7 +114,7 @@ func (packet *MysqlPacket) updatePacketSize(newSize int) {
 }
 
 // replaceQuery replace query in payload with new and update header with new size
-func (packet *MysqlPacket) replaceQuery(newQuery string) {
+func (packet *Packet) replaceQuery(newQuery string) {
 	if len(newQuery) > len(packet.data[1:]) {
 		// first byte CMD + new query
 		packet.data = append(packet.data[:1], []byte(newQuery)...)
@@ -127,7 +127,7 @@ func (packet *MysqlPacket) replaceQuery(newQuery string) {
 }
 
 // readPacket read header to struct and return payload as return result or error
-func (packet *MysqlPacket) readPacket(connection net.Conn) ([]byte, error) {
+func (packet *Packet) readPacket(connection net.Conn) ([]byte, error) {
 	if _, err := io.ReadFull(connection, packet.header); err != nil {
 		return nil, err
 	}
@@ -154,12 +154,12 @@ func (packet *MysqlPacket) readPacket(connection net.Conn) ([]byte, error) {
 }
 
 // Dump returns packet header and data as []byte
-func (packet *MysqlPacket) Dump() []byte {
+func (packet *Packet) Dump() []byte {
 	return append(packet.header, packet.data...)
 }
 
 // ReadPacket header and payload from connection or return error
-func (packet *MysqlPacket) ReadPacket(connection net.Conn) error {
+func (packet *Packet) ReadPacket(connection net.Conn) error {
 	data, err := packet.readPacket(connection)
 	if err == nil {
 		packet.data = data
@@ -168,7 +168,7 @@ func (packet *MysqlPacket) ReadPacket(connection net.Conn) error {
 }
 
 // IsEOF return true if packet is OkPacket or EOFPacket
-func (packet *MysqlPacket) IsEOF() bool {
+func (packet *Packet) IsEOF() bool {
 	// https://dev.mysql.com/doc/internals/en/packet-OK_Packet.html
 	// https://dev.mysql.com/doc/internals/en/packet-EOF_Packet.html
 	isOkPacket := packet.data[0] == OkPacket && packet.GetPacketPayloadLength() > 7
@@ -177,11 +177,11 @@ func (packet *MysqlPacket) IsEOF() bool {
 }
 
 // IsErr return true if packet has ErrPacket flag
-func (packet *MysqlPacket) IsErr() bool {
+func (packet *Packet) IsErr() bool {
 	return packet.data[0] == ErrPacket
 }
 
-func (packet *MysqlPacket) getServerCapabilities() int {
+func (packet *Packet) getServerCapabilities() int {
 	// https://dev.mysql.com/doc/internals/en/connection-phase-packets.html#idm140437490034448
 	endOfServerVersion := bytes.Index(packet.data[1:], []byte{0}) + 2 // 1 first byte of protocol version and 1 to point to next byte
 	// 4 bytes connection string + 8 bytes of auth plugin + 1 byte filler
@@ -189,7 +189,7 @@ func (packet *MysqlPacket) getServerCapabilities() int {
 	return int(binary.LittleEndian.Uint16(rawCapabilities))
 }
 
-func (packet *MysqlPacket) getServerCapabilitiesExtended() (int, error) {
+func (packet *Packet) getServerCapabilitiesExtended() (int, error) {
 	// https://dev.mysql.com/doc/internals/en/connection-phase-packets.html#idm140437490034448
 	endOfServerVersion := bytes.Index(packet.data[1:], []byte{0}) + 2 // 1 first byte of protocol version and 1 to point to next byte
 	// 4 bytes connection string + 8 bytes of auth plugin + 1 byte filler
@@ -204,38 +204,38 @@ func (packet *MysqlPacket) getServerCapabilitiesExtended() (int, error) {
 }
 
 // ServerSupportProtocol41 if server supports client_protocol_41
-func (packet *MysqlPacket) ServerSupportProtocol41() bool {
+func (packet *Packet) ServerSupportProtocol41() bool {
 	capabilities := packet.getServerCapabilities()
 	return (capabilities & ClientProtocol41) > 0
 }
 
-func (packet *MysqlPacket) getClientCapabilities() uint32 {
+func (packet *Packet) getClientCapabilities() uint32 {
 	// https://dev.mysql.com/doc/internals/en/connection-phase-packets.html#idm140437489940880
 	return binary.LittleEndian.Uint32(packet.data[:4])
 }
 
 // ClientSupportProtocol41 if client supports client_protocol_41
-func (packet *MysqlPacket) ClientSupportProtocol41() bool {
+func (packet *Packet) ClientSupportProtocol41() bool {
 	capabilities := packet.getClientCapabilities()
 	return (capabilities & ClientProtocol41) > 0
 }
 
 // IsSSLRequest return true if SslRequest flag up
-func (packet *MysqlPacket) IsSSLRequest() bool {
+func (packet *Packet) IsSSLRequest() bool {
 	capabilities := packet.getClientCapabilities()
 	return (capabilities & SslRequest) > 0
 }
 
 // IsClientDeprecateEOF return true if flag set
 // https://dev.mysql.com/doc/internals/en/capability-flags.html#flag-CLIENT_DEPRECATE_EOF
-func (packet *MysqlPacket) IsClientDeprecateEOF() bool {
+func (packet *Packet) IsClientDeprecateEOF() bool {
 	capabilities := packet.getClientCapabilities()
 	return (capabilities & ClientDeprecateEOF) > 0
 }
 
-// ReadPacket from connection and return MysqlPacket struct with data or error
-func ReadPacket(connection net.Conn) (*MysqlPacket, error) {
-	packet := NewMysqlPacket()
+// ReadPacket from connection and return Packet struct with data or error
+func ReadPacket(connection net.Conn) (*Packet, error) {
+	packet := NewPacket()
 	err := packet.ReadPacket(connection)
 	if err != nil {
 		return nil, err

--- a/decryptor/mysql/proxy.go
+++ b/decryptor/mysql/proxy.go
@@ -46,7 +46,7 @@ func (factory *proxyFactory) New(ctx context.Context, clientID []byte, dbConnect
 	if err != nil {
 		return nil, err
 	}
-	proxy, err := NewMysqlProxy(ctx, clientID, decryptor, dbConnection, clientConnection, factory.setting.TLSConfig(), factory.setting.Censor())
+	proxy, err := NewMysqlProxy(ctx, decryptor, dbConnection, clientConnection, factory.setting.TLSConfig(), factory.setting.Censor())
 	if err != nil {
 		return nil, err
 	}

--- a/decryptor/postgresql/pg_general_decryptor.go
+++ b/decryptor/postgresql/pg_general_decryptor.go
@@ -36,7 +36,7 @@ type PgDecryptor struct {
 	isWithZone         bool
 	isWholeMatch       bool
 	keyStore           keystore.KeyStore
-	zoneMatcher        *zone.ZoneIDMatcher
+	zoneMatcher        *zone.Matcher
 	pgDecryptor        base.DataDecryptor
 	binaryDecryptor    base.DataDecryptor
 	matchedDecryptor   base.DataDecryptor
@@ -77,12 +77,12 @@ func (decryptor *PgDecryptor) SetWithZone(b bool) {
 }
 
 // SetZoneMatcher sets ZoneID matcher
-func (decryptor *PgDecryptor) SetZoneMatcher(zoneMatcher *zone.ZoneIDMatcher) {
+func (decryptor *PgDecryptor) SetZoneMatcher(zoneMatcher *zone.Matcher) {
 	decryptor.zoneMatcher = zoneMatcher
 }
 
 // GetZoneMatcher returns ZoneID matcher
-func (decryptor *PgDecryptor) GetZoneMatcher() *zone.ZoneIDMatcher {
+func (decryptor *PgDecryptor) GetZoneMatcher() *zone.Matcher {
 	return decryptor.zoneMatcher
 }
 
@@ -128,7 +128,7 @@ func (decryptor *PgDecryptor) IsWithZone() bool {
 	return decryptor.isWithZone
 }
 
-// IsMatched find Begin tag and maps it to Matcher (either PgDecryptor or BinaryDecryptor)
+// IsMatched find Begin tag and maps it to Matcher (either PgDecryptor or Decryptor)
 // returns false if can't find tag or can't find corresponded decryptor
 func (decryptor *PgDecryptor) IsMatched() bool {
 	// TODO here pg_decryptor has higher priority than binary_decryptor
@@ -148,7 +148,7 @@ func (decryptor *PgDecryptor) IsMatched() bool {
 	}
 }
 
-// Reset resets both PgDecryptor and BinaryDecryptor and clears matching index
+// Reset resets both PgDecryptor and Decryptor and clears matching index
 func (decryptor *PgDecryptor) Reset() {
 	decryptor.matchedDecryptor = nil
 	decryptor.binaryDecryptor.Reset()
@@ -337,7 +337,7 @@ func (decryptor *PgDecryptor) CheckPoisonRecord(reader io.Reader) (bool, error) 
 	if err == nil {
 		decryptor.logger.Warningln("Recognized poison record")
 		if decryptor.GetPoisonCallbackStorage().HasCallbacks() {
-			err := decryptor.GetPoisonCallbackStorage().Call()
+			err = decryptor.GetPoisonCallbackStorage().Call()
 			if err != nil {
 				decryptor.logger.WithError(err).Errorln("Unexpected error in poison record callbacks")
 			}

--- a/decryptor/postgresql/pg_hex_decryptor.go
+++ b/decryptor/postgresql/pg_hex_decryptor.go
@@ -64,7 +64,7 @@ type PgHexDecryptor struct {
 	//uint64 in hex
 	hexLengthBuf [base.DataLengthSize * 2]byte
 	keyStore     keystore.KeyStore
-	zoneMatcher  *zone.ZoneIDMatcher
+	zoneMatcher  *zone.Matcher
 
 	hexBuf []byte
 	buf    []byte

--- a/decryptor/postgresql/proxy.go
+++ b/decryptor/postgresql/proxy.go
@@ -46,7 +46,7 @@ func (factory *proxyFactory) New(ctx context.Context, clientID []byte, dbConnect
 	if err != nil {
 		return nil, err
 	}
-	proxy, err := NewPgProxy(ctx, clientID, decryptor, dbConnection, clientConnection, factory.setting.TLSConfig(), factory.setting.Censor())
+	proxy, err := NewPgProxy(ctx, decryptor, dbConnection, clientConnection, factory.setting.TLSConfig(), factory.setting.Censor())
 	if err != nil {
 		return nil, err
 	}

--- a/examples/golang/src/example_with_zone/example_with_zone.go
+++ b/examples/golang/src/example_with_zone/example_with_zone.go
@@ -35,7 +35,7 @@ var AcraConnectorAddress = "http://127.0.0.1:9191"
 
 // ZoneData stores zone: zoneID and PublicKey
 type ZoneData struct {
-	Id        string
+	ID        string
 	PublicKey []byte
 }
 
@@ -102,7 +102,7 @@ func main() {
 			panic(err)
 		}
 		zonePublic := parsedZoneData.PublicKey
-		zoneID := []byte(parsedZoneData.Id)
+		zoneID := []byte(parsedZoneData.ID)
 
 		acrastruct, err := acrawriter.CreateAcrastruct([]byte(*data), &keys.PublicKey{Value: zonePublic}, zoneID)
 		if err != nil {

--- a/keystore/filesystem/server_keystore_test.go
+++ b/keystore/filesystem/server_keystore_test.go
@@ -28,7 +28,7 @@ import (
 	"testing"
 )
 
-func testGenerateKeyPair(store *FilesystemKeyStore, t *testing.T) {
+func testGenerateKeyPair(store *KeyStore, t *testing.T) {
 	clientID := []byte("some test id")
 	file, err := ioutil.TempFile("", "test_generate_key_pair")
 	if err != nil {
@@ -52,7 +52,7 @@ func testGenerateKeyPair(store *FilesystemKeyStore, t *testing.T) {
 	}
 }
 
-func testGeneral(store *FilesystemKeyStore, t *testing.T) {
+func testGeneral(store *KeyStore, t *testing.T) {
 	if store.HasZonePrivateKey([]byte("non-existent key")) {
 		t.Fatal("Expected false on non-existent key")
 	}
@@ -79,7 +79,7 @@ func testGeneral(store *FilesystemKeyStore, t *testing.T) {
 	}
 }
 
-func testGeneratingDataEncryptionKeys(store *FilesystemKeyStore, t *testing.T) {
+func testGeneratingDataEncryptionKeys(store *KeyStore, t *testing.T) {
 	testID := []byte("test id")
 	err := store.GenerateDataEncryptionKeys(testID)
 	if err != nil {
@@ -116,7 +116,7 @@ func checkPath(path string, t *testing.T) {
 	}
 }
 
-func testGenerateServerKeys(store *FilesystemKeyStore, t *testing.T) {
+func testGenerateServerKeys(store *KeyStore, t *testing.T) {
 	testID := []byte("test id")
 	err := store.GenerateServerKeys(testID)
 	if err != nil {
@@ -129,7 +129,7 @@ func testGenerateServerKeys(store *FilesystemKeyStore, t *testing.T) {
 	checkPath(absPath, t)
 }
 
-func testGenerateTranslatorKeys(store *FilesystemKeyStore, t *testing.T) {
+func testGenerateTranslatorKeys(store *KeyStore, t *testing.T) {
 	testID := []byte("test test id")
 	err := store.GenerateTranslatorKeys(testID)
 	if err != nil {
@@ -141,7 +141,7 @@ func testGenerateTranslatorKeys(store *FilesystemKeyStore, t *testing.T) {
 	checkPath(absPath, t)
 }
 
-func testGenerateConnectorKeys(store *FilesystemKeyStore, t *testing.T) {
+func testGenerateConnectorKeys(store *KeyStore, t *testing.T) {
 	testID := []byte("test id")
 	err := store.GenerateConnectorKeys(testID)
 	if err != nil {
@@ -156,7 +156,7 @@ func testGenerateConnectorKeys(store *FilesystemKeyStore, t *testing.T) {
 
 }
 
-func testReset(store *FilesystemKeyStore, t *testing.T) {
+func testReset(store *KeyStore, t *testing.T) {
 	testID := []byte("some test id")
 	if err := store.GenerateServerKeys(testID); err != nil {
 		t.Fatal(err)
@@ -183,7 +183,7 @@ func testReset(store *FilesystemKeyStore, t *testing.T) {
 	}
 }
 
-func testGetZonePublicKey(store *FilesystemKeyStore, t *testing.T) {
+func testGetZonePublicKey(store *KeyStore, t *testing.T) {
 	id, binPublic, err := store.GenerateZoneKey()
 	if err != nil {
 		t.Fatal(err)
@@ -196,7 +196,7 @@ func testGetZonePublicKey(store *FilesystemKeyStore, t *testing.T) {
 		t.Fatal("Incorrect public key value")
 	}
 }
-func testGetClientIDEncryptionPublicKey(store *FilesystemKeyStore, t *testing.T) {
+func testGetClientIDEncryptionPublicKey(store *KeyStore, t *testing.T) {
 	id := []byte("some id")
 	if err := store.GenerateDataEncryptionKeys(id); err != nil {
 		t.Fatal("Can't generate data encryption keys")
@@ -244,7 +244,7 @@ func TestFilesystemKeyStore(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, store := range []*FilesystemKeyStore{generalStore, splitKeysStore, noCacheKeyStore} {
+	for _, store := range []*KeyStore{generalStore, splitKeysStore, noCacheKeyStore} {
 		testGeneral(store, t)
 		testGeneratingDataEncryptionKeys(store, t)
 		testGenerateConnectorKeys(store, t)
@@ -264,7 +264,7 @@ func TestFilesystemKeyStoreWithCache(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Chmod(keyDirectory, 0700); err != nil {
+	if err = os.Chmod(keyDirectory, 0700); err != nil {
 		t.Fatal(err)
 	}
 	defer func() {
@@ -291,7 +291,7 @@ func TestFilesystemKeyStoreWithCache(t *testing.T) {
 	}
 	testID2 := []byte("test id 2")
 	// create one more key that shouldn't saved in cache with 1 size
-	if err := store.GenerateDataEncryptionKeys(testID2); err != nil {
+	if err = store.GenerateDataEncryptionKeys(testID2); err != nil {
 		t.Fatal(err)
 	}
 	// load and save in cache. it must drop previous key from cache
@@ -337,7 +337,7 @@ func TestFilesystemKeyStore_RotateZoneKey(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Chmod(keyDirectory, 0700); err != nil {
+	if err = os.Chmod(keyDirectory, 0700); err != nil {
 		t.Fatal(err)
 	}
 	defer func() {
@@ -375,7 +375,7 @@ func TestFilesystemKeyStore_RotateZoneKey(t *testing.T) {
 	}
 }
 
-func testSaveKeypairs(store *FilesystemKeyStore, t *testing.T) {
+func testSaveKeypairs(store *KeyStore, t *testing.T) {
 	store.Reset()
 	testID := []byte("testid")
 	startKeypair, err := keys.New(keys.KEYTYPE_EC)
@@ -391,7 +391,7 @@ func testSaveKeypairs(store *FilesystemKeyStore, t *testing.T) {
 	if _, err := store.getPrivateKeyByFilename(testID, filename); err == nil {
 		t.Fatal("Expected error")
 	}
-	if err := store.saveKeyPairWithFilename(startKeypair, filename, testID); err != nil {
+	if err = store.saveKeyPairWithFilename(startKeypair, filename, testID); err != nil {
 		t.Fatal(err)
 	}
 	if privateKey, err := store.getPrivateKeyByFilename(testID, filename); err != nil {
@@ -402,7 +402,7 @@ func testSaveKeypairs(store *FilesystemKeyStore, t *testing.T) {
 		}
 	}
 
-	if err := store.saveKeyPairWithFilename(overwritedKeypair, filename, testID); err != nil {
+	if err = store.saveKeyPairWithFilename(overwritedKeypair, filename, testID); err != nil {
 		t.Fatal(err)
 	}
 	if privateKey, err := store.getPrivateKeyByFilename(testID, filename); err != nil {

--- a/keystore/filesystem/translator_keystore.go
+++ b/keystore/filesystem/translator_keystore.go
@@ -25,7 +25,7 @@ import (
 
 // TranslatorFileSystemKeyStore stores AcraTranslator keys configuration
 type TranslatorFileSystemKeyStore struct {
-	*FilesystemKeyStore
+	*KeyStore
 	directory string
 	encryptor keystore.KeyEncryptor
 }
@@ -36,7 +36,7 @@ func NewTranslatorFileSystemKeyStore(directory string, encryptor keystore.KeyEnc
 	if err != nil {
 		return nil, err
 	}
-	return &TranslatorFileSystemKeyStore{FilesystemKeyStore: fsKeystore, directory: directory, encryptor: encryptor}, nil
+	return &TranslatorFileSystemKeyStore{KeyStore: fsKeystore, directory: directory, encryptor: encryptor}, nil
 }
 
 // CheckIfPrivateKeyExists checks if Keystore has Translator transport private key for establishing Secure Session connection,

--- a/keystore/lru/cache.go
+++ b/keystore/lru/cache.go
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package lru_cache implements simple LRU cache used by Keystore. LRU cache stores in memory some amount of
+// Package lru implements simple LRU cache used by Keystore. LRU cache stores in memory some amount of
 // encrypted keys and removes less used keys upon adding new ones.
-package lru_cache
+package lru
 
 import (
 	"github.com/cossacklabs/acra/utils"
@@ -25,8 +25,8 @@ import (
 	"sync"
 )
 
-// LRUCache implement keystore.Cache
-type LRUCache struct {
+// Cache implement keystore.Cache
+type Cache struct {
 	lru   *lru.Cache
 	mutex sync.RWMutex
 }
@@ -41,22 +41,22 @@ func clearCacheValue(key lru.Key, value interface{}) {
 	}
 }
 
-// NewLRUCacheKeystoreWrapper return new *LRUCache
-func NewLRUCacheKeystoreWrapper(size int) (*LRUCache, error) {
-	cache := &LRUCache{lru: lru.New(size)}
+// NewCacheKeystoreWrapper return new *Cache
+func NewCacheKeystoreWrapper(size int) (*Cache, error) {
+	cache := &Cache{lru: lru.New(size)}
 	cache.lru.OnEvicted = clearCacheValue
 	return cache, nil
 }
 
 // Add value by keyID
-func (cache *LRUCache) Add(keyID string, keyValue []byte) {
+func (cache *Cache) Add(keyID string, keyValue []byte) {
 	cache.mutex.Lock()
 	cache.lru.Add(keyID, keyValue)
 	cache.mutex.Unlock()
 }
 
 // Get value by keyID
-func (cache *LRUCache) Get(keyID string) ([]byte, bool) {
+func (cache *Cache) Get(keyID string) ([]byte, bool) {
 	cache.mutex.RLock()
 	defer cache.mutex.RUnlock()
 	value, ok := cache.lru.Get(keyID)
@@ -67,7 +67,7 @@ func (cache *LRUCache) Get(keyID string) ([]byte, bool) {
 }
 
 // Clear cache and remove all values with zeroing
-func (cache *LRUCache) Clear() {
+func (cache *Cache) Clear() {
 	cache.mutex.Lock()
 	cache.lru.Clear()
 	cache.mutex.Unlock()

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -36,7 +36,7 @@ const (
 	LogDiscard
 )
 
-const loggerKey = "logger"
+type loggerKey struct{}
 
 // SetLogLevel sets logging level
 func SetLogLevel(level int) {
@@ -85,7 +85,7 @@ func logFormatterFor(loggingFormat string, serviceName string) log.Formatter {
 
 // SetLoggerToContext sets logger to corresponded context
 func SetLoggerToContext(ctx context.Context, logger *log.Entry) context.Context {
-	return context.WithValue(ctx, loggerKey, logger)
+	return context.WithValue(ctx, loggerKey{}, logger)
 }
 
 // GetLoggerFromContext gets logger from context, returns nil if no logger.
@@ -98,6 +98,6 @@ func GetLoggerFromContext(ctx context.Context) *log.Entry {
 
 // GetLoggerFromContextOk gets logger from context, returns logger and success code.
 func GetLoggerFromContextOk(ctx context.Context) (*log.Entry, bool) {
-	entry, ok := ctx.Value(loggerKey).(*log.Entry)
+	entry, ok := ctx.Value(loggerKey{}).(*log.Entry)
 	return entry, ok
 }

--- a/network/connection_wrapper_test.go
+++ b/network/connection_wrapper_test.go
@@ -322,10 +322,10 @@ func testTLSConfig(serverWrapper *TLSConnectionWrapper, t *testing.T) {
 			t.Fatal("Timeout on wrap with incorrect cipher suits")
 		}
 	}
-	if err := clientConn.Close(); err != nil {
+	if err = clientConn.Close(); err != nil {
 		t.Fatal(err)
 	}
-	if err := serverConn.Close(); err != nil {
+	if err = serverConn.Close(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -373,10 +373,10 @@ func testTLSConfig(serverWrapper *TLSConnectionWrapper, t *testing.T) {
 			t.Fatal("Timeout on wrap with unsupported protocol version")
 		}
 	}
-	if err := clientConn.Close(); err != nil {
+	if err = clientConn.Close(); err != nil {
 		t.Fatal(err)
 	}
-	if err := serverConn.Close(); err != nil {
+	if err = serverConn.Close(); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/network/utils.go
+++ b/network/utils.go
@@ -28,12 +28,12 @@ import (
 
 // Custom connection schemes, used in AcraConnector and AcraTranslator
 const (
-	GRPC_SCHEME = "grpc"
-	HTTP_SCHEME = "http"
+	GRPCScheme = "grpc"
+	HTTPScheme = "http"
 )
 
 func customSchemeToBaseGolangScheme(scheme string) string {
-	if scheme == GRPC_SCHEME || scheme == HTTP_SCHEME {
+	if scheme == GRPCScheme || scheme == HTTPScheme {
 		return "tcp"
 	}
 	return scheme

--- a/sqlparser/sql.go
+++ b/sqlparser/sql.go
@@ -6,7 +6,6 @@ package sqlparser
 import __yyfmt__ "fmt"
 
 //line sql.y:18
-
 func setParseTree(yylex interface{}, stmt Statement) {
 	yylex.(*Tokenizer).ParseTree = stmt
 }

--- a/zone/matcher.go
+++ b/zone/matcher.go
@@ -50,7 +50,7 @@ type DbByteReader interface {
 
 // MatcherFactory creates matchers
 type MatcherFactory interface {
-	CreateMatcher() Matcher
+	createMatcher() matcher
 }
 
 /* custom matcher factories */
@@ -64,8 +64,8 @@ func NewPgHexMatcherFactory() MatcherFactory {
 }
 
 // CreateMatcher returns new PgHexMatcher
-func (*PgHexMatcherFactory) CreateMatcher() Matcher {
-	return NewPgMatcher(NewPgHexByteReader())
+func (*PgHexMatcherFactory) createMatcher() matcher {
+	return newPgMatcher(NewPgHexByteReader())
 }
 
 // PgEscapeMatcherFactory makes new pgMatchers for EscapedBytes mode
@@ -77,14 +77,14 @@ func NewPgEscapeMatcherFactory() MatcherFactory {
 }
 
 // CreateMatcher returns new PgEscapeMatcher
-func (*PgEscapeMatcherFactory) CreateMatcher() Matcher {
-	return NewPgMatcher(NewPgEscapeByteReader())
+func (*PgEscapeMatcherFactory) createMatcher() matcher {
+	return newPgMatcher(NewPgEscapeByteReader())
 }
 
 /* end custom matcher factories */
 
-// Matcher basic interface
-type Matcher interface {
+// matcher basic interface
+type matcher interface {
 	Match(byte) bool
 	Reset()
 	GetZoneID() []byte
@@ -94,15 +94,15 @@ type Matcher interface {
 
 // PgMatcher concatenates two matchers: pgMatcher and binaryMatcher
 type PgMatcher struct {
-	pgMatcher     Matcher
-	binaryMatcher Matcher
+	pgMatcher     matcher
+	binaryMatcher matcher
 }
 
-// NewPgMatcher returns new Matcher with pgMatcher and binaryMatcher
-func NewPgMatcher(dbReader DbByteReader) Matcher {
+// newPgMatcher returns new matcher with pgMatcher and binaryMatcher
+func newPgMatcher(dbReader DbByteReader) matcher {
 	return &PgMatcher{
-		pgMatcher:     NewBaseMatcher(dbReader),
-		binaryMatcher: NewBaseMatcher(NewBinaryByteReader()),
+		pgMatcher:     newBaseMatcher(dbReader),
+		binaryMatcher: newBaseMatcher(NewBinaryByteReader()),
 	}
 }
 
@@ -152,8 +152,8 @@ type BaseMatcher struct {
 	dbReader     DbByteReader
 }
 
-// NewBaseMatcher returns new Matcher
-func NewBaseMatcher(dbReader DbByteReader) Matcher {
+// newBaseMatcher returns new matcher
+func newBaseMatcher(dbReader DbByteReader) matcher {
 	return &BaseMatcher{
 		currentIndex: 0,
 		dbReader:     dbReader,
@@ -162,7 +162,7 @@ func NewBaseMatcher(dbReader DbByteReader) Matcher {
 		zoneID:       make([]byte, ZoneIDBlockLength)}
 }
 
-// Reset changes Matcher state to the initial one, used in tests only
+// Reset changes matcher state to the initial one, used in tests only
 func (matcher *BaseMatcher) Reset() {
 	// used only for tests
 	matcher.currentIndex = 0

--- a/zone/matcher_pool.go
+++ b/zone/matcher_pool.go
@@ -31,18 +31,18 @@ func NewMatcherPool(factory MatcherFactory) *MatcherPool {
 	return &MatcherPool{factory: factory, matchers: list.New()}
 }
 
-// Acquire returns first matcher from the list, or creates one from factory if matchers list is empty
-func (pool *MatcherPool) Acquire() Matcher {
+// acquire returns first matcher from the list, or creates one from factory if matchers list is empty
+func (pool *MatcherPool) acquire() matcher {
 	if pool.matchers.Len() == 0 {
-		return pool.factory.CreateMatcher()
+		return pool.factory.createMatcher()
 	}
 	/*pop from matchers and return*/
-	matcher := pool.matchers.Remove(pool.matchers.Front())
-	return matcher.(Matcher)
+	matcherImpl := pool.matchers.Remove(pool.matchers.Front())
+	return matcherImpl.(matcher)
 }
 
-// Release resets matcher and push it to the start of the list
-func (pool *MatcherPool) Release(matcher Matcher) {
+// release resets matcher and push it to the start of the list
+func (pool *MatcherPool) release(matcher matcher) {
 	matcher.Reset()
 	pool.matchers.PushFront(matcher)
 }

--- a/zone/matcher_test.go
+++ b/zone/matcher_test.go
@@ -13,15 +13,14 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package zone_test
+package zone
 
 import (
 	"encoding/hex"
-	"github.com/cossacklabs/acra/zone"
 	"testing"
 )
 
-func assertMatchFail(c byte, matcher zone.Matcher, t *testing.T) {
+func assertMatchFail(c byte, matcher matcher, t *testing.T) {
 	if matcher.Match(c) {
 		t.Fatalf("Expected match fail on char %v", string(c))
 	}
@@ -29,31 +28,31 @@ func assertMatchFail(c byte, matcher zone.Matcher, t *testing.T) {
 		t.Fatal("Unexpected matched status")
 	}
 }
-func assertMatchNotFail(c byte, matcher zone.Matcher, t *testing.T) {
+func assertMatchNotFail(c byte, matcher matcher, t *testing.T) {
 	if !matcher.Match(c) {
 		t.Fatal("Unexpected unmatch")
 	}
 }
 
 func testMatcherWithHexReader(t *testing.T) {
-	matcher := zone.NewPgHexMatcherFactory().CreateMatcher()
+	matcher := NewPgHexMatcherFactory().createMatcher()
 	// we neen explicit "end" for escape format where zone_id has dynamic size
 	// 973feb
-	var HEX_ZONE_ID_BEGIN = []byte(hex.EncodeToString(zone.ZoneIDBegin))
+	var HexZoneIDBegin = []byte(hex.EncodeToString(ZoneIDBegin))
 
 	// test fail on first char of tab begin
 	assertMatchFail('q', matcher, t)
 	matcher.Reset()
 
 	// test fail on last char of tag begin
-	for _, c := range HEX_ZONE_ID_BEGIN[:len(HEX_ZONE_ID_BEGIN)-1] {
+	for _, c := range HexZoneIDBegin[:len(HexZoneIDBegin)-1] {
 		assertMatchNotFail(byte(c), matcher, t)
 	}
 	assertMatchFail('q', matcher, t)
 	matcher.Reset()
 
 	// test fail on incorrect char in zone_id block
-	for _, c := range HEX_ZONE_ID_BEGIN {
+	for _, c := range HexZoneIDBegin {
 		assertMatchNotFail(byte(c), matcher, t)
 	}
 	// 4 correct digits
@@ -64,11 +63,11 @@ func testMatcherWithHexReader(t *testing.T) {
 	matcher.Reset()
 
 	// test correct matching
-	for _, c := range HEX_ZONE_ID_BEGIN {
+	for _, c := range HexZoneIDBegin {
 		assertMatchNotFail(byte(c), matcher, t)
 	}
 	// fill zone id
-	for i := 0; i < (zone.ZoneIDLength * 2); i++ {
+	for i := 0; i < (ZoneIDLength * 2); i++ {
 		assertMatchNotFail('a', matcher, t)
 	}
 
@@ -78,22 +77,22 @@ func testMatcherWithHexReader(t *testing.T) {
 }
 
 func testMatcherWithEscapeReader(t *testing.T) {
-	matcher := zone.NewBaseMatcher(zone.NewPgEscapeByteReader())
-	var INCORRECT_VALUE byte = 31
+	matcher := newBaseMatcher(NewPgEscapeByteReader())
+	var IncorrectValue byte = 31
 
 	t.Log("Test fail on first char of begin tag")
-	assertMatchFail(INCORRECT_VALUE, matcher, t)
+	assertMatchFail(IncorrectValue, matcher, t)
 	matcher.Reset()
 
 	t.Log("Test fail on last char of begin tag")
-	for _, c := range zone.ZoneIDBegin[:len(zone.ZoneIDBegin)-1] {
+	for _, c := range ZoneIDBegin[:len(ZoneIDBegin)-1] {
 		assertMatchNotFail(byte(c), matcher, t)
 	}
-	assertMatchFail(INCORRECT_VALUE, matcher, t)
+	assertMatchFail(IncorrectValue, matcher, t)
 	matcher.Reset()
 
 	t.Log("Test fail on incorrect char in zone_id block")
-	for _, c := range zone.ZoneIDBegin {
+	for _, c := range ZoneIDBegin {
 		assertMatchNotFail(byte(c), matcher, t)
 	}
 	// 4 correct printable digits
@@ -106,15 +105,15 @@ func testMatcherWithEscapeReader(t *testing.T) {
 	assertMatchNotFail('0', matcher, t)
 	assertMatchNotFail('1', matcher, t)
 
-	assertMatchFail(INCORRECT_VALUE, matcher, t)
+	assertMatchFail(IncorrectValue, matcher, t)
 	matcher.Reset()
 
 	t.Log("Test correct matching")
-	for _, c := range zone.ZoneIDBegin {
+	for _, c := range ZoneIDBegin {
 		assertMatchNotFail(byte(c), matcher, t)
 	}
 	// fill zone id
-	for i := 0; i < zone.ZoneIDLength; i++ {
+	for i := 0; i < ZoneIDLength; i++ {
 		assertMatchNotFail('a', matcher, t)
 	}
 	if !matcher.IsMatched() {
@@ -123,24 +122,24 @@ func testMatcherWithEscapeReader(t *testing.T) {
 }
 
 func testMatcherWithBinaryReader(t *testing.T) {
-	matcher := zone.NewBaseMatcher(zone.NewBinaryByteReader())
+	matcher := newBaseMatcher(NewBinaryByteReader())
 	// test fail on first char of tab begin
 	assertMatchFail('q', matcher, t)
 	matcher.Reset()
 
 	// test fail on last char of tag begin
-	for _, c := range zone.ZoneIDBegin[:len(zone.ZoneIDBegin)-1] {
+	for _, c := range ZoneIDBegin[:len(ZoneIDBegin)-1] {
 		assertMatchNotFail(byte(c), matcher, t)
 	}
 	assertMatchFail('q', matcher, t)
 	matcher.Reset()
 
 	// test correct matching
-	for _, c := range zone.ZoneIDBegin {
+	for _, c := range ZoneIDBegin {
 		assertMatchNotFail(byte(c), matcher, t)
 	}
 	// fill zone id
-	for i := 0; i < zone.ZoneIDLength; i++ {
+	for i := 0; i < ZoneIDLength; i++ {
 		assertMatchNotFail('a', matcher, t)
 	}
 
@@ -150,22 +149,22 @@ func testMatcherWithBinaryReader(t *testing.T) {
 }
 
 func testHasAnyMatchWithHexReader(t *testing.T) {
-	factory := zone.NewPgHexMatcherFactory()
-	matcher := factory.CreateMatcher()
-	var HEX_ZONE_ID_BEGIN = []byte(hex.EncodeToString(zone.ZoneIDBegin))
+	factory := NewPgHexMatcherFactory()
+	matcher := factory.createMatcher()
+	var HexZoneIDBegin = []byte(hex.EncodeToString(ZoneIDBegin))
 	if matcher.HasAnyMatch() {
 		t.Fatal("Expected no match")
 	}
-	matcher.Match(HEX_ZONE_ID_BEGIN[0])
+	matcher.Match(HexZoneIDBegin[0])
 	if !matcher.HasAnyMatch() {
 		t.Fatal("Expected no match")
 	}
-	matcher.Match(HEX_ZONE_ID_BEGIN[1])
+	matcher.Match(HexZoneIDBegin[1])
 	if !matcher.HasAnyMatch() {
 		t.Fatal("Expected no match")
 	}
 
-	matcher = factory.CreateMatcher()
+	matcher = factory.createMatcher()
 	incorrectByte := byte(1)
 	matcher.Match(incorrectByte)
 	if matcher.HasAnyMatch() {
@@ -174,20 +173,20 @@ func testHasAnyMatchWithHexReader(t *testing.T) {
 }
 
 func testHasAnyMatchWithEscapeReader(t *testing.T) {
-	factory := zone.NewPgEscapeMatcherFactory()
-	matcher := factory.CreateMatcher()
+	factory := NewPgEscapeMatcherFactory()
+	matcher := factory.createMatcher()
 	if matcher.HasAnyMatch() {
 		t.Fatal("Expected no match")
 	}
 	// test first octal value from zone_id_begin
-	for _, c := range zone.ZoneIDBegin[:3] {
+	for _, c := range ZoneIDBegin[:3] {
 		matcher.Match(c)
 		if !matcher.HasAnyMatch() {
 			t.Fatal("Unexpected no match")
 		}
 	}
 
-	matcher = factory.CreateMatcher()
+	matcher = factory.createMatcher()
 	incorrectByte := byte(1)
 	matcher.Match(incorrectByte)
 	if matcher.HasAnyMatch() {
@@ -196,17 +195,17 @@ func testHasAnyMatchWithEscapeReader(t *testing.T) {
 }
 
 func testHasAnyMatchWithBinaryReader(t *testing.T) {
-	matcher := zone.NewBaseMatcher(zone.NewBinaryByteReader())
+	matcher := newBaseMatcher(NewBinaryByteReader())
 	if matcher.HasAnyMatch() {
 		t.Fatal("Expected no match")
 	}
-	if !matcher.Match(zone.ZoneIDBegin[0]) {
+	if !matcher.Match(ZoneIDBegin[0]) {
 		t.Fatal("Expected match")
 	}
 	if !matcher.HasAnyMatch() {
 		t.Fatal("Expected match")
 	}
-	if !matcher.Match(zone.ZoneIDBegin[1]) {
+	if !matcher.Match(ZoneIDBegin[1]) {
 		t.Fatal("Expected match")
 	}
 	if !matcher.HasAnyMatch() {
@@ -223,16 +222,16 @@ func testHasAnyMatchWithBinaryReader(t *testing.T) {
 }
 
 func testPgMatcher(t *testing.T) {
-	pgMatcher := zone.NewPgMatcher(zone.NewPgHexByteReader())
+	pgMatcher := newPgMatcher(NewPgHexByteReader())
 	t.Log("Test binary zone id")
 	t.Log("Fill zone begin")
 	// test correct matching with binary zone_id
-	for _, c := range zone.ZoneIDBegin {
+	for _, c := range ZoneIDBegin {
 		assertMatchNotFail(byte(c), pgMatcher, t)
 	}
 	t.Log("Fill zone id")
 	// fill zone id
-	for i := 0; i < zone.ZoneIDLength; i++ {
+	for i := 0; i < ZoneIDLength; i++ {
 		t.Log("Fill ", i)
 		assertMatchNotFail('a', pgMatcher, t)
 	}
@@ -246,13 +245,13 @@ func testPgMatcher(t *testing.T) {
 		t.Fatal("Unexpected match")
 	}
 	pgMatcher.Reset()
-	var HEX_ZONE_ID_BEGIN = []byte(hex.EncodeToString(zone.ZoneIDBegin))
+	var HexZoneIDBegin = []byte(hex.EncodeToString(ZoneIDBegin))
 	t.Log("Test hex zone id")
-	for _, c := range HEX_ZONE_ID_BEGIN {
+	for _, c := range HexZoneIDBegin {
 		assertMatchNotFail(byte(c), pgMatcher, t)
 	}
 	// fill zone id
-	for i := 0; i < (zone.ZoneIDLength * 2); i++ {
+	for i := 0; i < (ZoneIDLength * 2); i++ {
 		assertMatchNotFail('a', pgMatcher, t)
 	}
 

--- a/zone/zone_id_matcher_test.go
+++ b/zone/zone_id_matcher_test.go
@@ -35,7 +35,7 @@ import (
 	"testing"
 )
 
-func assertZoneMatchNotFail(c byte, matcher *zone.ZoneIDMatcher, t *testing.T) {
+func assertZoneMatchNotFail(c byte, matcher *zone.Matcher, t *testing.T) {
 	if !matcher.Match(c) {
 		t.Fatal("Unexpected unmatch")
 	}


### PR DESCRIPTION
caught the moment when we all finished our work with code and renamed most of constants/identifiers according to golang conventions and reduced warnings from golint : )
left some warnings which related with package names with underscore where I am not sure that it need to be changed and some names of components
```
acra-censor/acra-censor_interfaces.go:36:6: type name will be used as acracensor.AcraCensorInterface by other packages, and that stutters; consider calling this Interface
cmd/acra-connector/connector-mode/connector-mode.go:21:1: don't use an underscore in package name
cmd/acra-translator/grpc_api/api_test.go:1:1: don't use an underscore in package name
cmd/acra-translator/grpc_api/decryptor.go:20:1: don't use an underscore in package name
cmd/acra-translator/http_api/decryptor.go:20:1: don't use an underscore in package name
cmd/acra-translator/http_api/decryptor_test.go:1:1: don't use an underscore in package name
cmd/acra-translator/http_api/mock_keystorage.go:17:1: don't use an underscore in package name
cmd/acra-translator/http_api/mock_poison_callback.go:17:1: don't use an underscore in package name
network/secure_session_wrapper.go:49:34: method GetPublicKeyForId should be GetPublicKeyForID
zone/utils.go:40:6: func name will be used as zone.ZoneDataToJSON by other packages, and that stutters; consider calling this DataToJSON
```
