### PR TITLE
fetching configuration via webconfig [T1099]

### DIFF
--- a/cmd/acra-connector/acra-connector.go
+++ b/cmd/acra-connector/acra-connector.go
@@ -310,7 +310,7 @@ func main() {
 		if *acraServerEnableHTTPAPI {
 			if *acraServerHost == "" && *acraServerAPIConnectionString == "" {
 				log.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorWrongConfiguration).
-					Errorln("Configuration error: you must pass acraserver_connection_host or acra_api_connection_string parameter")
+					Errorln("Configuration error: you must pass acraserver_connection_host or acraserver_api_connection_string parameter")
 				os.Exit(1)
 			}
 			if *acraServerHost != "" {

--- a/cmd/acra-server/config.go
+++ b/cmd/acra-server/config.go
@@ -236,11 +236,9 @@ func (config *Config) GetConfigPath() string {
 func (config *Config) ToJSON() ([]byte, error) {
 	var s UIEditableConfig
 	var err error
-	s.DbHost, s.DbPort, err = network.SplitConnectionString(config.acraConnectionString)
-	if err != nil {
-		return nil, err
-	}
-	s.DbHost, s.ConnectorAPIPort, err = network.SplitConnectionString(config.acraAPIConnectionString)
+	s.DbHost = config.dbHost
+	s.DbPort = config.dbPort
+	_, s.ConnectorAPIPort, err = network.SplitConnectionString(config.acraAPIConnectionString)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
in one recent refactoring I broke fetching acraserver configuration via acra-webconfigui and @shad met this bug

AcraServer returned his host/port values that it listen instead db host/port. Now it fixed and updated tests that should catch such errors.