### PR TITLE
Update acrawriter.podspec for iOS to handle correct bitcode

### DIFF
--- a/acrawriter.podspec
+++ b/acrawriter.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name = "acrawriter"
-    s.version = "1.0.1"
+    s.version = "1.0.2"
     s.summary = "AcraWriter library for iOS: encrypts data into AcraStructs, allowing Acra to decrypt it"
     s.description = "Part of Acra database protection suite: developers can encrypt the sensitive data by generating AcraStructs with AcraWriter anywhere across their apps. AcraServer or AcraTranslator can be used for decryption."
     s.homepage = "https://cossacklabs.com"
@@ -22,13 +22,7 @@ Pod::Spec.new do |s|
         'HEADER_SEARCH_PATHS' => '"${PODS_ROOT}/themis/src" "${PODS_ROOT}/themis/src/wrappers/themis/Obj-C"', 'CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES' => 'YES' }
 
     # Enable bitcode
-    # 'bitcode-marker' directive omits bitcode payload in binary for debug builds
-    s.ios.pod_target_xcconfig = {
-        'OTHER_CFLAGS[config=Debug]'                => '$(inherited) -fembed-bitcode-marker',
-        'OTHER_CFLAGS[config=Release]'              => '$(inherited) -fembed-bitcode',
-        'BITCODE_GENERATION_MODE[config=Release]'   => 'bitcode',
-        'BITCODE_GENERATION_MODE[config=Debug]'     => 'bitcode-marker'
-    }
+    s.ios.pod_target_xcconfig = {'ENABLE_BITCODE' => 'YES' }
         
     s.osx.xcconfig = { 'OTHER_CFLAGS' => '-DLIBRESSL', 'USE_HEADERMAP' => 'NO', 
         'HEADER_SEARCH_PATHS' => '"${PODS_ROOT}/themis/src" "${PODS_ROOT}/themis/src/wrappers/themis/Obj-C"', 'CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES' => 'YES' }

--- a/examples/objc/AcraWriterUsage.xcodeproj/project.pbxproj
+++ b/examples/objc/AcraWriterUsage.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		4ACC6B505D562BE081989D22 /* Pods_AcraWriterUsage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8EF1A773623A7DB9E6C5779D /* Pods_AcraWriterUsage.framework */; };
 		732D83F0211335BF0003A087 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 732D83EF211335BF0003A087 /* AppDelegate.m */; };
 		732D83F3211335BF0003A087 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 732D83F2211335BF0003A087 /* ViewController.m */; };
 		732D83F6211335BF0003A087 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 732D83F4211335BF0003A087 /* Main.storyboard */; };
@@ -15,7 +14,8 @@
 		732D83FB211335C00003A087 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 732D83F9211335C00003A087 /* LaunchScreen.storyboard */; };
 		732D83FE211335C00003A087 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 732D83FD211335C00003A087 /* main.m */; };
 		732D8408211335C00003A087 /* AcraWriterUsageTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 732D8407211335C00003A087 /* AcraWriterUsageTests.m */; };
-		A6AD04A30E1E4B70672BAA6B /* Pods_AcraWriterUsageTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2B2441F5B5753904BB78B525 /* Pods_AcraWriterUsageTests.framework */; };
+		8142E89781F516BB946FF4A8 /* Pods_AcraWriterUsageTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 43BA9081908C5B9819811F61 /* Pods_AcraWriterUsageTests.framework */; };
+		8EA7C54417BBB62BEA3A95A7 /* Pods_AcraWriterUsage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 599D242AA5078E7AB0EA3DE1 /* Pods_AcraWriterUsage.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -29,7 +29,11 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		2B2441F5B5753904BB78B525 /* Pods_AcraWriterUsageTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AcraWriterUsageTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		000F9E90D133936B188FDEAE /* Pods-AcraWriterUsageTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AcraWriterUsageTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-AcraWriterUsageTests/Pods-AcraWriterUsageTests.debug.xcconfig"; sourceTree = "<group>"; };
+		1798B87B497DCDF9176CEE40 /* Pods-AcraWriterUsage.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AcraWriterUsage.release.xcconfig"; path = "Pods/Target Support Files/Pods-AcraWriterUsage/Pods-AcraWriterUsage.release.xcconfig"; sourceTree = "<group>"; };
+		325FED2B7906627FC3CCC715 /* Pods-AcraWriterUsage.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AcraWriterUsage.debug.xcconfig"; path = "Pods/Target Support Files/Pods-AcraWriterUsage/Pods-AcraWriterUsage.debug.xcconfig"; sourceTree = "<group>"; };
+		43BA9081908C5B9819811F61 /* Pods_AcraWriterUsageTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AcraWriterUsageTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		599D242AA5078E7AB0EA3DE1 /* Pods_AcraWriterUsage.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AcraWriterUsage.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		732D83EB211335BF0003A087 /* AcraWriterUsage.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AcraWriterUsage.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		732D83EE211335BF0003A087 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		732D83EF211335BF0003A087 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
@@ -43,11 +47,7 @@
 		732D8403211335C00003A087 /* AcraWriterUsageTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AcraWriterUsageTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		732D8407211335C00003A087 /* AcraWriterUsageTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AcraWriterUsageTests.m; sourceTree = "<group>"; };
 		732D8409211335C00003A087 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		8EF1A773623A7DB9E6C5779D /* Pods_AcraWriterUsage.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AcraWriterUsage.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		B47CFAC8612FFA98CB13547A /* Pods-AcraWriterUsageTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AcraWriterUsageTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-AcraWriterUsageTests/Pods-AcraWriterUsageTests.debug.xcconfig"; sourceTree = "<group>"; };
-		BEEB54E7E943ED3A8AD0B576 /* Pods-AcraWriterUsageTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AcraWriterUsageTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-AcraWriterUsageTests/Pods-AcraWriterUsageTests.release.xcconfig"; sourceTree = "<group>"; };
-		D4CB591BB97DDD07334DAB9B /* Pods-AcraWriterUsage.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AcraWriterUsage.debug.xcconfig"; path = "Pods/Target Support Files/Pods-AcraWriterUsage/Pods-AcraWriterUsage.debug.xcconfig"; sourceTree = "<group>"; };
-		E6B1A4E637ED5D50E2BAC9D2 /* Pods-AcraWriterUsage.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AcraWriterUsage.release.xcconfig"; path = "Pods/Target Support Files/Pods-AcraWriterUsage/Pods-AcraWriterUsage.release.xcconfig"; sourceTree = "<group>"; };
+		9248965C428B52308C8E3711 /* Pods-AcraWriterUsageTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AcraWriterUsageTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-AcraWriterUsageTests/Pods-AcraWriterUsageTests.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -55,7 +55,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4ACC6B505D562BE081989D22 /* Pods_AcraWriterUsage.framework in Frameworks */,
+				8EA7C54417BBB62BEA3A95A7 /* Pods_AcraWriterUsage.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -63,18 +63,29 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A6AD04A30E1E4B70672BAA6B /* Pods_AcraWriterUsageTests.framework in Frameworks */,
+				8142E89781F516BB946FF4A8 /* Pods_AcraWriterUsageTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		26EA1F2CA053770B39A06467 /* Frameworks */ = {
+		0BE498505135C8B2BD82DF7D /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				8EF1A773623A7DB9E6C5779D /* Pods_AcraWriterUsage.framework */,
-				2B2441F5B5753904BB78B525 /* Pods_AcraWriterUsageTests.framework */,
+				325FED2B7906627FC3CCC715 /* Pods-AcraWriterUsage.debug.xcconfig */,
+				1798B87B497DCDF9176CEE40 /* Pods-AcraWriterUsage.release.xcconfig */,
+				000F9E90D133936B188FDEAE /* Pods-AcraWriterUsageTests.debug.xcconfig */,
+				9248965C428B52308C8E3711 /* Pods-AcraWriterUsageTests.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
+		0C245D43662F7600737674CE /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				599D242AA5078E7AB0EA3DE1 /* Pods_AcraWriterUsage.framework */,
+				43BA9081908C5B9819811F61 /* Pods_AcraWriterUsageTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -85,8 +96,8 @@
 				732D83ED211335BF0003A087 /* AcraWriterUsage */,
 				732D8406211335C00003A087 /* AcraWriterUsageTests */,
 				732D83EC211335BF0003A087 /* Products */,
-				DF46AF7EE65C617481B8B6B9 /* Pods */,
-				26EA1F2CA053770B39A06467 /* Frameworks */,
+				0BE498505135C8B2BD82DF7D /* Pods */,
+				0C245D43662F7600737674CE /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -124,17 +135,6 @@
 			path = AcraWriterUsageTests;
 			sourceTree = "<group>";
 		};
-		DF46AF7EE65C617481B8B6B9 /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				D4CB591BB97DDD07334DAB9B /* Pods-AcraWriterUsage.debug.xcconfig */,
-				E6B1A4E637ED5D50E2BAC9D2 /* Pods-AcraWriterUsage.release.xcconfig */,
-				B47CFAC8612FFA98CB13547A /* Pods-AcraWriterUsageTests.debug.xcconfig */,
-				BEEB54E7E943ED3A8AD0B576 /* Pods-AcraWriterUsageTests.release.xcconfig */,
-			);
-			name = Pods;
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -142,11 +142,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 732D840C211335C00003A087 /* Build configuration list for PBXNativeTarget "AcraWriterUsage" */;
 			buildPhases = (
-				23AD0D6382A9E6DF8C24602B /* [CP] Check Pods Manifest.lock */,
+				44AB8C470F7948AF097BBC04 /* [CP] Check Pods Manifest.lock */,
 				732D83E7211335BF0003A087 /* Sources */,
 				732D83E8211335BF0003A087 /* Frameworks */,
 				732D83E9211335BF0003A087 /* Resources */,
-				4227F3057AB67B413EB9FA18 /* [CP] Embed Pods Frameworks */,
+				636BEFA6F9FCEAC48C5B8462 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -161,11 +161,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 732D840F211335C00003A087 /* Build configuration list for PBXNativeTarget "AcraWriterUsageTests" */;
 			buildPhases = (
-				31C533E2D171FBD07C1B46B0 /* [CP] Check Pods Manifest.lock */,
+				932C2707C6E6F7CB3FF61163 /* [CP] Check Pods Manifest.lock */,
 				732D83FF211335C00003A087 /* Sources */,
 				732D8400211335C00003A087 /* Frameworks */,
 				732D8401211335C00003A087 /* Resources */,
-				0F903F486805F130BFCE4983 /* [CP] Embed Pods Frameworks */,
+				EF00CFB56A5B493825814764 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -235,33 +235,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		0F903F486805F130BFCE4983 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-AcraWriterUsageTests/Pods-AcraWriterUsageTests-frameworks.sh",
-				"${PODS_ROOT}/GRKOpenSSLFramework/OpenSSL-iOS/bin/openssl.framework",
-				"${BUILT_PRODUCTS_DIR}/acrawriter/acrawriter.framework",
-				"${BUILT_PRODUCTS_DIR}/themis/themis.framework",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/openssl.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/acrawriter.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/themis.framework",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-AcraWriterUsageTests/Pods-AcraWriterUsageTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		23AD0D6382A9E6DF8C24602B /* [CP] Check Pods Manifest.lock */ = {
+		44AB8C470F7948AF097BBC04 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -283,29 +257,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		31C533E2D171FBD07C1B46B0 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-AcraWriterUsageTests-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		4227F3057AB67B413EB9FA18 /* [CP] Embed Pods Frameworks */ = {
+		636BEFA6F9FCEAC48C5B8462 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -329,6 +281,54 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-AcraWriterUsage/Pods-AcraWriterUsage-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		932C2707C6E6F7CB3FF61163 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-AcraWriterUsageTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		EF00CFB56A5B493825814764 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${SRCROOT}/Pods/Target Support Files/Pods-AcraWriterUsageTests/Pods-AcraWriterUsageTests-frameworks.sh",
+				"${PODS_ROOT}/GRKOpenSSLFramework/OpenSSL-iOS/bin/openssl.framework",
+				"${BUILT_PRODUCTS_DIR}/acrawriter/acrawriter.framework",
+				"${BUILT_PRODUCTS_DIR}/themis/themis.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/openssl.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/acrawriter.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/themis.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-AcraWriterUsageTests/Pods-AcraWriterUsageTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -494,10 +494,11 @@
 		};
 		732D840D211335C00003A087 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = D4CB591BB97DDD07334DAB9B /* Pods-AcraWriterUsage.debug.xcconfig */;
+			baseConfigurationReference = 325FED2B7906627FC3CCC715 /* Pods-AcraWriterUsage.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = X6X7AHQ2D4;
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				INFOPLIST_FILE = AcraWriterUsage/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -512,10 +513,11 @@
 		};
 		732D840E211335C00003A087 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = E6B1A4E637ED5D50E2BAC9D2 /* Pods-AcraWriterUsage.release.xcconfig */;
+			baseConfigurationReference = 1798B87B497DCDF9176CEE40 /* Pods-AcraWriterUsage.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = X6X7AHQ2D4;
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				INFOPLIST_FILE = AcraWriterUsage/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -530,7 +532,7 @@
 		};
 		732D8410211335C00003A087 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B47CFAC8612FFA98CB13547A /* Pods-AcraWriterUsageTests.debug.xcconfig */;
+			baseConfigurationReference = 000F9E90D133936B188FDEAE /* Pods-AcraWriterUsageTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -549,7 +551,7 @@
 		};
 		732D8411211335C00003A087 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = BEEB54E7E943ED3A8AD0B576 /* Pods-AcraWriterUsageTests.release.xcconfig */;
+			baseConfigurationReference = 9248965C428B52308C8E3711 /* Pods-AcraWriterUsageTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;

--- a/examples/objc/AcraWriterUsage/AppDelegate.m
+++ b/examples/objc/AcraWriterUsage/AppDelegate.m
@@ -11,7 +11,7 @@
 
 // if ONLY_LOCAL_SETUP is true, don't send AcraStruct to AcraServer,
 // let users try project locally without being pissed off because of connection error
-#define ONLY_LOCAL_SETUP 0
+#define ONLY_LOCAL_SETUP 1
 
 @interface AppDelegate ()
 

--- a/examples/objc/Podfile.lock
+++ b/examples/objc/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - acrawriter (1.0.1):
+  - acrawriter (1.0.2):
     - themis (~> 0.10.0)
-  - GRKOpenSSLFramework (1.0.2.15)
-  - themis (0.10.2):
-    - themis/themis-openssl (= 0.10.2)
-  - themis/themis-openssl (0.10.2):
+  - GRKOpenSSLFramework (1.0.2.16)
+  - themis (0.10.3):
+    - themis/themis-openssl (= 0.10.3)
+  - themis/themis-openssl (0.10.3):
     - GRKOpenSSLFramework (~> 1.0.1)
-    - themis/themis-openssl/core (= 0.10.2)
-    - themis/themis-openssl/objcwrapper (= 0.10.2)
-  - themis/themis-openssl/core (0.10.2):
+    - themis/themis-openssl/core (= 0.10.3)
+    - themis/themis-openssl/objcwrapper (= 0.10.3)
+  - themis/themis-openssl/core (0.10.3):
     - GRKOpenSSLFramework (~> 1.0.1)
-  - themis/themis-openssl/objcwrapper (0.10.2):
+  - themis/themis-openssl/objcwrapper (0.10.3):
     - GRKOpenSSLFramework (~> 1.0.1)
     - themis/themis-openssl/core
 
@@ -24,9 +24,9 @@ SPEC REPOS:
     - themis
 
 SPEC CHECKSUMS:
-  acrawriter: 6be833b02f7f73fceaaa42ad2c6a950bc65925f4
-  GRKOpenSSLFramework: 8180d66833be66fc0f2d4942757d095edb0778d0
-  themis: bb0d7915dcb400748942969d9ab4c48f95193514
+  acrawriter: e56f932d8493f57476490809760e2b14cc842f8f
+  GRKOpenSSLFramework: 35944e317e6336b2944ad70b059d84db6b2d8532
+  themis: bdbb1d0baeee19ff213dc7355e9e2b48debea359
 
 PODFILE CHECKSUM: 32ce5b4065bc5fcd34089758cb59f3f7757bba17
 


### PR DESCRIPTION
Similar fix as in Themis (https://github.com/cossacklabs/themis/pull/407/), update `acrawriter.podspec` to use more correct (and device-compatible) settings for bitcode.

- [x] updated podspec.
- [x] tested on device.
- [x] pushed podspec to cocoapods repo.
- [x] updated example projects.