### PR TITLE
install correct pip and libpq-dev to build python dependencies

### DIFF
--- a/.circleci/prepare.sh
+++ b/.circleci/prepare.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 mkdir $HOME/$GOPATH_FOLDER
 
-sudo apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get -y install libssl-dev python python-setuptools python3 python3-setuptools python3-pip git rsync psmisc
+sudo apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get -y install libssl-dev libpq-dev python python-setuptools python3 python3-setuptools python3-pip git rsync psmisc
 cd $HOME
 git clone https://github.com/cossacklabs/themis
 cd themis
@@ -17,8 +17,10 @@ for version in $VERSIONS; do
     rm ${archive}
 done
 
+# https://github.com/pypa/pip/issues/5240
+python3 -m pip install --user --upgrade pip==9.0.3
 
-pip3 install -r $HOME/project/tests/requirements.txt -r $HOME/project/wrappers/python/acrawriter/test-requirements.txt
+pip3 install --user -r $HOME/project/tests/requirements.txt -r $HOME/project/wrappers/python/acrawriter/test-requirements.txt
 # install from sources because pip install git+https://github.com/mysql/mysql-connector-python not support recursive submodules
 git clone https://github.com/Lagovas/mysql-connector-python
 cd mysql-connector-python


### PR DESCRIPTION
new version pip has some conflicts and some people fix it with binding last correct pip version until it will be fixed