### PR TITLE
export edition and version as build_info

### DIFF
--- a/cmd/acra-connector/prometheus.go
+++ b/cmd/acra-connector/prometheus.go
@@ -48,11 +48,11 @@ func registerMetrics() {
 	registerLock.Do(func() {
 		prometheus.MustRegister(connectionCounter)
 		prometheus.MustRegister(connectionProcessingTimeHistogram)
-		cmd.RegisterVersionMetrics(ServiceName)
 		version, err := utils.GetParsedVersion()
 		if err != nil {
 			panic(err)
 		}
-		cmd.ExportVersionMetric(version)
+		cmd.RegisterVersionMetrics(ServiceName, version)
+		cmd.RegisterBuildInfoMetrics(ServiceName, utils.CommunityEdition)
 	})
 }

--- a/cmd/acra-server/prometheus.go
+++ b/cmd/acra-server/prometheus.go
@@ -51,11 +51,11 @@ func registerMetrics() {
 		prometheus.MustRegister(connectionProcessingTimeHistogram)
 		base.RegisterAcraStructProcessingMetrics()
 		base.RegisterDbProcessingMetrics()
-		cmd.RegisterVersionMetrics(ServiceName)
 		version, err := utils.GetParsedVersion()
 		if err != nil {
 			panic(err)
 		}
-		cmd.ExportVersionMetric(version)
+		cmd.RegisterVersionMetrics(ServiceName, version)
+		cmd.RegisterBuildInfoMetrics(ServiceName, utils.CommunityEdition)
 	})
 }

--- a/cmd/acra-translator/prometheus.go
+++ b/cmd/acra-translator/prometheus.go
@@ -52,11 +52,11 @@ func registerMetrics() {
 		prometheus.MustRegister(connectionProcessingTimeHistogram)
 		prometheus.MustRegister(common.RequestProcessingTimeHistogram)
 		base.RegisterAcraStructProcessingMetrics()
-		cmd.RegisterVersionMetrics(ServiceName)
 		version, err := utils.GetParsedVersion()
 		if err != nil {
 			panic(err)
 		}
-		cmd.ExportVersionMetric(version)
+		cmd.RegisterVersionMetrics(ServiceName, version)
+		cmd.RegisterBuildInfoMetrics(ServiceName, utils.CommunityEdition)
 	})
 }

--- a/utils/version.go
+++ b/utils/version.go
@@ -35,6 +35,16 @@ type Version struct {
 	Patch string
 }
 
+// ProductEdition type for edition values
+type ProductEdition int
+
+const (
+	CommunityEdition = iota
+	EnterpriseEdition
+)
+
+var Edition ProductEdition = CommunityEdition
+
 // ComparisonStatus result of comparison versions
 type ComparisonStatus int
 


### PR DESCRIPTION
export `acra[server|connector|translator]_build_info` metric with two labels:
* version - with @shadinua we discussed that it will be useful too to have metric in such format and it's a convenient way to export it and used in other libraries (ex: prometheus' golang client library)
* edition[ce|ee]

plus I merged exporting static values as metrics (version major/minor/patch parts) with registering them. because they should be used only once and it unnecessary to split it to two explicit calls