### PR TITLE
print version on start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ _testmain.go
 *.prof
 
 .idea/
+# used by intellij IDEA for project structures
+*.iml
 bin
 src/github.com/
 

--- a/cmd/acra-connector/acra-connector.go
+++ b/cmd/acra-connector/acra-connector.go
@@ -209,7 +209,7 @@ type Config struct {
 }
 
 func main() {
-	log.Infof("Starting service %v [pid=%v]", ServiceName, os.Getpid())
+	log.WithField("version", utils.VERSION).Infof("Starting service %v [pid=%v]", ServiceName, os.Getpid())
 
 	loggingFormat := flag.String("logging_format", "plaintext", "Logging format: plaintext, json or CEF")
 	keysDir := flag.String("keys_dir", keystore.DefaultKeyDirShort, "Folder from which will be loaded keys")

--- a/cmd/acra-server/acra-server.go
+++ b/cmd/acra-server/acra-server.go
@@ -73,7 +73,7 @@ var ErrWaitTimeout = errors.New("timeout")
 
 func main() {
 	loggingFormat := flag.String("logging_format", "plaintext", "Logging format: plaintext, json or CEF")
-	log.Infof("Starting service %v [pid=%v]", ServiceName, os.Getpid())
+	log.WithField("version", utils.VERSION).Infof("Starting service %v [pid=%v]", ServiceName, os.Getpid())
 
 	dbHost := flag.String("db_host", "", "Host to db")
 	dbPort := flag.Int("db_port", 5432, "Port to db")

--- a/cmd/acra-translator/acra-translator.go
+++ b/cmd/acra-translator/acra-translator.go
@@ -49,7 +49,7 @@ var DefaultConfigPath = utils.GetConfigPathByName(ServiceName)
 func main() {
 	config := NewConfig()
 	loggingFormat := flag.String("logging_format", "plaintext", "Logging format: plaintext, json or CEF")
-	log.Infof("Starting service %v [pid=%v]", ServiceName, os.Getpid())
+	log.WithField("version", utils.VERSION).Infof("Starting service %v [pid=%v]", ServiceName, os.Getpid())
 
 	incomingConnectionHTTPString := flag.String("incoming_connection_http_string", "", "Connection string for HTTP transport like http://0.0.0.0:9595")
 	incomingConnectionGRPCString := flag.String("incoming_connection_grpc_string", "", "Default option: connection string for gRPC transport like grpc://0.0.0.0:9696")

--- a/utils/version.go
+++ b/utils/version.go
@@ -17,4 +17,4 @@ limitations under the License.
 package utils
 
 // VERSION is current Acra suite version
-var VERSION = "0.84.0" // change on current during build
+var VERSION = "0.84.2" // change on current during build


### PR DESCRIPTION
added logging version at start. it looks now like that:
```
INFO[0000] Starting service acra-server [pid=591]        version=0.84.2
INFO[2019-02-21T14:46:00+02:00] Validating service configuration...
...
```