### PR TITLE
fix querycapture duplicate logs

### DIFF
--- a/acra-censor/common/logging_logic.go
+++ b/acra-censor/common/logging_logic.go
@@ -214,7 +214,7 @@ func (queryWriter *QueryWriter) deserializeQueries() ([]*QueryInfo, error) {
 
 func (queryWriter *QueryWriter) serializeQueries(queries []*QueryInfo) []byte {
 	var linesToAppend []byte
-	var tempQueryInfo = &QueryInfo{}
+	var tempQueryInfo = QueryInfo{}
 	for _, queryInfo := range queries {
 		tempQueryInfo.RawQuery = queryInfo.RawQuery
 		tempQueryInfo.IsForbidden = queryInfo.IsForbidden

--- a/acra-censor/common/logging_logic.go
+++ b/acra-censor/common/logging_logic.go
@@ -162,6 +162,7 @@ func (queryWriter *QueryWriter) WriteQuery(query string) {
 func (queryWriter *QueryWriter) reset() {
 	queryWriter.mutex.Lock()
 	queryWriter.Queries = nil
+	queryWriter.queryIndex = 0
 	queryWriter.mutex.Unlock()
 }
 
@@ -172,6 +173,7 @@ func (queryWriter *QueryWriter) readStoredQueries() error {
 		return err
 	}
 	queryWriter.Queries = q
+	queryWriter.queryIndex = len(q)
 	return nil
 }
 
@@ -179,11 +181,13 @@ func (queryWriter *QueryWriter) dumpBufferedQueries() error {
 	queryWriter.mutex.Lock()
 	defer queryWriter.mutex.Unlock()
 
-	partialRawData := queryWriter.serializeQueries(queryWriter.Queries[queryWriter.queryIndex:])
-	if err := queryWriter.logStorage.Append(partialRawData); err != nil {
-		return err
+	if len(queryWriter.Queries) != 0 {
+		partialRawData := queryWriter.serializeQueries(queryWriter.Queries[queryWriter.queryIndex:])
+		if err := queryWriter.logStorage.Append(partialRawData); err != nil {
+			return err
+		}
+		queryWriter.queryIndex = len(queryWriter.Queries)
 	}
-	queryWriter.queryIndex = len(queryWriter.Queries)
 	return nil
 }
 

--- a/acra-censor/common/logging_logic_test.go
+++ b/acra-censor/common/logging_logic_test.go
@@ -38,7 +38,7 @@ func TestSerializationOnUniqueQueries(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer func (){
+	defer func() {
 		err = os.Remove(tmpFile.Name())
 		if err != nil {
 			t.Fatal(err)

--- a/acra-censor/common/logging_logic_test.go
+++ b/acra-censor/common/logging_logic_test.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -94,7 +95,6 @@ func TestSerializationOnUniqueQueries(t *testing.T) {
 }
 
 func TestOutputFileAfterDumpStoredQueries(t *testing.T) {
-	// TODO finish test
 	tmpFile, err := ioutil.TempFile("", "censor_log")
 	if err != nil {
 		t.Fatal(err)
@@ -108,32 +108,38 @@ func TestOutputFileAfterDumpStoredQueries(t *testing.T) {
 		t.Fatal(err)
 	}
 	writer, err := NewFileQueryWriter(tmpFile.Name())
-
-	defer func() {
-		writer.Free()
-		err = os.Remove(tmpFile.Name())
-		if err != nil {
-			t.Fatal(err)
-		}
-	}()
-
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	for _, query := range testQueries {
-		_, queryWithHiddenValues, _, err := HandleRawSQLQuery(query)
-		if err != nil {
-			t.Fatal(err)
-		}
-		writer.captureQuery(queryWithHiddenValues)
-		if err != nil {
-			t.Fatal(err)
-		}
+	testQuery := "select 1 from dual"
+	writer.captureQuery(testQuery)
+	if err = writer.DumpQueries(); err != nil {
+		t.Fatal(err)
 	}
-	time.Sleep(DefaultSerializationTimeout + 100*time.Millisecond)
-	if len(writer.Queries) != len(testQueries) {
-		t.Fatal("Expected: " + strings.Join(testQueries, " | ") + "\nGot: " + strings.Join(rawStrings(writer.Queries), " | "))
+	writer.reset()
+
+	if err = writer.readStoredQueries(); err != nil {
+		t.Fatal(err)
+	}
+	if writer.queryIndex != 1 {
+		t.Fatal("Expected queryIndex == 1")
+	}
+	if len(writer.Queries) != 1 {
+		t.Fatal("Expected len(writer.Queries) != 1")
+	}
+	if err = writer.dumpBufferedQueries(); err != nil {
+		t.Fatal(err)
+	}
+	dumpedLines, err := ioutil.ReadFile(tmpFile.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	queries := bytes.Split(dumpedLines, []byte{'\n'})
+
+	// 1 expected query and 1 empty line from endline symbol
+	if len(queries) != 2 && !bytes.Equal(queries[1], []byte{}) {
+		t.Fatalf("Expected 1 dumped query, took %d: %s\n", len(queries), string(dumpedLines))
 	}
 }
 

--- a/acra-censor/common/logging_logic_test.go
+++ b/acra-censor/common/logging_logic_test.go
@@ -38,23 +38,21 @@ func TestSerializationOnUniqueQueries(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err = tmpFile.Close(); err != nil {
-		t.Fatal(err)
-	}
-	writer, err := NewFileQueryWriter(tmpFile.Name())
-	go writer.Start()
-
-	defer func() {
-		writer.Free()
+	defer func (){
 		err = os.Remove(tmpFile.Name())
 		if err != nil {
 			t.Fatal(err)
 		}
 	}()
-
+	if err = tmpFile.Close(); err != nil {
+		t.Fatal(err)
+	}
+	writer, err := NewFileQueryWriter(tmpFile.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
+	go writer.Start()
+	defer writer.Free()
 
 	for _, query := range testQueries {
 		_, queryWithHiddenValues, _, err := HandleRawSQLQuery(query)
@@ -74,6 +72,7 @@ func TestSerializationOnUniqueQueries(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	writer.reset()
 	if len(writer.Queries) != 0 {
 		t.Fatal("Expected no queries \nGot: " + strings.Join(rawStrings(writer.Queries), " | "))
 	}

--- a/acra-censor/handlers/querycapture_handler.go
+++ b/acra-censor/handlers/querycapture_handler.go
@@ -37,8 +37,6 @@ func (handler *QueryCaptureHandler) CheckQuery(sqlQuery string, parsedQuery sqlp
 		return true, nil
 	}
 	handler.writer.WriteQuery(sqlQuery)
-	// TODO refactor to use only handler.Queries and index of not dumped queries. On dump signal dump all queries after index
-	// TODO and only increment index without overhead of extra queries in memory
 	return true, nil
 }
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -832,7 +832,7 @@ class BaseTestCase(PrometheusMixin, unittest.TestCase):
         return port+1
 
     def fork_connector(self, connector_port: int, acraserver_port: int, client_id: str, api_port: int=None, zone_mode: bool=False, check_connection: bool=True):
-        logging.info("fork connector with port {} and client_id={}", connector_port, client_id)
+        logging.info("fork connector with port {} and client_id={}".format(connector_port, client_id))
 
         acraserver_connection = self.get_acraserver_connection_string(acraserver_port)
         acraserver_api_connection = self.get_acraserver_api_connection_string(acraserver_port)


### PR DESCRIPTION
found that when censor starts and read existing queries from disk he doesn't update queryindex and work with queryindex == 0. and then after serialization timer's tick it dump buffered queries that was appended (all queries stored in handler.Queries array after queryindex position that store index of last dumped query). And it dump all queries loaded at start and only after that update queryindex to correct value `Length(loadedQueries)`. 