### PR TITLE
fix parsing Parse packet for pgsql protocol

### DIFF
--- a/decryptor/postgresql/utils.go
+++ b/decryptor/postgresql/utils.go
@@ -111,11 +111,12 @@ func NewParsePacket(data []byte) (*ParsePacket, error) {
 	endIndex += startIndex + 1
 	query := data[startIndex:endIndex]
 	numParams := paramsNum(data[endIndex : endIndex+2])
-	endIndex++
+	endIndex+=2
 	var params []objectID
 	if endIndex < len(data) {
 		for i := 0; i < numParams.ToInt(); i++ {
 			params = append(params, data[endIndex:endIndex+4])
+			endIndex += 4
 		}
 	}
 	return &ParsePacket{

--- a/decryptor/postgresql/utils_test.go
+++ b/decryptor/postgresql/utils_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package postgresql
 
 import (
+	"bytes"
 	"encoding/hex"
 	"testing"
 )
@@ -40,5 +41,24 @@ func TestFetchQueryFromParse(t *testing.T) {
 	}
 	if string(query[:len(query)-1]) != parsePacketQuery {
 		t.Fatal("Incorrect query string")
+	}
+}
+
+func TestParseCommand(t *testing.T){
+	// copied from wireshark and java app with data which found that error
+	parseHexWithParameters := `500000009e00696e7365727420696e746f20626c6f675f656e747269657328617574686f722c20626f64792c20626f64795f68746d6c2c20686561646c696e652c2073756d6d6172792c2073756d6d6172795f68746d6c2c206964292076616c756573202824312c2024322c2024332c2024342c2024352c2024362c2024372900000700000011000000110000001100000011000000110000001100000017`
+	parseBin, err := hex.DecodeString(parseHexWithParameters)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const headerLength = 5
+	parseBin = parseBin[headerLength:]
+
+	packet, err := NewParsePacket(parseBin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(parseBin, packet.Marshal()){
+		t.Fatal("parsed and marshaled data not equal")
 	}
 }


### PR DESCRIPTION
end of Parse packet has 2 bytes for count of parameters and sequence of 4 byte parameters
our code didn't read these parameters. it's read 1 byte of param count and +3 bytes of first parameter and do it in loop *( 
it wasn't catched because these part tested only in our integration tests and drivers which we use for that doesn't describe parameters types explicitly.
I copied one example of such packet as fixture for unit test. because we don't need any generator for such packets and we pass this data as is so we can't programmatically generate such packets for tests