### PR TITLE
export version as metric

### DIFF
--- a/cmd/acra-connector/prometheus.go
+++ b/cmd/acra-connector/prometheus.go
@@ -16,6 +16,7 @@ limitations under the License.
 package main
 
 import (
+	"github.com/cossacklabs/acra/cmd"
 	"github.com/cossacklabs/acra/utils"
 	"github.com/prometheus/client_golang/prometheus"
 	"sync"
@@ -47,11 +48,11 @@ func registerMetrics() {
 	registerLock.Do(func() {
 		prometheus.MustRegister(connectionCounter)
 		prometheus.MustRegister(connectionProcessingTimeHistogram)
-		utils.RegisterVersionMetrics(ServiceName)
+		cmd.RegisterVersionMetrics(ServiceName)
 		version, err := utils.GetParsedVersion()
 		if err != nil {
 			panic(err)
 		}
-		utils.ExportVersionMetric(version)
+		cmd.ExportVersionMetric(version)
 	})
 }

--- a/cmd/acra-connector/prometheus.go
+++ b/cmd/acra-connector/prometheus.go
@@ -16,6 +16,7 @@ limitations under the License.
 package main
 
 import (
+	"github.com/cossacklabs/acra/utils"
 	"github.com/prometheus/client_golang/prometheus"
 	"sync"
 )
@@ -46,5 +47,6 @@ func registerMetrics() {
 	registerLock.Do(func() {
 		prometheus.MustRegister(connectionCounter)
 		prometheus.MustRegister(connectionProcessingTimeHistogram)
+		utils.RegisterVersionMetrics(ServiceName)
 	})
 }

--- a/cmd/acra-connector/prometheus.go
+++ b/cmd/acra-connector/prometheus.go
@@ -48,5 +48,10 @@ func registerMetrics() {
 		prometheus.MustRegister(connectionCounter)
 		prometheus.MustRegister(connectionProcessingTimeHistogram)
 		utils.RegisterVersionMetrics(ServiceName)
+		version, err := utils.GetParsedVersion()
+		if err != nil {
+			panic(err)
+		}
+		utils.ExportVersionMetric(version)
 	})
 }

--- a/cmd/acra-server/prometheus.go
+++ b/cmd/acra-server/prometheus.go
@@ -17,6 +17,7 @@ package main
 
 import (
 	"github.com/cossacklabs/acra/decryptor/base"
+	"github.com/cossacklabs/acra/utils"
 	"github.com/prometheus/client_golang/prometheus"
 	"sync"
 )
@@ -49,5 +50,6 @@ func registerMetrics() {
 		prometheus.MustRegister(connectionProcessingTimeHistogram)
 		base.RegisterAcraStructProcessingMetrics()
 		base.RegisterDbProcessingMetrics()
+		utils.RegisterVersionMetrics(ServiceName)
 	})
 }

--- a/cmd/acra-server/prometheus.go
+++ b/cmd/acra-server/prometheus.go
@@ -16,6 +16,7 @@ limitations under the License.
 package main
 
 import (
+	"github.com/cossacklabs/acra/cmd"
 	"github.com/cossacklabs/acra/decryptor/base"
 	"github.com/cossacklabs/acra/utils"
 	"github.com/prometheus/client_golang/prometheus"
@@ -50,11 +51,11 @@ func registerMetrics() {
 		prometheus.MustRegister(connectionProcessingTimeHistogram)
 		base.RegisterAcraStructProcessingMetrics()
 		base.RegisterDbProcessingMetrics()
-		utils.RegisterVersionMetrics(ServiceName)
+		cmd.RegisterVersionMetrics(ServiceName)
 		version, err := utils.GetParsedVersion()
 		if err != nil {
 			panic(err)
 		}
-		utils.ExportVersionMetric(version)
+		cmd.ExportVersionMetric(version)
 	})
 }

--- a/cmd/acra-server/prometheus.go
+++ b/cmd/acra-server/prometheus.go
@@ -51,5 +51,10 @@ func registerMetrics() {
 		base.RegisterAcraStructProcessingMetrics()
 		base.RegisterDbProcessingMetrics()
 		utils.RegisterVersionMetrics(ServiceName)
+		version, err := utils.GetParsedVersion()
+		if err != nil {
+			panic(err)
+		}
+		utils.ExportVersionMetric(version)
 	})
 }

--- a/cmd/acra-translator/common/prometheus.go
+++ b/cmd/acra-translator/common/prometheus.go
@@ -29,7 +29,7 @@ const (
 var (
 	// RequestProcessingTimeHistogram collect metrics about time of processing requests to http/grpc api
 	RequestProcessingTimeHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Name:    "translator_request_processing_seconds",
+		Name:    "acratranslator_request_processing_seconds",
 		Help:    "Time of response processing",
 		Buckets: []float64{0.000001, 0.00001, 0.00002, 0.00003, 0.00004, 0.00005, 0.00006, 0.00007, 0.00008, 0.00009, 0.0001, 0.0005, 0.001, 0.005, 0.01, 1},
 	}, []string{requestTypeLabel})

--- a/cmd/acra-translator/prometheus.go
+++ b/cmd/acra-translator/prometheus.go
@@ -18,6 +18,7 @@ package main
 import (
 	"github.com/cossacklabs/acra/cmd/acra-translator/common"
 	"github.com/cossacklabs/acra/decryptor/base"
+	"github.com/cossacklabs/acra/utils"
 	"github.com/prometheus/client_golang/prometheus"
 	"sync"
 )
@@ -50,5 +51,6 @@ func registerMetrics() {
 		prometheus.MustRegister(connectionProcessingTimeHistogram)
 		prometheus.MustRegister(common.RequestProcessingTimeHistogram)
 		base.RegisterAcraStructProcessingMetrics()
+		utils.RegisterVersionMetrics(ServiceName)
 	})
 }

--- a/cmd/acra-translator/prometheus.go
+++ b/cmd/acra-translator/prometheus.go
@@ -52,5 +52,10 @@ func registerMetrics() {
 		prometheus.MustRegister(common.RequestProcessingTimeHistogram)
 		base.RegisterAcraStructProcessingMetrics()
 		utils.RegisterVersionMetrics(ServiceName)
+		version, err := utils.GetParsedVersion()
+		if err != nil {
+			panic(err)
+		}
+		utils.ExportVersionMetric(version)
 	})
 }

--- a/cmd/acra-translator/prometheus.go
+++ b/cmd/acra-translator/prometheus.go
@@ -16,6 +16,7 @@ limitations under the License.
 package main
 
 import (
+	"github.com/cossacklabs/acra/cmd"
 	"github.com/cossacklabs/acra/cmd/acra-translator/common"
 	"github.com/cossacklabs/acra/decryptor/base"
 	"github.com/cossacklabs/acra/utils"
@@ -51,11 +52,11 @@ func registerMetrics() {
 		prometheus.MustRegister(connectionProcessingTimeHistogram)
 		prometheus.MustRegister(common.RequestProcessingTimeHistogram)
 		base.RegisterAcraStructProcessingMetrics()
-		utils.RegisterVersionMetrics(ServiceName)
+		cmd.RegisterVersionMetrics(ServiceName)
 		version, err := utils.GetParsedVersion()
 		if err != nil {
 			panic(err)
 		}
-		utils.ExportVersionMetric(version)
+		cmd.ExportVersionMetric(version)
 	})
 }

--- a/cmd/prometheus.go
+++ b/cmd/prometheus.go
@@ -17,12 +17,17 @@ limitations under the License.
 package cmd
 
 import (
+	"fmt"
 	"github.com/cossacklabs/acra/logging"
 	"github.com/cossacklabs/acra/network"
+	"github.com/cossacklabs/acra/utils"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
 	"net"
 	"net/http"
+	"strings"
+	"sync"
 )
 
 // RunPrometheusHTTPHandler run in goroutine http server that process with connectionString address and export
@@ -42,4 +47,68 @@ func RunPrometheusHTTPHandler(connectionString string) (net.Listener, *http.Serv
 		}
 	}()
 	return listener, server, nil
+}
+
+var registerLock = sync.Once{}
+
+// serviceNameToLabelFormat convert service name to lower case and remove all '_'
+// ex. Acra-Server will be changed to acraserver
+func serviceNameToLabelFormat(serviceName string) string {
+	const replaceAll = -1
+	return strings.ToLower(strings.Replace(serviceName, "-", "", replaceAll))
+}
+
+// ExportVersionMetric set values for version metrics
+func ExportVersionMetric(version *utils.Version) {
+	version, err := utils.GetParsedVersion()
+	if err != nil {
+		panic(err)
+	}
+
+	if majorVersionGauge == nil || minorVersionGauge == nil || patchVersionGauge == nil {
+		panic("call RegisterVersionMetrics before exporting to initialize and register metrics")
+	}
+
+	val, _ := version.MajorAsFloat64()
+	majorVersionGauge.With(nil).Set(val)
+
+	val, _ = version.MinorAsFloat64()
+	minorVersionGauge.With(nil).Set(val)
+
+	val, _ = version.PatchAsFloat64()
+	patchVersionGauge.With(nil).Set(val)
+}
+
+var (
+	majorVersionGauge *prometheus.GaugeVec
+	minorVersionGauge *prometheus.GaugeVec
+	patchVersionGauge *prometheus.GaugeVec
+)
+
+// RegisterVersionMetrics set and register metrics with current version value
+func RegisterVersionMetrics(serviceName string) {
+	labelServiceName := serviceNameToLabelFormat(serviceName)
+	majorVersionGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: fmt.Sprintf("%s_version_major", labelServiceName),
+			Help: "Major number of version",
+		}, []string{})
+
+	minorVersionGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: fmt.Sprintf("%s_version_minor", labelServiceName),
+			Help: "Minor number of version",
+		}, []string{})
+
+	patchVersionGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: fmt.Sprintf("%s_version_patch", labelServiceName),
+			Help: "Patch number of version",
+		}, []string{})
+
+	registerLock.Do(func() {
+		prometheus.MustRegister(majorVersionGauge)
+		prometheus.MustRegister(minorVersionGauge)
+		prometheus.MustRegister(patchVersionGauge)
+	})
 }

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -15,3 +15,4 @@ git+https://github.com/yaml/pyyaml@release/4.2
 grpcio==1.13.0
 grpcio-tools==1.13.0
 googleapis-common-protos==1.5.3
+prometheus_client==0.6.0

--- a/tests/test.py
+++ b/tests/test.py
@@ -2473,7 +2473,7 @@ class TestAcraWebconfigWeb(AcraCatchLogsMixin, BaseTestCase):
                         os.kill(int(pid), signal.SIGKILL)
                     except ProcessLookupError:
                         pass
-                    send_signal_by_process_name('acra-server', signal.SIGKILL)
+            send_signal_by_process_name('acra-server', signal.SIGKILL)
 
             # restore changed config
             os.rename('configs/acra-server.yaml.backup',
@@ -3420,7 +3420,7 @@ class TestPrometheusMetrics(AcraTranslatorMixin, BaseTestCase):
             # acra-connector keypair1 + keypair2
             'acraserver_connections_total': {'min_value': 2},
 
-            'acraserver_connections_processing_seconds_bucket': {'min_value': 1},
+            'acraserver_connections_processing_seconds_bucket': {'min_value': 0},
             'acraserver_connections_processing_seconds_sum': {'min_value': TestPrometheusMetrics.MIN_EXECUTION_TIME},
             'acraserver_connections_processing_seconds_count': {'min_value': 1},
 
@@ -3447,7 +3447,7 @@ class TestPrometheusMetrics(AcraTranslatorMixin, BaseTestCase):
         labels = {
             'acraconnector_connections_total': {'min_value': 2},
 
-            'acraconnector_connections_processing_seconds_bucket': {'min_value': 1},
+            'acraconnector_connections_processing_seconds_bucket': {'min_value': 0},
             'acraconnector_connections_processing_seconds_sum': {'min_value': TestPrometheusMetrics.MIN_EXECUTION_TIME},
             'acraconnector_connections_processing_seconds_count': {'min_value': 1},
 
@@ -3462,7 +3462,7 @@ class TestPrometheusMetrics(AcraTranslatorMixin, BaseTestCase):
         labels = {
             'acratranslator_connections_total': {'min_value': 1},
 
-            'acratranslator_connections_processing_seconds_bucket': {'min_value': 1},
+            'acratranslator_connections_processing_seconds_bucket': {'min_value': 0},
             'acratranslator_connections_processing_seconds_sum': {'min_value': TestPrometheusMetrics.MIN_EXECUTION_TIME},
             'acratranslator_connections_processing_seconds_count': {'min_value': 1},
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -3417,17 +3417,20 @@ class TestPrometheusMetrics(AcraTranslatorMixin, BaseTestCase):
         # run some queries to set some values for counters
         HexFormatTest.testConnectorRead(self)
         labels = {
-            'acraserver_connections_total': {'min_value': 1},
-            'acraserver_connections_processing_seconds': {'min_value': TestPrometheusMetrics.MIN_EXECUTION_TIME},
-            'acraserver_connections_processing_seconds_bucket': {'min_value': TestPrometheusMetrics.MIN_EXECUTION_TIME},
+            # acra-connector keypair1 + keypair2
+            'acraserver_connections_total': {'min_value': 2},
+            'acraserver_connections_processing_seconds_bucket': {'min_value': 1},
             'acraserver_connections_processing_seconds_sum': {'min_value': TestPrometheusMetrics.MIN_EXECUTION_TIME},
             'acraserver_connections_processing_seconds_count': {'min_value': 1},
-            'acraserver_response_processing_seconds': {'min_value': TestPrometheusMetrics.MIN_EXECUTION_TIME},
-            'acraserver_request_processing_seconds': {'min_value': TestPrometheusMetrics.MIN_EXECUTION_TIME},
+
+            'acraserver_response_processing_seconds_sum': {'min_value': TestPrometheusMetrics.MIN_EXECUTION_TIME},
+            'acraserver_response_processing_seconds_bucket': {'min_value': 0},
+            'acraserver_response_processing_seconds_count': {'min_value': 1},
+
             'acraserver_request_processing_seconds_sum': {'min_value': TestPrometheusMetrics.MIN_EXECUTION_TIME},
             'acraserver_request_processing_seconds_count': {'min_value': 1},
-            'acraserver_response_processing_seconds_bucket': {'min_value': 0},
             'acraserver_request_processing_seconds_bucket': {'min_value': 0},
+
             'acra_acrastruct_decryptions_total': {'min_value': 1},
             'acraserver_version_major': {'min_value': 0},
             'acraserver_version_minor': {'min_value': 0},
@@ -3440,9 +3443,9 @@ class TestPrometheusMetrics(AcraTranslatorMixin, BaseTestCase):
         # connector should has some values in counter after connections checks
         # on setUp
         labels = {
-            'acraconnector_connections_total': {'min_value': 1},
-            'acraconnector_connections_processing_seconds': {'min_value': TestPrometheusMetrics.MIN_EXECUTION_TIME},
-            'acraconnector_connections_processing_seconds_bucket': {'min_value': TestPrometheusMetrics.MIN_EXECUTION_TIME},
+            'acraconnector_connections_total': {'min_value': 2},
+            #'acraconnector_connections_processing_seconds': {'min_value': TestPrometheusMetrics.MIN_EXECUTION_TIME},
+            'acraconnector_connections_processing_seconds_bucket': {'min_value': 1},
             'acraconnector_connections_processing_seconds_sum': {'min_value': TestPrometheusMetrics.MIN_EXECUTION_TIME},
             'acraconnector_connections_processing_seconds_count': {'min_value': 1},
             'acraconnector_version_major': {'min_value': 0},
@@ -3455,16 +3458,19 @@ class TestPrometheusMetrics(AcraTranslatorMixin, BaseTestCase):
     def testAcraTranslator(self):
         labels = {
             'acratranslator_connections_total': {'min_value': 1},
-            'acratranslator_connections_processing_seconds': {'min_value': TestPrometheusMetrics.MIN_EXECUTION_TIME},
-            'acratranslator_connections_processing_seconds_bucket': {'min_value': TestPrometheusMetrics.MIN_EXECUTION_TIME},
+
+            'acratranslator_connections_processing_seconds_bucket': {'min_value': 1},
             'acratranslator_connections_processing_seconds_sum': {'min_value': TestPrometheusMetrics.MIN_EXECUTION_TIME},
             'acratranslator_connections_processing_seconds_count': {'min_value': 1},
-            #'acratranslator_request_processing_seconds_sum': {'min_value': TestPrometheusMetrics.MIN_EXECUTION_TIME},
-            #'acratranslator_request_processing_seconds_count': {'min_value': 0},
+
+            'acratranslator_request_processing_seconds_bucket': {'min_value': 0},
+            'acratranslator_request_processing_seconds_sum': {'min_value': TestPrometheusMetrics.MIN_EXECUTION_TIME},
+            'acratranslator_request_processing_seconds_count': {'min_value': 1},
 
             'acratranslator_version_major': {'min_value': 0},
             'acratranslator_version_minor': {'min_value': 0},
             'acratranslator_version_patch': {'min_value': 0},
+
             'acra_acrastruct_decryptions_total': {'min_value': 1},
         }
         translator_port = 3456

--- a/tests/test.py
+++ b/tests/test.py
@@ -3419,6 +3419,7 @@ class TestPrometheusMetrics(AcraTranslatorMixin, BaseTestCase):
         labels = {
             # acra-connector keypair1 + keypair2
             'acraserver_connections_total': {'min_value': 2},
+
             'acraserver_connections_processing_seconds_bucket': {'min_value': 1},
             'acraserver_connections_processing_seconds_sum': {'min_value': TestPrometheusMetrics.MIN_EXECUTION_TIME},
             'acraserver_connections_processing_seconds_count': {'min_value': 1},
@@ -3432,6 +3433,7 @@ class TestPrometheusMetrics(AcraTranslatorMixin, BaseTestCase):
             'acraserver_request_processing_seconds_bucket': {'min_value': 0},
 
             'acra_acrastruct_decryptions_total': {'min_value': 1},
+
             'acraserver_version_major': {'min_value': 0},
             'acraserver_version_minor': {'min_value': 0},
             'acraserver_version_patch': {'min_value': 0},
@@ -3444,10 +3446,11 @@ class TestPrometheusMetrics(AcraTranslatorMixin, BaseTestCase):
         # on setUp
         labels = {
             'acraconnector_connections_total': {'min_value': 2},
-            #'acraconnector_connections_processing_seconds': {'min_value': TestPrometheusMetrics.MIN_EXECUTION_TIME},
+
             'acraconnector_connections_processing_seconds_bucket': {'min_value': 1},
             'acraconnector_connections_processing_seconds_sum': {'min_value': TestPrometheusMetrics.MIN_EXECUTION_TIME},
             'acraconnector_connections_processing_seconds_count': {'min_value': 1},
+
             'acraconnector_version_major': {'min_value': 0},
             'acraconnector_version_minor': {'min_value': 0},
             'acraconnector_version_patch': {'min_value': 0},

--- a/utils/version.go
+++ b/utils/version.go
@@ -16,5 +16,121 @@ limitations under the License.
 
 package utils
 
+import (
+	"errors"
+	"fmt"
+	"github.com/prometheus/client_golang/prometheus"
+	"strconv"
+	"strings"
+	"sync"
+)
+
 // VERSION is current Acra suite version
-var VERSION = "0.84.0" // change on current during build
+// store it as string instead initialized struct value to easy change/grep/sed/replace value via scripts
+var VERSION = "0.84.2"
+
+// Version store version info
+type Version struct {
+	Major string
+	Minor string
+	Patch string
+}
+
+// MajorAsFloat64 return major number as float64
+func (v *Version) MajorAsFloat64() (float64, error) {
+	return strconv.ParseFloat(v.Major, 64)
+}
+
+// MinorAsFloat64 return minor number as float64
+func (v *Version) MinorAsFloat64() (float64, error) {
+	return strconv.ParseFloat(v.Minor, 64)
+}
+
+// PatchAsFloat64 return patch number as float64
+func (v *Version) PatchAsFloat64() (float64, error) {
+	return strconv.ParseFloat(v.Patch, 64)
+}
+
+const (
+	major = iota
+	minor
+	patch
+)
+
+// ErrInvalidVersionFormat error for incorrectly formatted version value
+var ErrInvalidVersionFormat = errors.New("VERSION value has incorrect format (semver expected)")
+
+// GetParsedVersion return version as Version struct
+func GetParsedVersion() (*Version, error) {
+	parts := strings.Split(VERSION, ".")
+	if len(parts) != 3 {
+		return nil, ErrInvalidVersionFormat
+	}
+	for _, part := range parts {
+		// validate that version has correct values
+		if _, err := strconv.ParseUint(part, 10, 64); err != nil {
+			return nil, err
+		}
+	}
+	return &Version{parts[major], parts[minor], parts[patch]}, nil
+}
+
+var registerLock = sync.Once{}
+
+// serviceNameToLabelFormat convert service name to lower case and remove all '_'
+// ex. Acra-Server will be changed to acraserver
+func serviceNameToLabelFormat(serviceName string) string {
+	const replaceAll = -1
+	return strings.ToLower(strings.Replace(serviceName, "-", "", replaceAll))
+}
+
+// RegisterVersionMetrics set and register metrics with current version value
+func RegisterVersionMetrics(serviceName string) {
+	labelServiceName := serviceNameToLabelFormat(serviceName)
+	majorVersionGauge := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: fmt.Sprintf("%s_version_major", labelServiceName),
+			Help: "Major number of version",
+		}, []string{})
+
+	minorVersionGauge := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: fmt.Sprintf("%s_version_minor", labelServiceName),
+			Help: "Minor number of version",
+		}, []string{})
+
+	patchVersionGauge := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: fmt.Sprintf("%s_version_patch", labelServiceName),
+			Help: "Patch number of version",
+		}, []string{})
+
+	version, err := GetParsedVersion()
+	if err != nil {
+		panic(err)
+	}
+
+	if val, err := version.MajorAsFloat64(); err == nil {
+		majorVersionGauge.With(nil).Set(val)
+	} else {
+		panic(err)
+	}
+
+	if val, err := version.MinorAsFloat64(); err == nil {
+		minorVersionGauge.With(nil).Set(val)
+	} else {
+		panic(err)
+	}
+
+	if val, err := version.PatchAsFloat64(); err == nil {
+		patchVersionGauge.With(nil).Set(val)
+	} else {
+		panic(err)
+	}
+
+	registerLock.Do(func() {
+		prometheus.MustRegister(majorVersionGauge)
+		prometheus.MustRegister(minorVersionGauge)
+		prometheus.MustRegister(patchVersionGauge)
+	})
+}


### PR DESCRIPTION
* export `<service_name>_version_major`, `<service_name>_version_minor`, `<service_name>_version_patch` metrics where <service_name> replaced with _acraserver_ | _acraconnector_ | _acratranslator_ (all services that works as daemon)
* renamed _translator_request_processing_seconds_ -> _**acra**translator_request_processing_seconds_ metric name according to other metrics name
* updated tests that should check that all expected metrics exported and check that they have any value where it possible