### PR TITLE
remove side effect from re-using generated zones in other test modules

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -467,9 +467,6 @@ def drop_tables():
 def setUpModule():
     global zones
     global KEYS_FOLDER
-    # use list.clear instead >>> zones = []; to avoid creation new variable with new address and allow to use it from
-    # other test modules
-    zones.clear()
     clean_binaries()
     clean_misc()
     KEYS_FOLDER = tempfile.TemporaryDirectory()
@@ -515,6 +512,9 @@ def tearDownModule():
     clean_binaries()
     clean_misc()
     KEYS_FOLDER.cleanup()
+    # use list.clear instead >>> zones = []; to avoid creation new variable with new address and allow to use it from
+    # other test modules
+    zones.clear()
     clean_test_data()
     for path in [MASTER_KEY_PATH]:
         try:

--- a/tests/test.py
+++ b/tests/test.py
@@ -467,6 +467,9 @@ def drop_tables():
 def setUpModule():
     global zones
     global KEYS_FOLDER
+    # use list.clear instead >>> zones = []; to avoid creation new variable with new address and allow to use it from
+    # other test modules
+    zones.clear()
     clean_binaries()
     clean_misc()
     KEYS_FOLDER = tempfile.TemporaryDirectory()


### PR DESCRIPTION
small refactoring that allow to re-use generated zones from ACE integration tests in AEE tests.
If AEE tests will import some TestCase from ACE and `zones` global variable with pre-generated values, then `unittest` module will call `setUpModule` + `tearDownModule` for ACE tests initialization and once `setUpModule` for AEE tests that call base `setUpModule`. `zones` will contain all zones that was generated in `setUpModule` for ACE but files that store keys will be deleted in `tearDownModule`. But `zones` variable wasn't updated after deletion and AEE will try to use not-existing keys from first generation
