### PR TITLE
correctly turn off encryptor

### DIFF
--- a/decryptor/base/observers.go
+++ b/decryptor/base/observers.go
@@ -68,6 +68,7 @@ type QueryObserver interface {
 // QueryObservable used to handle subscribers for new incoming queries
 type QueryObservable interface {
 	AddQueryObserver(QueryObserver)
+	RegisteredObserversCount() int
 }
 
 // QueryObserverManager interface for observer aggregations
@@ -84,6 +85,11 @@ type ArrayQueryObserverableManager struct {
 // AddQueryObserver observer to array
 func (manager *ArrayQueryObserverableManager) AddQueryObserver(obs QueryObserver) {
 	manager.subscribers = append(manager.subscribers, obs)
+}
+
+// RegisteredObserversCount return count of registered observers
+func (manager *ArrayQueryObserverableManager) RegisteredObserversCount() int {
+	return len(manager.subscribers)
 }
 
 // OnQuery would be called for each added observer to manager

--- a/decryptor/mysql/proxy.go
+++ b/decryptor/mysql/proxy.go
@@ -50,11 +50,12 @@ func (factory *proxyFactory) New(ctx context.Context, clientID []byte, dbConnect
 	if err != nil {
 		return nil, err
 	}
-
-	queryEncryptor, err := encryptor.NewMysqlQueryEncryptor(factory.setting.TableSchemaStore(), clientID, factory.dataEncryptor)
-	if err != nil {
-		return nil, err
+	if !factory.setting.TableSchemaStore().IsEmpty() {
+		queryEncryptor, err := encryptor.NewMysqlQueryEncryptor(factory.setting.TableSchemaStore(), clientID, factory.dataEncryptor)
+		if err != nil {
+			return nil, err
+		}
+		proxy.AddQueryObserver(queryEncryptor)
 	}
-	proxy.AddQueryObserver(queryEncryptor)
 	return proxy, nil
 }

--- a/decryptor/mysql/proxy_test.go
+++ b/decryptor/mysql/proxy_test.go
@@ -13,7 +13,7 @@ func (*decryptorFactory) New(clientID []byte) (base.Decryptor, error) {
 	return nil, nil
 }
 
-type tableSchemaStore struct{empty bool}
+type tableSchemaStore struct{ empty bool }
 
 func (*tableSchemaStore) GetTableSchema(tableName string) *config.TableSchema {
 	panic("implement me")
@@ -52,4 +52,3 @@ func TestEncryptorTurnOnOff(t *testing.T) {
 		t.Fatal("Unexpected observers count")
 	}
 }
-

--- a/decryptor/mysql/proxy_test.go
+++ b/decryptor/mysql/proxy_test.go
@@ -1,0 +1,55 @@
+package mysql
+
+import (
+	"context"
+	"github.com/cossacklabs/acra/decryptor/base"
+	"github.com/cossacklabs/acra/encryptor/config"
+	"testing"
+)
+
+type decryptorFactory struct{}
+
+func (*decryptorFactory) New(clientID []byte) (base.Decryptor, error) {
+	return nil, nil
+}
+
+type tableSchemaStore struct{empty bool}
+
+func (*tableSchemaStore) GetTableSchema(tableName string) *config.TableSchema {
+	panic("implement me")
+}
+
+func (store *tableSchemaStore) IsEmpty() bool {
+	return store.empty
+}
+
+func TestEncryptorTurnOnOff(t *testing.T) {
+	emptyStore := &tableSchemaStore{true}
+	nonEmptyStore := &tableSchemaStore{false}
+	setting := base.NewProxySetting(&decryptorFactory{}, emptyStore, nil, nil, nil)
+	proxyFactory, err := NewProxyFactory(setting)
+	if err != nil {
+		t.Fatal(setting)
+	}
+	proxy, err := proxyFactory.New(context.TODO(), nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if proxy.RegisteredObserversCount() > 0 {
+		t.Fatal("Unexpected observers count")
+	}
+
+	setting = base.NewProxySetting(&decryptorFactory{}, nonEmptyStore, nil, nil, nil)
+	proxyFactory, err = NewProxyFactory(setting)
+	if err != nil {
+		t.Fatal(setting)
+	}
+	proxy, err = proxyFactory.New(context.TODO(), nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if proxy.RegisteredObserversCount() != 1 {
+		t.Fatal("Unexpected observers count")
+	}
+}
+

--- a/decryptor/mysql/response_proxy.go
+++ b/decryptor/mysql/response_proxy.go
@@ -182,6 +182,11 @@ func (handler *Handler) AddQueryObserver(obs base.QueryObserver) {
 	handler.queryObserverManager.AddQueryObserver(obs)
 }
 
+// RegisteredObserversCount return count of registered observers
+func (handler *Handler) RegisteredObserversCount() int {
+	return handler.queryObserverManager.RegisteredObserversCount()
+}
+
 func (handler *Handler) setQueryHandler(callback ResponseHandler) {
 	handler.responseHandler = callback
 }

--- a/decryptor/postgresql/pg_decryptor.go
+++ b/decryptor/postgresql/pg_decryptor.go
@@ -120,8 +120,8 @@ func (proxy *PgProxy) AddQueryObserver(obs base.QueryObserver) {
 }
 
 // RegisteredObserversCount return count of registered observers
-func (handler *PgProxy) RegisteredObserversCount() int {
-	return handler.queryObserverManager.RegisteredObserversCount()
+func (proxy *PgProxy) RegisteredObserversCount() int {
+	return proxy.queryObserverManager.RegisteredObserversCount()
 }
 
 // ProxyClientConnection checks every client request using AcraCensor,

--- a/decryptor/postgresql/pg_decryptor.go
+++ b/decryptor/postgresql/pg_decryptor.go
@@ -119,6 +119,11 @@ func (proxy *PgProxy) AddQueryObserver(obs base.QueryObserver) {
 	proxy.queryObserverManager.AddQueryObserver(obs)
 }
 
+// RegisteredObserversCount return count of registered observers
+func (handler *PgProxy) RegisteredObserversCount() int {
+	return handler.queryObserverManager.RegisteredObserversCount()
+}
+
 // ProxyClientConnection checks every client request using AcraCensor,
 // if request is allowed, sends it to the Pg database
 func (proxy *PgProxy) ProxyClientConnection(errCh chan<- error) {

--- a/decryptor/postgresql/proxy.go
+++ b/decryptor/postgresql/proxy.go
@@ -51,11 +51,13 @@ func (factory *proxyFactory) New(ctx context.Context, clientID []byte, dbConnect
 		return nil, err
 	}
 
-	queryEncryptor, err := encryptor.NewPostgresqlQueryEncryptor(factory.setting.TableSchemaStore(), clientID, factory.dataEncryptor)
-	if err != nil {
-		return nil, err
+	if !factory.setting.TableSchemaStore().IsEmpty() {
+		queryEncryptor, err := encryptor.NewPostgresqlQueryEncryptor(factory.setting.TableSchemaStore(), clientID, factory.dataEncryptor)
+		if err != nil {
+			return nil, err
+		}
+		proxy.AddQueryObserver(queryEncryptor)
 	}
-	proxy.AddQueryObserver(queryEncryptor)
 
 	return proxy, nil
 }

--- a/decryptor/postgresql/proxy_test.go
+++ b/decryptor/postgresql/proxy_test.go
@@ -12,7 +12,7 @@ func (*decryptorFactory) New(clientID []byte) (base.Decryptor, error) {
 	return nil, nil
 }
 
-type tableSchemaStore struct{empty bool}
+type tableSchemaStore struct{ empty bool }
 
 func (*tableSchemaStore) GetTableSchema(tableName string) *config.TableSchema {
 	panic("implement me")

--- a/decryptor/postgresql/proxy_test.go
+++ b/decryptor/postgresql/proxy_test.go
@@ -1,0 +1,53 @@
+package postgresql
+
+import (
+	"github.com/cossacklabs/acra/decryptor/base"
+	"github.com/cossacklabs/acra/encryptor/config"
+	"testing"
+)
+
+type decryptorFactory struct{}
+
+func (*decryptorFactory) New(clientID []byte) (base.Decryptor, error) {
+	return nil, nil
+}
+
+type tableSchemaStore struct{empty bool}
+
+func (*tableSchemaStore) GetTableSchema(tableName string) *config.TableSchema {
+	panic("implement me")
+}
+
+func (store *tableSchemaStore) IsEmpty() bool {
+	return store.empty
+}
+
+func TestEncryptorTurnOnOff(t *testing.T) {
+	emptyStore := &tableSchemaStore{true}
+	nonEmptyStore := &tableSchemaStore{false}
+	setting := base.NewProxySetting(&decryptorFactory{}, emptyStore, nil, nil, nil)
+	proxyFactory, err := NewProxyFactory(setting)
+	if err != nil {
+		t.Fatal(setting)
+	}
+	proxy, err := proxyFactory.New(nil, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if proxy.RegisteredObserversCount() > 0 {
+		t.Fatal("Unexpected observers count")
+	}
+
+	setting = base.NewProxySetting(&decryptorFactory{}, nonEmptyStore, nil, nil, nil)
+	proxyFactory, err = NewProxyFactory(setting)
+	if err != nil {
+		t.Fatal(setting)
+	}
+	proxy, err = proxyFactory.New(nil, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if proxy.RegisteredObserversCount() != 1 {
+		t.Fatal("Unexpected observers count")
+	}
+}

--- a/encryptor/config/tableSchema.go
+++ b/encryptor/config/tableSchema.go
@@ -21,6 +21,7 @@ import "gopkg.in/yaml.v2"
 // TableSchemaStore interface to fetch schema for table
 type TableSchemaStore interface {
 	GetTableSchema(tableName string) *TableSchema
+	IsEmpty() bool
 }
 
 type storeConfig struct {
@@ -57,6 +58,14 @@ func (store *MapTableSchemaStore) GetTableSchema(tableName string) *TableSchema 
 		return schema
 	}
 	return nil
+}
+
+// IsEmpty return true if hasn't any schemas
+func (store *MapTableSchemaStore) IsEmpty() bool {
+	if store.schemas == nil || len(store.schemas) == 0 {
+		return true
+	}
+	return false
 }
 
 // ColumnEncryptionSetting describe how to encrypt column


### PR DESCRIPTION
don't initialize encryptor if config is empty and do not add it to OnQuery observers. it helps to avoid extra parsing of incoming queries
