### PR TITLE
fix injected mode with plaintext at end of data

### DIFF
--- a/decryptor/mysql/decryptor.go
+++ b/decryptor/mysql/decryptor.go
@@ -341,7 +341,7 @@ func (decryptor *Decryptor) decryptInlineBlock(block []byte) ([]byte, error) {
 		output.Write(block[index : index+1])
 		index++
 	}
-	if len(output.Bytes()) == len(block){
+	if len(output.Bytes()) == len(block) {
 		return block, errPlainData
 	}
 	return output.Bytes(), nil

--- a/decryptor/mysql/decryptor.go
+++ b/decryptor/mysql/decryptor.go
@@ -295,7 +295,6 @@ func (decryptor *Decryptor) decryptWholeBlock(block []byte) ([]byte, error) {
 }
 
 func (decryptor *Decryptor) decryptInlineBlock(block []byte) ([]byte, error) {
-	var output bytes.Buffer
 	index := 0
 	if decryptor.IsWithZone() && !decryptor.IsMatchedZone() {
 		decryptor.MatchZoneInBlock(block)
@@ -304,12 +303,13 @@ func (decryptor *Decryptor) decryptInlineBlock(block []byte) ([]byte, error) {
 		}
 		return block, nil
 	}
-	var decrypted []byte
-	for index < len(block) {
+
+	output := bytes.NewBuffer(make([]byte, 0, len(block)))
+	for {
 		beginTagIndex, tagLength := decryptor.BeginTagIndex(block[index:])
 		if beginTagIndex == utils.NotFound {
 			output.Write(block[index:])
-			return nil, errPlainData
+			break
 		}
 		output.Write(block[index : index+beginTagIndex])
 		index += beginTagIndex
@@ -323,10 +323,10 @@ func (decryptor *Decryptor) decryptInlineBlock(block []byte) ([]byte, error) {
 				return nil, err
 			}
 		} else {
-			decrypted, err = decryptor.decryptBlock(blockReader, decryptor.GetMatchedZoneID(), privateKey)
+			decrypted, err := decryptor.decryptBlock(blockReader, decryptor.GetMatchedZoneID(), privateKey)
 			if err == nil {
 				base.AcrastructDecryptionCounter.WithLabelValues(base.DecryptionTypeSuccess).Inc()
-				index += tagLength + (len(block[beginTagIndex+tagLength:]) - blockReader.Len())
+				index += tagLength + (len(block[index+tagLength:]) - blockReader.Len())
 				output.Write(decrypted)
 				decryptor.ResetZoneMatch()
 				continue
@@ -340,6 +340,9 @@ func (decryptor *Decryptor) decryptInlineBlock(block []byte) ([]byte, error) {
 
 		output.Write(block[index : index+1])
 		index++
+	}
+	if len(output.Bytes()) == len(block){
+		return block, errPlainData
 	}
 	return output.Bytes(), nil
 }


### PR DESCRIPTION
previously when acra didn't find acrastruct signature it didn't flush remaining part of plaintext
so when acra process block of data like `<plaintext1> <acrastruct> <plaintext2>` it return `<plaintext1> <decrypted>` and drop last `<plaintext2>`
this pr fix this problem for pgsql/mysql protocols and add tests which should detect it in a future

plus I met flapping test case with prometheus metrics when connection processing on acra-translator was so fast that it didn't increase sum value... so set it to 0