### PR TITLE
Revert #324

### DIFF
--- a/wrappers/objc/AcraWriter/AcraWriter.m
+++ b/wrappers/objc/AcraWriter/AcraWriter.m
@@ -16,7 +16,7 @@
 
 #import "AcraWriter.h"
 #import "AcraStruct+Internal.h"
-#import <themis/objcthemis.h>
+#import <objcthemis/objcthemis.h>
 
 @implementation AcraWriter
 


### PR DESCRIPTION
It's something weird going on, podspec from #325 can't pass validation with new header. I believe it's connected with HEADER_SEARCH_PATH, Swift frameworks and all the magic Xcode makes out-of-the-box.

So I revert this change, and move `HEADER_SEARCH_PATH` back to the podspec.

Sorry for the mess.