### PR TITLE
public methods to extract table aliases from query

### DIFF
--- a/decryptor/postgresql/dataProcessor.go
+++ b/decryptor/postgresql/dataProcessor.go
@@ -33,9 +33,17 @@ func NewEncodeDecodeWrapper(processor base.DataProcessor) base.DataProcessor {
 		if err != nil {
 			return data, err
 		}
-		output := make([]byte, len(HexPrefix)+hex.EncodedLen(len(data)))
-		copy(output, HexPrefix)
-		hex.Encode(output[len(HexPrefix):], data)
-		return output, nil
+
+		// if data was simple string without binary data then return it as is otherwise encode as hex value
+		for _, c := range data {
+			if !utils.IsPrintableEscapeChar(c) {
+				output := make([]byte, len(HexPrefix)+hex.EncodedLen(len(data)))
+				copy(output, HexPrefix)
+				hex.Encode(output[len(HexPrefix):], data)
+				data = output
+				break
+			}
+		}
+		return data, nil
 	})
 }

--- a/encryptor/config/tableSchema.go
+++ b/encryptor/config/tableSchema.go
@@ -100,5 +100,8 @@ func (schema *TableSchema) NeedToEncrypt(columnName string) bool {
 
 // GetColumnEncryptionSettings return setting or nil
 func (schema *TableSchema) GetColumnEncryptionSettings(columnName string) *ColumnEncryptionSetting {
+	if schema.mapEncryptedColumns == nil {
+		schema.initMap()
+	}
 	return schema.mapEncryptedColumns[columnName]
 }

--- a/logging/log_formatters.go
+++ b/logging/log_formatters.go
@@ -67,7 +67,7 @@ func CEFFormatter(fields logrus.Fields) logrus.Formatter {
 		}
 	}
 
-	return AcraCEFFormatter{
+	return &AcraCEFFormatter{
 		CEFTextFormatter: CEFTextFormatter{
 			TimestampFormat: time.RFC3339,
 		},
@@ -161,7 +161,7 @@ func (f AcraJSONFormatter) Format(e *logrus.Entry) ([]byte, error) {
 // Format formats an entry to a AcraCEF format according to the given Formatter and Fields.
 //
 // Note: the given entry is copied and not changed during the formatting process.
-func (f AcraCEFFormatter) Format(e *logrus.Entry) ([]byte, error) {
+func (f *AcraCEFFormatter) Format(e *logrus.Entry) ([]byte, error) {
 	ne := copyEntry(e, f.Fields)
 	if value, ok := ne.Data[FieldKeyUnixTime]; !ok || value == 0 {
 		ne.Data[FieldKeyUnixTime] = unixTimeWithMilliseconds(e)

--- a/utils/dbByteArrayEncoders.go
+++ b/utils/dbByteArrayEncoders.go
@@ -89,8 +89,8 @@ func DecodeOctal(data []byte) ([]byte, error) {
 
 // DecodeEscaped with hex or octal encodings
 func DecodeEscaped(data []byte) ([]byte, error) {
-	hexdata := data[2:]
-	if bytes.Equal(data[:2], []byte{'\\', 'x'}) {
+	if len(data) > 2 && bytes.Equal(data[:2], []byte{'\\', 'x'}) {
+		hexdata := data[2:]
 		output := make([]byte, hex.DecodedLen(len(hexdata)))
 		_, err := hex.Decode(output, hexdata)
 		return output, err


### PR DESCRIPTION
* make public `GetTablesWithAliases` function (was method) and `AliasedTableName` to reuse it in enterprise code 
* fix govet, use pointer to struct with sync.Once - https://goreportcard.com/report/github.com/cossacklabs/acra
* return decrypted string as is without encoding to hex if it simple string. it reduces length of packet