### PR TITLE
Fix integration tests [T1353]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,7 +184,7 @@ jobs:
       - store_artifacts:
           path: /home/user/tests_output
 
-  mysql:
+  mysql-ssl:
     docker:
     - image: cossacklabs/android-build
     # use the same credentials for mysql db as for postgresql (which support was added first)
@@ -225,7 +225,7 @@ jobs:
     - store_artifacts:
         path: /home/user/tests_output
 
-  mysql-ssl:
+  mysql:
     docker:
       - image: cossacklabs/android-build
       - image: mysql:5.7.25

--- a/.circleci/integration.sh
+++ b/.circleci/integration.sh
@@ -30,9 +30,10 @@ for version in $VERSIONS; do
     export PATH=$GOROOT/bin/:$PATH;
 
     # remove built packages with another golang version and force to rebuild
-    rm -rf $GOPATH/pkg
+    go clean -i -cache -testcache | true
+    go mod download
 
-    
+
     echo "--------------------  Testing with TEST_TLS=${TEST_TLS}"
 
     for iteration in {1..3}; do

--- a/.circleci/prepare.sh
+++ b/.circleci/prepare.sh
@@ -20,7 +20,10 @@ done
 # https://github.com/pypa/pip/issues/5240
 python3 -m pip install --user --upgrade pip==9.0.3
 
-pip3 install --user -r $HOME/project/tests/requirements.txt -r $HOME/project/wrappers/python/acrawriter/test-requirements.txt
+pip3 install --user -r $HOME/project/tests/requirements.txt 
+# run as separate command due to same dependency 'sqlalchemy' to avoid duplicated requirement and error
+# pip3 will use previously installed
+pip3 install --user -r $HOME/project/wrappers/python/acrawriter/test-requirements.txt
 # install from sources because pip install git+https://github.com/mysql/mysql-connector-python not support recursive submodules
 git clone https://github.com/Lagovas/mysql-connector-python
 cd mysql-connector-python

--- a/tests/acra-censor_configs/acra-censor_whitelist.yaml
+++ b/tests/acra-censor_configs/acra-censor_whitelist.yaml
@@ -21,6 +21,7 @@ handlers:
       - SHOW VARIABLES LIKE 'lower_case_table_names'
       - SET NAMES utf8mb4
       - show collation where `Charset` = 'utf8mb4' and `Collation` = 'utf8mb4_bin'
+      - SET NAMES latin1
       #postgres
       - BEGIN
       - "SELECT t.oid, typarray\nFROM pg_type t JOIN pg_namespace ns\n    ON typnamespace = ns.oid\nWHERE typname = 'hstore';\n"

--- a/tests/acra-censor_configs/acra-censor_whitelist.yaml
+++ b/tests/acra-censor_configs/acra-censor_whitelist.yaml
@@ -18,6 +18,9 @@ handlers:
       - SET AUTOCOMMIT = 0
       - SET NAMES 'ascii' COLLATE 'ascii_general_ci'
       - SET @@session.autocommit = OFF
+      - SHOW VARIABLES LIKE 'lower_case_table_names'
+      - SET NAMES utf8mb4
+      - show collation where `Charset` = 'utf8mb4' and `Collation` = 'utf8mb4_bin'
       #postgres
       - BEGIN
       - "SELECT t.oid, typarray\nFROM pg_type t JOIN pg_namespace ns\n    ON typnamespace = ns.oid\nWHERE typname = 'hstore';\n"

--- a/tests/acra-censor_configs/acra-censor_whitelist.yaml
+++ b/tests/acra-censor_configs/acra-censor_whitelist.yaml
@@ -22,6 +22,7 @@ handlers:
       - SET NAMES utf8mb4
       - show collation where `Charset` = 'utf8mb4' and `Collation` = 'utf8mb4_bin'
       - SET NAMES latin1
+      - SELECT @@tx_isolation
       #postgres
       - BEGIN
       - "SELECT t.oid, typarray\nFROM pg_type t JOIN pg_namespace ns\n    ON typnamespace = ns.oid\nWHERE typname = 'hstore';\n"

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,16 +1,13 @@
 pythemis
-psycopg2
-asyncpg
-sqlalchemy
+psycopg2==2.8.3
+asyncpg==0.18.3
+SQLAlchemy==1.3.9
 PyMySQL==0.8.0
 semver==2.7.9
-requests
+requests==2.22.0
 # driver with binary prepared statements support
 #mysql-connector-python==8.0.11
-# stable release now 3.13 which has vulnerability
-# https://github.com/yaml/pyyaml/issues/243
-git+https://github.com/yaml/pyyaml@release/4.2
-
+pyyaml==5.1.2
 # https://grpc.io/docs/quickstart/python.html
 grpcio==1.13.0
 grpcio-tools==1.13.0


### PR DESCRIPTION
Integration tests failed due to 2 problems:
* compilation binaries as startup
* sqlalchemy and his drivers to mysql/mariadb added new and changed old queries which they send to db before executing users query (like setup correct charset, fetch some db metadata, default transaction mode, etc) and they are not in our whitelist config which used in tests and censor drop connection with database (as it should be when he doesn't know these queries : )
When we added module support golang need more time to fetch all dependencies
Our integration test compile all needed binaries at start and then use them and has timeout 2 minutes
Now compilation with fetching dependencies sometimes takes more than 2min and raise exception.
**Solution:**
* Added fetching all dependencies before running test
* Added new queries to whitelist

P.S. was surprised when saw that failed mysql-ssl and mariadb tests. their faults should be the same but it wasn't. and I found misnaming circleci jobs : )