### PR TITLE
Fix themis dependency in the docker image

### DIFF
--- a/docker/acra-build.dockerfile
+++ b/docker/acra-build.dockerfile
@@ -32,8 +32,7 @@ WORKDIR /root
 RUN ["/bin/bash", "-c", \
     "set -o pipefail && \
     curl -sSL https://pkgs.cossacklabs.com/scripts/libthemis_install.sh | \
-        bash -s -- --yes --method source --branch $VCS_BRANCH \
-        --without-packing --without-clean"]
+        bash -s -- --yes"]
 # Install golang and set environment variables
 RUN GO_SRC_FILE="go1.13.7.linux-amd64.tar.gz" && \
     wget --no-verbose --no-check-certificate \


### PR DESCRIPTION
Earlier, we changed the prefix of paths where Themis installed when building from sources. Now it is `/usr/local/lib/` instead of `/usr/lib/`. But in the case when we build a new docker image from scratch which does not include system configuration files, libraries cannot be found.

Let's install Themis from packages into build image and always use `stable` branch regardless of the Acra branch.