### PR TITLE
Update acrawriter.podspec

### DIFF
--- a/acrawriter.podspec
+++ b/acrawriter.podspec
@@ -1,10 +1,13 @@
 Pod::Spec.new do |s|
     s.name = "acrawriter"
-    s.version = "1.0.2"
+    s.version = "1.0.3"
     s.summary = "AcraWriter library for iOS: encrypts data into AcraStructs, allowing Acra to decrypt it"
     s.description = "Part of Acra database protection suite: developers can encrypt the sensitive data by generating AcraStructs with AcraWriter anywhere across their apps. AcraServer or AcraTranslator can be used for decryption."
     s.homepage = "https://cossacklabs.com"
-    s.source = { :git => "https://github.com/cossacklabs/acra.git", :branch => 'master'}
+    
+    # TODO: change on release :)
+    s.source = { :git => "https://github.com/cossacklabs/acra.git", :branch => 'vxtl/ios-acrawriter'}
+
     s.license = { :type => 'Apache 2.0'}    
     s.author = {'cossacklabs' => 'info@cossacklabs.com'}
     
@@ -17,14 +20,8 @@ Pod::Spec.new do |s|
 
     s.source_files = "wrappers/objc/AcraWriter/*.{h,m}"
     s.public_header_files = "wrappers/objc/AcraWriter/AcraWriter.h", "wrappers/objc/AcraWriter/AcraStruct.h"
-
-    s.ios.xcconfig = { 'OTHER_CFLAGS' => '-DLIBRESSL', 'USE_HEADERMAP' => 'NO', 
-        'HEADER_SEARCH_PATHS' => '"${PODS_ROOT}/themis/src" "${PODS_ROOT}/themis/src/wrappers/themis/Obj-C"', 'CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES' => 'YES' }
-
+    
     # Enable bitcode
     s.ios.pod_target_xcconfig = {'ENABLE_BITCODE' => 'YES' }
-        
-    s.osx.xcconfig = { 'OTHER_CFLAGS' => '-DLIBRESSL', 'USE_HEADERMAP' => 'NO', 
-        'HEADER_SEARCH_PATHS' => '"${PODS_ROOT}/themis/src" "${PODS_ROOT}/themis/src/wrappers/themis/Obj-C"', 'CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES' => 'YES' }
 
 end

--- a/acrawriter.podspec
+++ b/acrawriter.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
     s.homepage = "https://cossacklabs.com"
     
     # TODO: change on release :)
-    s.source = { :git => "https://github.com/cossacklabs/acra.git", :branch => 'vxtl/ios-acrawriter'}
+    s.source = { :git => "https://github.com/cossacklabs/acra.git", :commit => '0c366dd146521e2e8787e90813a819c72f97eb05'}
 
     s.license = { :type => 'Apache 2.0'}    
     s.author = {'cossacklabs' => 'info@cossacklabs.com'}

--- a/acrawriter.podspec
+++ b/acrawriter.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
     s.license = { :type => 'Apache 2.0'}    
     s.author = {'cossacklabs' => 'info@cossacklabs.com'}
     
-    s.dependency 'themis', '~> 0.10.0'
+    s.dependency 'themis', '~> 0.10.4'
 
     s.ios.deployment_target = '8.0'
     s.osx.deployment_target = '10.9'

--- a/acrawriter.podspec
+++ b/acrawriter.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
     s.homepage = "https://cossacklabs.com"
     
     # TODO: change on release :)
-    s.source = { :git => "https://github.com/cossacklabs/acra.git", :commit => '46c9a06289706dd0bc0910ece5be8c06200e50da'}
+    s.source = { :git => "https://github.com/cossacklabs/acra.git", :commit => 'd289875e36a4f3be61a0f307dfa19637d45cc321'}
 
     s.license = { :type => 'Apache 2.0'}    
     s.author = {'cossacklabs' => 'info@cossacklabs.com'}

--- a/acrawriter.podspec
+++ b/acrawriter.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
     s.homepage = "https://cossacklabs.com"
     
     # TODO: change on release :)
-    s.source = { :git => "https://github.com/cossacklabs/acra.git", :commit => '0c366dd146521e2e8787e90813a819c72f97eb05'}
+    s.source = { :git => "https://github.com/cossacklabs/acra.git", :commit => '46c9a06289706dd0bc0910ece5be8c06200e50da'}
 
     s.license = { :type => 'Apache 2.0'}    
     s.author = {'cossacklabs' => 'info@cossacklabs.com'}
@@ -24,4 +24,7 @@ Pod::Spec.new do |s|
     # Enable bitcode
     s.ios.pod_target_xcconfig = {'ENABLE_BITCODE' => 'YES' }
 
+    s.ios.xcconfig = { 'HEADER_SEARCH_PATHS' => '"${PODS_ROOT}/themis/src" "${PODS_ROOT}/themis/src/wrappers/themis/Obj-C"'}
+    s.osx.xcconfig = { 'HEADER_SEARCH_PATHS' => '"${PODS_ROOT}/themis/src" "${PODS_ROOT}/themis/src/wrappers/themis/Obj-C"'}
+    
 end


### PR DESCRIPTION
After Themis started to support Swift frameworks, `acrawriter.podspec` could be simplified.

1. Remove unneeded `s.ios.xcconfig` and `s.osx.xcconfig` configurations.
2. Stick with Themis 0.10.4 and above
3. Podspec source file will be re-linked after #324 merge

This PR will be updated after merging #324