### PR TITLE
Use keystore v2

### DIFF
--- a/cmd/acra-addzone/acra-addzone.go
+++ b/cmd/acra-addzone/acra-addzone.go
@@ -55,7 +55,7 @@ var (
 func main() {
 	outputDir := flag.String("keys_output_dir", keystore.DefaultKeyDirShort, "Folder where will be saved generated zone keys")
 	flag.Bool("fs_keystore_enable", true, "Use filesystem key store (deprecated, ignored)")
-	keystoreOpts := flag.String("keystore", "v1", "Key Store format to use: v1 (current), v2 (experimental)")
+	keystoreOpts := flag.String("keystore", "", "force Key Store format: v1 (current), v2 (experimental)")
 
 	logging.SetLogLevel(logging.LogVerbose)
 
@@ -75,6 +75,13 @@ func main() {
 	}
 
 	var keyStore keystore.StorageKeyCreation
+	if *keystoreOpts == "" {
+		if filesystemV2.IsKeyDirectory(output) {
+			*keystoreOpts = "v2"
+		} else {
+			*keystoreOpts = "v1"
+		}
+	}
 	switch *keystoreOpts {
 	case "v1":
 		keyStore = openKeyStoreV1(output)

--- a/cmd/acra-addzone/acra-addzone.go
+++ b/cmd/acra-addzone/acra-addzone.go
@@ -30,16 +30,19 @@ package main
 import (
 	"flag"
 	"fmt"
+	"os"
+	"path/filepath"
+
 	"github.com/cossacklabs/acra/cmd"
 	"github.com/cossacklabs/acra/keystore"
 	"github.com/cossacklabs/acra/keystore/filesystem"
+	keystoreV2 "github.com/cossacklabs/acra/keystore/v2/keystore"
+	filesystemV2 "github.com/cossacklabs/acra/keystore/v2/keystore/filesystem"
 	"github.com/cossacklabs/acra/logging"
 	"github.com/cossacklabs/acra/utils"
 	"github.com/cossacklabs/acra/zone"
 	"github.com/cossacklabs/themis/gothemis/keys"
 	log "github.com/sirupsen/logrus"
-	"os"
-	"path/filepath"
 )
 
 // Constants used by AcraAddZone util.
@@ -51,7 +54,8 @@ var (
 
 func main() {
 	outputDir := flag.String("keys_output_dir", keystore.DefaultKeyDirShort, "Folder where will be saved generated zone keys")
-	fsKeystore := flag.Bool("fs_keystore_enable", true, "Use filesystem key store")
+	flag.Bool("fs_keystore_enable", true, "Use filesystem key store (deprecated, ignored)")
+	keystoreOpts := flag.String("keystore", "v1", "Key Store format to use: v1 (current), v2 (experimental)")
 
 	logging.SetLogLevel(logging.LogVerbose)
 
@@ -69,26 +73,18 @@ func main() {
 		log.WithError(err).Errorln("Can't get absolute path for output dir")
 		os.Exit(1)
 	}
+
 	var keyStore keystore.StorageKeyCreation
-	if *fsKeystore {
-		masterKey, err := keystore.GetMasterKeyFromEnvironment()
-		if err != nil {
-			log.WithError(err).Errorln("Can't load master key")
-			os.Exit(1)
-		}
-		scellEncryptor, err := keystore.NewSCellKeyEncryptor(masterKey)
-		if err != nil {
-			log.WithError(err).Errorln("Can't init scell encryptor")
-			os.Exit(1)
-		}
-		keyStore, err = filesystem.NewFilesystemKeyStore(output, scellEncryptor)
-		if err != nil {
-			log.WithError(err).Errorln("Can't create key store")
-			os.Exit(1)
-		}
-	} else {
-		panic("No more supported keystores")
+	switch *keystoreOpts {
+	case "v1":
+		keyStore = openKeyStoreV1(output)
+	case "v2":
+		keyStore = openKeyStoreV2(output)
+	default:
+		log.Errorf("unknown keystore option: %v", *keystoreOpts)
+		os.Exit(1)
 	}
+
 	id, publicKey, err := keyStore.GenerateZoneKey()
 	if err != nil {
 		log.WithError(err).Errorln("Can't add zone")
@@ -100,4 +96,42 @@ func main() {
 		os.Exit(1)
 	}
 	fmt.Println(string(json))
+}
+
+func openKeyStoreV1(output string) keystore.StorageKeyCreation {
+	masterKey, err := keystore.GetMasterKeyFromEnvironment()
+	if err != nil {
+		log.WithError(err).Errorln("Can't load master key")
+		os.Exit(1)
+	}
+	scellEncryptor, err := keystore.NewSCellKeyEncryptor(masterKey)
+	if err != nil {
+		log.WithError(err).Errorln("Can't init scell encryptor")
+		os.Exit(1)
+	}
+	keyStore, err := filesystem.NewFilesystemKeyStore(output, scellEncryptor)
+	if err != nil {
+		log.WithError(err).Errorln("Can't init key store")
+		os.Exit(1)
+	}
+	return keyStore
+}
+
+func openKeyStoreV2(keyDirPath string) keystore.StorageKeyCreation {
+	encryption, signature, err := keystoreV2.GetMasterKeysFromEnvironment()
+	if err != nil {
+		log.WithError(err).Error("cannot read master keys from environment")
+		os.Exit(1)
+	}
+	suite, err := keystoreV2.NewSCellSuite(encryption, signature)
+	if err != nil {
+		log.WithError(err).Error("failed to initialize Secure Cell crypto suite")
+		os.Exit(1)
+	}
+	keyDir, err := filesystemV2.OpenDirectoryRW(keyDirPath, suite)
+	if err != nil {
+		log.WithError(err).WithField("path", keyDirPath).Error("cannot open key directory")
+		os.Exit(1)
+	}
+	return keystoreV2.NewServerKeyStore(keyDir)
 }

--- a/cmd/acra-authmanager/acra_authmanager.go
+++ b/cmd/acra-authmanager/acra_authmanager.go
@@ -179,7 +179,7 @@ func main() {
 	password := flag.String("password", "", "Password")
 	filePath := flag.String("file", cmd.DefaultAcraServerAuthPath, "Auth file")
 	keysDir := flag.String("keys_dir", keystore.DefaultKeyDirShort, "Folder from which will be loaded keys")
-	keystoreOpts := flag.String("keystore", "v1", "Key Store format to use: v1 (current), v2 (experimental)")
+	keystoreOpts := flag.String("keystore", "", "force Key Store format: v1 (current), v2 (experimental)")
 	debug := flag.Bool("d", false, "Turn on debug logging")
 
 	if err := cmd.Parse(defaultConfigPath, serviceName); err != nil {
@@ -197,6 +197,13 @@ func main() {
 	}
 
 	var keyStore keystore.WebConfigKeyStore
+	if *keystoreOpts == "" {
+		if filesystemV2.IsKeyDirectory(*keysDir) {
+			*keystoreOpts = "v2"
+		} else {
+			*keystoreOpts = "v1"
+		}
+	}
 	switch *keystoreOpts {
 	case "v1":
 		keyStore = openKeyStoreV1(*keysDir)

--- a/cmd/acra-authmanager/acra_authmanager.go
+++ b/cmd/acra-authmanager/acra_authmanager.go
@@ -31,6 +31,8 @@ import (
 	"github.com/cossacklabs/acra/cmd"
 	"github.com/cossacklabs/acra/keystore"
 	"github.com/cossacklabs/acra/keystore/filesystem"
+	keystoreV2 "github.com/cossacklabs/acra/keystore/v2/keystore"
+	filesystemV2 "github.com/cossacklabs/acra/keystore/v2/keystore/filesystem"
 	"github.com/cossacklabs/acra/logging"
 	"github.com/cossacklabs/acra/utils"
 	"github.com/cossacklabs/themis/gothemis/cell"
@@ -177,6 +179,7 @@ func main() {
 	password := flag.String("password", "", "Password")
 	filePath := flag.String("file", cmd.DefaultAcraServerAuthPath, "Auth file")
 	keysDir := flag.String("keys_dir", keystore.DefaultKeyDirShort, "Folder from which will be loaded keys")
+	keystoreOpts := flag.String("keystore", "v1", "Key Store format to use: v1 (current), v2 (experimental)")
 	debug := flag.Bool("d", false, "Turn on debug logging")
 
 	if err := cmd.Parse(defaultConfigPath, serviceName); err != nil {
@@ -193,20 +196,14 @@ func main() {
 		logging.SetLogLevel(logging.LogVerbose)
 	}
 
-	masterKey, err := keystore.GetMasterKeyFromEnvironment()
-	if err != nil {
-		log.WithError(err).Errorln("Can't load master key")
-		os.Exit(1)
-	}
-	encryptor, err := keystore.NewSCellKeyEncryptor(masterKey)
-	if err != nil {
-		log.WithError(err).Errorln("Can't initialize scell encryptor")
-		os.Exit(1)
-	}
 	var keyStore keystore.WebConfigKeyStore
-	keyStore, err = filesystem.NewFilesystemKeyStore(*keysDir, encryptor)
-	if err != nil {
-		log.WithError(err).Errorln("NewFilesystemKeyStore")
+	switch *keystoreOpts {
+	case "v1":
+		keyStore = openKeyStoreV1(*keysDir)
+	case "v2":
+		keyStore = openKeyStoreV2(*keysDir)
+	default:
+		log.Errorf("unknown keystore option: %v", *keystoreOpts)
 		os.Exit(1)
 	}
 
@@ -246,5 +243,42 @@ func main() {
 			os.Exit(1)
 		}
 	}
+}
 
+func openKeyStoreV1(keysDir string) keystore.WebConfigKeyStore {
+	masterKey, err := keystore.GetMasterKeyFromEnvironment()
+	if err != nil {
+		log.WithError(err).Errorln("Can't load master key")
+		os.Exit(1)
+	}
+	encryptor, err := keystore.NewSCellKeyEncryptor(masterKey)
+	if err != nil {
+		log.WithError(err).Errorln("Can't init scell encryptor")
+		os.Exit(1)
+	}
+	keyStore, err := filesystem.NewFilesystemKeyStore(keysDir, encryptor)
+	if err != nil {
+		log.WithError(err).Errorln("Can't init key store")
+		os.Exit(1)
+	}
+	return keyStore
+}
+
+func openKeyStoreV2(keyDirPath string) keystore.WebConfigKeyStore {
+	encryption, signature, err := keystoreV2.GetMasterKeysFromEnvironment()
+	if err != nil {
+		log.WithError(err).Error("cannot read master keys from environment")
+		os.Exit(1)
+	}
+	suite, err := keystoreV2.NewSCellSuite(encryption, signature)
+	if err != nil {
+		log.WithError(err).Error("failed to initialize Secure Cell crypto suite")
+		os.Exit(1)
+	}
+	keyDir, err := filesystemV2.OpenDirectoryRW(keyDirPath, suite)
+	if err != nil {
+		log.WithError(err).WithField("path", keyDirPath).Error("cannot open key directory")
+		os.Exit(1)
+	}
+	return keystoreV2.NewServerKeyStore(keyDir)
 }

--- a/cmd/acra-connector/acra-connector.go
+++ b/cmd/acra-connector/acra-connector.go
@@ -28,8 +28,6 @@ import (
 	"crypto/tls"
 	"flag"
 	"fmt"
-	log "github.com/sirupsen/logrus"
-	"go.opencensus.io/trace"
 	"io"
 	"net"
 	"os"
@@ -41,13 +39,17 @@ import (
 	"syscall"
 
 	"github.com/cossacklabs/acra/cmd"
-	"github.com/cossacklabs/acra/cmd/acra-connector/connector-mode"
+	connector_mode "github.com/cossacklabs/acra/cmd/acra-connector/connector-mode"
 	"github.com/cossacklabs/acra/keystore"
 	"github.com/cossacklabs/acra/keystore/filesystem"
+	keystoreV2 "github.com/cossacklabs/acra/keystore/v2/keystore"
+	filesystemV2 "github.com/cossacklabs/acra/keystore/v2/keystore/filesystem"
 	"github.com/cossacklabs/acra/logging"
 	"github.com/cossacklabs/acra/network"
 	"github.com/cossacklabs/acra/utils"
 	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
+	"go.opencensus.io/trace"
 )
 
 // Constants used by AcraConnector.
@@ -213,6 +215,7 @@ func main() {
 
 	loggingFormat := flag.String("logging_format", "plaintext", "Logging format: plaintext, json or CEF")
 	keysDir := flag.String("keys_dir", keystore.DefaultKeyDirShort, "Folder from which will be loaded keys")
+	keystoreOpts := flag.String("keystore", "v1", "Key Store format to use: v1 (current), v2 (experimental)")
 	clientID := flag.String("client_id", "", "Client ID")
 	acraServerHost := flag.String("acraserver_connection_host", "", "IP or domain to AcraServer daemon")
 	acraServerAPIPort := flag.Int("acraserver_api_connection_port", cmd.DefaultAcraServerAPIPort, "Port of Acra HTTP API")
@@ -329,21 +332,14 @@ func main() {
 
 	// --------- keystore  -----------
 	log.Infof("Initializing keystore...")
-	masterKey, err := keystore.GetMasterKeyFromEnvironment()
-	if err != nil {
-		log.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantLoadMasterKey).WithError(err).Errorln("Can't load master key")
-		os.Exit(1)
-	}
-	scellEncryptor, err := keystore.NewSCellKeyEncryptor(masterKey)
-	if err != nil {
-		log.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantInitPrivateKeysEncryptor).WithError(err).Errorln("Can't init scell encryptor")
-		os.Exit(1)
-	}
 	var keyStore keystore.TransportKeyStore
-	keyStore, err = filesystem.NewConnectorFileSystemKeyStore(*keysDir, []byte(*clientID), scellEncryptor, connectorMode)
-	if err != nil {
-		log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantInitKeyStore).
-			Errorln("Can't initialize keystore")
+	switch *keystoreOpts {
+	case "v1":
+		keyStore = openKeyStoreV1(*keysDir, []byte(*clientID), connectorMode)
+	case "v2":
+		keyStore = openKeyStoreV2(*keysDir, []byte(*clientID), connectorMode)
+	default:
+		log.Errorf("unknown keystore option: %v", *keystoreOpts)
 		os.Exit(1)
 	}
 	log.Infof("Keystore init OK")
@@ -507,4 +503,49 @@ func main() {
 		}
 		go handleClientConnection(config, connection)
 	}
+}
+
+func openKeyStoreV1(keysDir string, clientID []byte, connectorMode connector_mode.ConnectorMode) keystore.TransportKeyStore {
+	masterKey, err := keystore.GetMasterKeyFromEnvironment()
+	if err != nil {
+		log.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantLoadMasterKey).WithError(err).Errorln("Can't load master key")
+		os.Exit(1)
+	}
+	scellEncryptor, err := keystore.NewSCellKeyEncryptor(masterKey)
+	if err != nil {
+		log.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantInitPrivateKeysEncryptor).WithError(err).Errorln("Can't init scell encryptor")
+		os.Exit(1)
+	}
+	keyStore, err := filesystem.NewConnectorFileSystemKeyStore(keysDir, clientID, scellEncryptor, connectorMode)
+	if err != nil {
+		log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantInitKeyStore).
+			Errorln("Can't initialize keystore")
+		os.Exit(1)
+	}
+	return keyStore
+}
+
+func openKeyStoreV2(outputDir string, clientID []byte, mode connector_mode.ConnectorMode) keystore.TransportKeyStore {
+	encryption, signature, err := keystoreV2.GetMasterKeysFromEnvironment()
+	if err != nil {
+		log.WithError(err).
+			WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantLoadMasterKey).
+			Error("cannot read master keys from environment")
+		os.Exit(1)
+	}
+	suite, err := keystoreV2.NewSCellSuite(encryption, signature)
+	if err != nil {
+		log.WithError(err).
+			WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantInitPrivateKeysEncryptor).
+			Error("failed to initialize Secure Cell crypto suite")
+		os.Exit(1)
+	}
+	keyDir, err := filesystemV2.OpenDirectoryRW(outputDir, suite)
+	if err != nil {
+		log.WithError(err).
+			WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantInitKeyStore).
+			WithField("path", outputDir).Error("cannot open key directory")
+		os.Exit(1)
+	}
+	return keystoreV2.NewConnectorKeyStore(keyDir, clientID, mode)
 }

--- a/cmd/acra-connector/acra-connector.go
+++ b/cmd/acra-connector/acra-connector.go
@@ -215,7 +215,7 @@ func main() {
 
 	loggingFormat := flag.String("logging_format", "plaintext", "Logging format: plaintext, json or CEF")
 	keysDir := flag.String("keys_dir", keystore.DefaultKeyDirShort, "Folder from which will be loaded keys")
-	keystoreOpts := flag.String("keystore", "v1", "Key Store format to use: v1 (current), v2 (experimental)")
+	keystoreOpts := flag.String("keystore", "", "force Key Store format: v1 (current), v2 (experimental)")
 	clientID := flag.String("client_id", "", "Client ID")
 	acraServerHost := flag.String("acraserver_connection_host", "", "IP or domain to AcraServer daemon")
 	acraServerAPIPort := flag.Int("acraserver_api_connection_port", cmd.DefaultAcraServerAPIPort, "Port of Acra HTTP API")
@@ -333,6 +333,13 @@ func main() {
 	// --------- keystore  -----------
 	log.Infof("Initializing keystore...")
 	var keyStore keystore.TransportKeyStore
+	if *keystoreOpts == "" {
+		if filesystemV2.IsKeyDirectory(*keysDir) {
+			*keystoreOpts = "v2"
+		} else {
+			*keystoreOpts = "v1"
+		}
+	}
 	switch *keystoreOpts {
 	case "v1":
 		keyStore = openKeyStoreV1(*keysDir, []byte(*clientID), connectorMode)

--- a/cmd/acra-keymaker/acra-keymaker.go
+++ b/cmd/acra-keymaker/acra-keymaker.go
@@ -23,14 +23,17 @@ package main
 
 import (
 	"flag"
+	"io/ioutil"
+	"os"
+
 	"github.com/cossacklabs/acra/cmd"
 	"github.com/cossacklabs/acra/keystore"
 	"github.com/cossacklabs/acra/keystore/filesystem"
+	keystoreV2 "github.com/cossacklabs/acra/keystore/v2/keystore"
+	filesystemV2 "github.com/cossacklabs/acra/keystore/v2/keystore/filesystem"
 	"github.com/cossacklabs/acra/logging"
 	"github.com/cossacklabs/acra/utils"
 	log "github.com/sirupsen/logrus"
-	"io/ioutil"
-	"os"
 )
 
 // Constants used by AcraKeymaker
@@ -50,6 +53,7 @@ func main() {
 	outputDir := flag.String("keys_output_dir", keystore.DefaultKeyDirShort, "Folder where will be saved keys")
 	outputPublicKey := flag.String("keys_public_output_dir", keystore.DefaultKeyDirShort, "Folder where will be saved public key")
 	masterKey := flag.String("generate_master_key", "", "Generate new random master key and save to file")
+	keystoreOpts := flag.String("keystore", "v1", "Key Store format to use: v1 (current), v2 (experimental)")
 
 	logging.SetLogLevel(logging.LogVerbose)
 
@@ -73,28 +77,15 @@ func main() {
 		os.Exit(0)
 	}
 
-	symmetricKey, err := keystore.GetMasterKeyFromEnvironment()
-	if err != nil {
-		if err == keystore.ErrEmptyMasterKey {
-			log.Infof("You must pass master key via %v environment variable", keystore.AcraMasterKeyVarName)
-			os.Exit(1)
-		}
-		log.WithError(err).Errorln("Can't load master key")
-		os.Exit(1)
-	}
-	scellEncryptor, err := keystore.NewSCellKeyEncryptor(symmetricKey)
-	if err != nil {
-		log.WithError(err).Errorln("Can't init scell encryptor")
-		os.Exit(1)
-	}
 	var store keystore.KeyMaking
-	if *outputPublicKey != *outputDir {
-		store, err = filesystem.NewFilesystemKeyStoreTwoPath(*outputDir, *outputPublicKey, scellEncryptor)
-	} else {
-		store, err = filesystem.NewFilesystemKeyStore(*outputDir, scellEncryptor)
-	}
-	if err != nil {
-		panic(err)
+	switch *keystoreOpts {
+	case "v1":
+		store = openKeyStoreV1(*outputDir, *outputPublicKey)
+	case "v2":
+		store = openKeyStoreV2(*outputDir)
+	default:
+		log.Errorf("unknown keystore option: %v", *keystoreOpts)
+		os.Exit(1)
 	}
 
 	if *acraConnector {
@@ -148,4 +139,51 @@ func main() {
 			panic(err)
 		}
 	}
+}
+
+func openKeyStoreV1(outputDir, outputPublicKey string) keystore.KeyMaking {
+	symmetricKey, err := keystore.GetMasterKeyFromEnvironment()
+	if err != nil {
+		if err == keystore.ErrEmptyMasterKey {
+			log.Infof("You must pass master key via %v environment variable", keystore.AcraMasterKeyVarName)
+			os.Exit(1)
+		}
+		log.WithError(err).Errorln("Can't load master key")
+		os.Exit(1)
+	}
+	scellEncryptor, err := keystore.NewSCellKeyEncryptor(symmetricKey)
+	if err != nil {
+		log.WithError(err).Errorln("Can't init scell encryptor")
+		os.Exit(1)
+	}
+	var store keystore.KeyMaking
+	if outputPublicKey != outputDir {
+		store, err = filesystem.NewFilesystemKeyStoreTwoPath(outputDir, outputPublicKey, scellEncryptor)
+	} else {
+		store, err = filesystem.NewFilesystemKeyStore(outputDir, scellEncryptor)
+	}
+	if err != nil {
+		log.WithError(err).Errorln("Can't init key store")
+		os.Exit(1)
+	}
+	return store
+}
+
+func openKeyStoreV2(keyDirPath string) keystore.KeyMaking {
+	encryption, signature, err := keystoreV2.GetMasterKeysFromEnvironment()
+	if err != nil {
+		log.WithError(err).Error("cannot read master keys from environment")
+		os.Exit(1)
+	}
+	suite, err := keystoreV2.NewSCellSuite(encryption, signature)
+	if err != nil {
+		log.WithError(err).Error("failed to initialize Secure Cell crypto suite")
+		os.Exit(1)
+	}
+	keyDir, err := filesystemV2.OpenDirectoryRW(keyDirPath, suite)
+	if err != nil {
+		log.WithError(err).WithField("path", keyDirPath).Error("cannot open key directory")
+		os.Exit(1)
+	}
+	return keystoreV2.NewServerKeyStore(keyDir)
 }

--- a/cmd/acra-keymaker/acra-keymaker.go
+++ b/cmd/acra-keymaker/acra-keymaker.go
@@ -53,7 +53,7 @@ func main() {
 	outputDir := flag.String("keys_output_dir", keystore.DefaultKeyDirShort, "Folder where will be saved keys")
 	outputPublicKey := flag.String("keys_public_output_dir", keystore.DefaultKeyDirShort, "Folder where will be saved public key")
 	masterKey := flag.String("generate_master_key", "", "Generate new random master key and save to file")
-	keystoreOpts := flag.String("keystore", "v1", "Key Store format to use: v1 (current), v2 (experimental)")
+	keystoreOpts := flag.String("keystore", "", "force Key Store format: v1 (current), v2 (experimental)")
 
 	logging.SetLogLevel(logging.LogVerbose)
 
@@ -78,6 +78,15 @@ func main() {
 	}
 
 	var store keystore.KeyMaking
+	if *keystoreOpts == "" {
+		// IsKeyDirectory returns false for missing directories too.
+		// Create keystore v1 by default if it does not exist.
+		if filesystemV2.IsKeyDirectory(*outputDir) {
+			*keystoreOpts = "v2"
+		} else {
+			*keystoreOpts = "v1"
+		}
+	}
 	switch *keystoreOpts {
 	case "v1":
 		store = openKeyStoreV1(*outputDir, *outputPublicKey)

--- a/cmd/acra-poisonrecordmaker/acra-poisonrecordmaker.go
+++ b/cmd/acra-poisonrecordmaker/acra-poisonrecordmaker.go
@@ -50,7 +50,7 @@ var (
 
 func main() {
 	keysDir := flag.String("keys_dir", keystore.DefaultKeyDirShort, "Folder from which will be loaded keys")
-	keystoreOpts := flag.String("keystore", "v1", "Key Store format to use: v1 (current), v2 (experimental)")
+	keystoreOpts := flag.String("keystore", "", "force Key Store format: v1 (current), v2 (experimental)")
 	dataLength := flag.Int("data_length", poison.UseDefaultDataLength, fmt.Sprintf("Length of random data for data block in acrastruct. -1 is random in range 1..%v", poison.DefaultDataLength))
 
 	logging.SetLogLevel(logging.LogDiscard)
@@ -63,6 +63,13 @@ func main() {
 	}
 
 	var store keystore.PoisonKeyStore
+	if *keystoreOpts == "" {
+		if filesystemV2.IsKeyDirectory(*keysDir) {
+			*keystoreOpts = "v2"
+		} else {
+			*keystoreOpts = "v1"
+		}
+	}
 	switch *keystoreOpts {
 	case "v1":
 		store = openKeyStoreV1(*keysDir)

--- a/cmd/acra-rollback/acra-rollback.go
+++ b/cmd/acra-rollback/acra-rollback.go
@@ -157,7 +157,7 @@ func (ex *WriteToFileExecutor) Close() {
 
 func main() {
 	keysDir := flag.String("keys_dir", keystore.DefaultKeyDirShort, "Folder from which the keys will be loaded")
-	keystoreOpts := flag.String("keystore", "v1", "Key Store format to use: v1 (current), v2 (experimental)")
+	keystoreOpts := flag.String("keystore", "", "force Key Store format: v1 (current), v2 (experimental)")
 	clientID := flag.String("client_id", "", "Client ID should be name of file with private key")
 	connectionString := flag.String("connection_string", "", "Connection string for db")
 	sqlSelect := flag.String("select", "", "Query to fetch data for decryption")
@@ -227,6 +227,13 @@ func main() {
 	}
 
 	var keystorage keystore.DecryptionKeyStore
+	if *keystoreOpts == "" {
+		if filesystemV2.IsKeyDirectory(absKeysDir) {
+			*keystoreOpts = "v2"
+		} else {
+			*keystoreOpts = "v1"
+		}
+	}
 	switch *keystoreOpts {
 	case "v1":
 		keystorage = openKeyStoreV1(absKeysDir)

--- a/cmd/acra-rotate/acra-rotate.go
+++ b/cmd/acra-rotate/acra-rotate.go
@@ -88,7 +88,7 @@ func openKeyStoreV2(keyDirPath string) keystore.RotateStorageKeyStore {
 
 func main() {
 	keysDir := flag.String("keys_dir", keystore.DefaultKeyDirShort, "Folder from which the keys will be loaded")
-	keystoreOpts := flag.String("keystore", "v1", "Key Store format to use: v1 (current), v2 (experimental)")
+	keystoreOpts := flag.String("keystore", "", "force Key Store format: v1 (current), v2 (experimental)")
 	fileMapConfig := flag.String("file_map_config", "", "Path to file with map of <ZoneId>: <FilePaths> in json format {\"zone_id1\": [\"filepath1\", \"filepath2\"], \"zone_id2\": [\"filepath1\", \"filepath2\"]}")
 
 	sqlSelect := flag.String("sql_select", "", "Select query with ? as placeholders where last columns in result must be ClientId/ZoneId and AcraStruct. Other columns will be passed into insert/update query into placeholders")
@@ -108,6 +108,13 @@ func main() {
 	}
 
 	var keystorage keystore.RotateStorageKeyStore
+	if *keystoreOpts == "" {
+		if filesystemV2.IsKeyDirectory(*keysDir) {
+			*keystoreOpts = "v2"
+		} else {
+			*keystoreOpts = "v1"
+		}
+	}
 	switch *keystoreOpts {
 	case "v1":
 		keystorage = openKeyStoreV1(*keysDir)

--- a/cmd/acra-rotate/acra-rotate.go
+++ b/cmd/acra-rotate/acra-rotate.go
@@ -27,6 +27,8 @@ import (
 	"github.com/cossacklabs/acra/cmd"
 	"github.com/cossacklabs/acra/keystore"
 	"github.com/cossacklabs/acra/keystore/filesystem"
+	keystoreV2 "github.com/cossacklabs/acra/keystore/v2/keystore"
+	filesystemV2 "github.com/cossacklabs/acra/keystore/v2/keystore/filesystem"
 	"github.com/cossacklabs/acra/logging"
 	"github.com/cossacklabs/acra/utils"
 	_ "github.com/go-sql-driver/mysql"
@@ -41,7 +43,7 @@ var (
 	ServiceName       = "acra-rotate"
 )
 
-func initKeyStore(dirPath string) (keystore.RotateStorageKeyStore, error) {
+func openKeyStoreV1(dirPath string) keystore.RotateStorageKeyStore {
 	absKeysDir, err := filepath.Abs(dirPath)
 	if err != nil {
 		log.WithError(err).Errorln("Can't get absolute path for keys_dir")
@@ -50,18 +52,43 @@ func initKeyStore(dirPath string) (keystore.RotateStorageKeyStore, error) {
 	masterKey, err := keystore.GetMasterKeyFromEnvironment()
 	if err != nil {
 		log.WithError(err).Errorln("Can't load master key")
-		return nil, err
+		os.Exit(1)
 	}
 	scellEncryptor, err := keystore.NewSCellKeyEncryptor(masterKey)
 	if err != nil {
 		log.WithError(err).Errorln("Can't init scell encryptor")
-		return nil, err
+		os.Exit(1)
 	}
-	return filesystem.NewFilesystemKeyStore(absKeysDir, scellEncryptor)
+	keystorage, err := filesystem.NewFilesystemKeyStore(absKeysDir, scellEncryptor)
+	if err != nil {
+		log.WithError(err).Errorln("can't initialize key store")
+		os.Exit(1)
+	}
+	return keystorage
+}
+
+func openKeyStoreV2(keyDirPath string) keystore.RotateStorageKeyStore {
+	encryption, signature, err := keystoreV2.GetMasterKeysFromEnvironment()
+	if err != nil {
+		log.WithError(err).Error("cannot read master keys from environment")
+		os.Exit(1)
+	}
+	suite, err := keystoreV2.NewSCellSuite(encryption, signature)
+	if err != nil {
+		log.WithError(err).Error("failed to initialize Secure Cell crypto suite")
+		os.Exit(1)
+	}
+	keyDir, err := filesystemV2.OpenDirectoryRW(keyDirPath, suite)
+	if err != nil {
+		log.WithError(err).WithField("path", keyDirPath).Error("cannot open key directory")
+		os.Exit(1)
+	}
+	return keystoreV2.NewServerKeyStore(keyDir)
 }
 
 func main() {
 	keysDir := flag.String("keys_dir", keystore.DefaultKeyDirShort, "Folder from which the keys will be loaded")
+	keystoreOpts := flag.String("keystore", "v1", "Key Store format to use: v1 (current), v2 (experimental)")
 	fileMapConfig := flag.String("file_map_config", "", "Path to file with map of <ZoneId>: <FilePaths> in json format {\"zone_id1\": [\"filepath1\", \"filepath2\"], \"zone_id2\": [\"filepath1\", \"filepath2\"]}")
 
 	sqlSelect := flag.String("sql_select", "", "Select query with ? as placeholders where last columns in result must be ClientId/ZoneId and AcraStruct. Other columns will be passed into insert/update query into placeholders")
@@ -80,11 +107,17 @@ func main() {
 		os.Exit(1)
 	}
 
-	keystorage, err := initKeyStore(*keysDir)
-	if err != nil {
-		log.WithError(err).Errorln("Can't initialize keystore")
+	var keystorage keystore.RotateStorageKeyStore
+	switch *keystoreOpts {
+	case "v1":
+		keystorage = openKeyStoreV1(*keysDir)
+	case "v2":
+		keystorage = openKeyStoreV2(*keysDir)
+	default:
+		log.Errorf("unknown keystore option: %v", *keystoreOpts)
 		os.Exit(1)
 	}
+
 	if *dryRun {
 		log.Infoln("Rotating in dry-run mode")
 	}

--- a/cmd/acra-server/acra-server.go
+++ b/cmd/acra-server/acra-server.go
@@ -91,7 +91,7 @@ func main() {
 
 	keysDir := flag.String("keys_dir", keystore.DefaultKeyDirShort, "Folder from which will be loaded keys")
 	keysCacheSize := flag.Int("keystore_cache_size", keystore.InfiniteCacheSize, "Maximum number of keys stored in in-memory LRU cache in encrypted form. 0 - no limits, -1 - turn off cache")
-	keystoreOpts := flag.String("keystore", "v1", "Key Store format to use: v1 (current), v2 (experimental)")
+	keystoreOpts := flag.String("keystore", "", "force Key Store format: v1 (current), v2 (experimental)")
 
 	_ = flag.Bool("pgsql_hex_bytea", false, "Hex format for Postgresql bytea data (deprecated, ignored)")
 	flag.Bool("pgsql_escape_bytea", false, "Escape format for Postgresql bytea data (deprecated, ignored)")
@@ -204,6 +204,13 @@ func main() {
 
 	log.Infof("Initialising keystore...")
 	var keyStore keystore.ServerKeyStore
+	if *keystoreOpts == "" {
+		if filesystemV2.IsKeyDirectory(*keysDir) {
+			*keystoreOpts = "v2"
+		} else {
+			*keystoreOpts = "v1"
+		}
+	}
 	switch *keystoreOpts {
 	case "v1":
 		keyStore = openKeyStoreV1(*keysDir, *keysCacheSize)

--- a/cmd/acra-translator/acra-translator.go
+++ b/cmd/acra-translator/acra-translator.go
@@ -58,7 +58,7 @@ func main() {
 
 	keysDir := flag.String("keys_dir", keystore.DefaultKeyDirShort, "Folder from which will be loaded keys")
 	keysCacheSize := flag.Int("keystore_cache_size", keystore.InfiniteCacheSize, "Count of keys that will be stored in in-memory LRU cache in encrypted form. 0 - no limits, -1 - turn off cache")
-	keystoreOpts := flag.String("keystore", "v1", "Key Store format to use: v1 (current), v2 (experimental)")
+	keystoreOpts := flag.String("keystore", "", "force Key Store format: v1 (current), v2 (experimental)")
 
 	secureSessionID := flag.String("securesession_id", "acra_translator", "Id that will be sent in secure session")
 
@@ -109,6 +109,13 @@ func main() {
 
 	log.Infof("Initialising keystore...")
 	var keyStore keystore.TranslationKeyStore
+	if *keystoreOpts == "" {
+		if filesystemV2.IsKeyDirectory(*keysDir) {
+			*keystoreOpts = "v2"
+		} else {
+			*keystoreOpts = "v1"
+		}
+	}
 	switch *keystoreOpts {
 	case "v1":
 		keyStore = openKeyStoreV1(*keysDir, *keysCacheSize)

--- a/configs/acra-addzone.yaml
+++ b/configs/acra-addzone.yaml
@@ -14,6 +14,6 @@ generate_markdown_args_table: false
 # Folder where will be saved generated zone keys
 keys_output_dir: .acrakeys
 
-# Key Store format to use: v1 (current), v2 (experimental)
-keystore: v1
+# force Key Store format: v1 (current), v2 (experimental)
+keystore: 
 

--- a/configs/acra-addzone.yaml
+++ b/configs/acra-addzone.yaml
@@ -5,7 +5,7 @@ config_file:
 # dump config
 dump_config: false
 
-# Use filesystem key store
+# Use filesystem key store (deprecated, ignored)
 fs_keystore_enable: true
 
 # Generate with yaml config markdown text file with descriptions of all args
@@ -13,4 +13,7 @@ generate_markdown_args_table: false
 
 # Folder where will be saved generated zone keys
 keys_output_dir: .acrakeys
+
+# Key Store format to use: v1 (current), v2 (experimental)
+keystore: v1
 

--- a/configs/acra-authmanager.yaml
+++ b/configs/acra-authmanager.yaml
@@ -17,6 +17,9 @@ generate_markdown_args_table: false
 # Folder from which will be loaded keys
 keys_dir: .acrakeys
 
+# Key Store format to use: v1 (current), v2 (experimental)
+keystore: v1
+
 # Password
 password: 
 

--- a/configs/acra-authmanager.yaml
+++ b/configs/acra-authmanager.yaml
@@ -17,8 +17,8 @@ generate_markdown_args_table: false
 # Folder from which will be loaded keys
 keys_dir: .acrakeys
 
-# Key Store format to use: v1 (current), v2 (experimental)
-keystore: v1
+# force Key Store format: v1 (current), v2 (experimental)
+keystore: 
 
 # Password
 password: 

--- a/configs/acra-connector.yaml
+++ b/configs/acra-connector.yaml
@@ -83,6 +83,9 @@ jaeger_collector_endpoint:
 # Folder from which will be loaded keys
 keys_dir: .acrakeys
 
+# Key Store format to use: v1 (current), v2 (experimental)
+keystore: v1
+
 # Logging format: plaintext, json or CEF
 logging_format: plaintext
 

--- a/configs/acra-connector.yaml
+++ b/configs/acra-connector.yaml
@@ -83,8 +83,8 @@ jaeger_collector_endpoint:
 # Folder from which will be loaded keys
 keys_dir: .acrakeys
 
-# Key Store format to use: v1 (current), v2 (experimental)
-keystore: v1
+# force Key Store format: v1 (current), v2 (experimental)
+keystore: 
 
 # Logging format: plaintext, json or CEF
 logging_format: plaintext

--- a/configs/acra-keymaker.yaml
+++ b/configs/acra-keymaker.yaml
@@ -35,3 +35,6 @@ keys_output_dir: .acrakeys
 # Folder where will be saved public key
 keys_public_output_dir: .acrakeys
 
+# Key Store format to use: v1 (current), v2 (experimental)
+keystore: v1
+

--- a/configs/acra-keymaker.yaml
+++ b/configs/acra-keymaker.yaml
@@ -35,6 +35,6 @@ keys_output_dir: .acrakeys
 # Folder where will be saved public key
 keys_public_output_dir: .acrakeys
 
-# Key Store format to use: v1 (current), v2 (experimental)
-keystore: v1
+# force Key Store format: v1 (current), v2 (experimental)
+keystore: 
 

--- a/configs/acra-poisonrecordmaker.yaml
+++ b/configs/acra-poisonrecordmaker.yaml
@@ -14,6 +14,6 @@ generate_markdown_args_table: false
 # Folder from which will be loaded keys
 keys_dir: .acrakeys
 
-# Key Store format to use: v1 (current), v2 (experimental)
-keystore: v1
+# force Key Store format: v1 (current), v2 (experimental)
+keystore: 
 

--- a/configs/acra-poisonrecordmaker.yaml
+++ b/configs/acra-poisonrecordmaker.yaml
@@ -14,3 +14,6 @@ generate_markdown_args_table: false
 # Folder from which will be loaded keys
 keys_dir: .acrakeys
 
+# Key Store format to use: v1 (current), v2 (experimental)
+keystore: v1
+

--- a/configs/acra-rollback.yaml
+++ b/configs/acra-rollback.yaml
@@ -26,6 +26,9 @@ insert:
 # Folder from which the keys will be loaded
 keys_dir: .acrakeys
 
+# Key Store format to use: v1 (current), v2 (experimental)
+keystore: v1
+
 # Handle MySQL connections
 mysql_enable: false
 

--- a/configs/acra-rollback.yaml
+++ b/configs/acra-rollback.yaml
@@ -26,8 +26,8 @@ insert:
 # Folder from which the keys will be loaded
 keys_dir: .acrakeys
 
-# Key Store format to use: v1 (current), v2 (experimental)
-keystore: v1
+# force Key Store format: v1 (current), v2 (experimental)
+keystore: 
 
 # Handle MySQL connections
 mysql_enable: false

--- a/configs/acra-rotate.yaml
+++ b/configs/acra-rotate.yaml
@@ -20,8 +20,8 @@ generate_markdown_args_table: false
 # Folder from which the keys will be loaded
 keys_dir: .acrakeys
 
-# Key Store format to use: v1 (current), v2 (experimental)
-keystore: v1
+# force Key Store format: v1 (current), v2 (experimental)
+keystore: 
 
 # Handle MySQL connections
 mysql_enable: false

--- a/configs/acra-rotate.yaml
+++ b/configs/acra-rotate.yaml
@@ -20,6 +20,9 @@ generate_markdown_args_table: false
 # Folder from which the keys will be loaded
 keys_dir: .acrakeys
 
+# Key Store format to use: v1 (current), v2 (experimental)
+keystore: v1
+
 # Handle MySQL connections
 mysql_enable: false
 

--- a/configs/acra-server.yaml
+++ b/configs/acra-server.yaml
@@ -83,6 +83,9 @@ jaeger_collector_endpoint:
 # Folder from which will be loaded keys
 keys_dir: .acrakeys
 
+# Key Store format to use: v1 (current), v2 (experimental)
+keystore: v1
+
 # Maximum number of keys stored in in-memory LRU cache in encrypted form. 0 - no limits, -1 - turn off cache
 keystore_cache_size: 0
 

--- a/configs/acra-server.yaml
+++ b/configs/acra-server.yaml
@@ -83,8 +83,8 @@ jaeger_collector_endpoint:
 # Folder from which will be loaded keys
 keys_dir: .acrakeys
 
-# Key Store format to use: v1 (current), v2 (experimental)
-keystore: v1
+# force Key Store format: v1 (current), v2 (experimental)
+keystore: 
 
 # Maximum number of keys stored in in-memory LRU cache in encrypted form. 0 - no limits, -1 - turn off cache
 keystore_cache_size: 0

--- a/configs/acra-translator.yaml
+++ b/configs/acra-translator.yaml
@@ -38,8 +38,8 @@ jaeger_collector_endpoint:
 # Folder from which will be loaded keys
 keys_dir: .acrakeys
 
-# Key Store format to use: v1 (current), v2 (experimental)
-keystore: v1
+# force Key Store format: v1 (current), v2 (experimental)
+keystore: 
 
 # Count of keys that will be stored in in-memory LRU cache in encrypted form. 0 - no limits, -1 - turn off cache
 keystore_cache_size: 0

--- a/configs/acra-translator.yaml
+++ b/configs/acra-translator.yaml
@@ -38,6 +38,9 @@ jaeger_collector_endpoint:
 # Folder from which will be loaded keys
 keys_dir: .acrakeys
 
+# Key Store format to use: v1 (current), v2 (experimental)
+keystore: v1
+
 # Count of keys that will be stored in in-memory LRU cache in encrypted form. 0 - no limits, -1 - turn off cache
 keystore_cache_size: 0
 

--- a/keystore/v2/keystore/crypto.go
+++ b/keystore/v2/keystore/crypto.go
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020, Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package keystore
+
+import (
+	"encoding/base64"
+	"os"
+
+	keystoreV1 "github.com/cossacklabs/acra/keystore"
+	"github.com/cossacklabs/acra/keystore/v2/keystore/crypto"
+	log "github.com/sirupsen/logrus"
+)
+
+// Master key environment variable names:
+const (
+	AcraMasterEncryptionKeyVarName = "ACRA_MASTER_ENCRYPTION_KEY"
+	AcraMasterSignatureKeyVarName  = "ACRA_MASTER_SIGNATURE_KEY"
+)
+
+// GetMasterKeysFromEnvironment reads master keys from default environment variables.
+// Returns encryption key, signature key, error.
+func GetMasterKeysFromEnvironment() ([]byte, []byte, error) {
+	encryptionKey, err := getMasterKeyFromEnvironment(AcraMasterEncryptionKeyVarName)
+	if err != nil {
+		log.WithError(err).Errorf("cannot read %v", AcraMasterEncryptionKeyVarName)
+		return nil, nil, err
+	}
+	signatureKey, err := getMasterKeyFromEnvironment(AcraMasterSignatureKeyVarName)
+	if err != nil {
+		log.WithError(err).Errorf("cannot read %v", AcraMasterSignatureKeyVarName)
+		return nil, nil, err
+	}
+	return encryptionKey, signatureKey, nil
+}
+
+func getMasterKeyFromEnvironment(name string) (key []byte, err error) {
+	base64value := os.Getenv(name)
+	if len(base64value) == 0 {
+		return nil, keystoreV1.ErrEmptyMasterKey
+	}
+	key, err = base64.StdEncoding.DecodeString(base64value)
+	if err != nil {
+		return
+	}
+	err = keystoreV1.ValidateMasterKey(key)
+	if err != nil {
+		return
+	}
+	return
+}
+
+// NewSCellSuite creates default cryptography suite for KeyStore:
+// - keys are encrypted by Themis Secure Cell in Seal mode
+// - key store is signed with HMAC-SHA-256
+func NewSCellSuite(encryptionKey, signatureKey []byte) (*crypto.KeyStoreSuite, error) {
+	return crypto.NewSCellSuite(encryptionKey, signatureKey)
+}

--- a/keystore/v2/keystore/crypto.go
+++ b/keystore/v2/keystore/crypto.go
@@ -34,15 +34,19 @@ const (
 // GetMasterKeysFromEnvironment reads master keys from default environment variables.
 // Returns encryption key, signature key, error.
 func GetMasterKeysFromEnvironment() ([]byte, []byte, error) {
-	encryptionKey, err := getMasterKeyFromEnvironment(AcraMasterEncryptionKeyVarName)
-	if err != nil {
-		log.WithError(err).Errorf("cannot read %v", AcraMasterEncryptionKeyVarName)
-		return nil, nil, err
+	encryptionKey, errE := getMasterKeyFromEnvironment(AcraMasterEncryptionKeyVarName)
+	if errE != nil {
+		log.WithError(errE).Warnf("cannot read %v", AcraMasterEncryptionKeyVarName)
 	}
-	signatureKey, err := getMasterKeyFromEnvironment(AcraMasterSignatureKeyVarName)
-	if err != nil {
-		log.WithError(err).Errorf("cannot read %v", AcraMasterSignatureKeyVarName)
-		return nil, nil, err
+	signatureKey, errS := getMasterKeyFromEnvironment(AcraMasterSignatureKeyVarName)
+	if errS != nil {
+		log.WithError(errS).Warnf("cannot read %v", AcraMasterSignatureKeyVarName)
+	}
+	if errE != nil {
+		return nil, nil, errE
+	}
+	if errS != nil {
+		return nil, nil, errS
 	}
 	return encryptionKey, signatureKey, nil
 }

--- a/keystore/v2/keystore/filesystem/backend/filesystem.go
+++ b/keystore/v2/keystore/filesystem/backend/filesystem.go
@@ -197,7 +197,7 @@ func checkVersionFile(rootDir string) error {
 	return createVersionFile(rootDir)
 }
 
-func createVersionFile(rootDir string) error {
+func createVersionFile(rootDir string) (err error) {
 	path := versionFilePath(rootDir)
 	// Make sure the file does not exist and create it with proper mode.
 	file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, versionPerm)
@@ -219,8 +219,7 @@ func createVersionFile(rootDir string) error {
 	if err != nil {
 		return err
 	}
-	// Return deferred Close() error, if any
-	return err
+	return nil
 }
 
 // Close this backend instance, freeing any associated resources.

--- a/keystore/v2/keystore/filesystem/keyStore.go
+++ b/keystore/v2/keystore/filesystem/keyStore.go
@@ -61,6 +61,15 @@ func OpenDirectoryRW(rootDir string, cryptosuite *crypto.KeyStoreSuite) (api.Mut
 	return CustomKeyStore(backend, cryptosuite)
 }
 
+// IsKeyDirectory checks if the directory contains a key store.
+// This is a conservative check.
+// That is, positive return value does not mean that the directory contains *a valid* key store.
+// However, false value means that the directory definitely is not a valid key store.
+// In particular, false is returned if the directory does not exists or cannot be opened.
+func IsKeyDirectory(rootDir string) bool {
+	return backend.CheckDirectoryVersion(rootDir) == nil
+}
+
 // NewInMemory returns a new, empty in-memory key store.
 // This is mostly useful for testing.
 func NewInMemory(cryptosuite *crypto.KeyStoreSuite) (api.MutableKeyStore, error) {

--- a/keystore/v2/keystore/filesystem/keyStore_test.go
+++ b/keystore/v2/keystore/filesystem/keyStore_test.go
@@ -78,9 +78,17 @@ func TestKeyStoreOpeningDir(t *testing.T) {
 
 	rootPath := filepath.Join(testDir, "root")
 
+	if IsKeyDirectory(rootPath) {
+		t.Errorf("missing directory cannot be IsKeyDirectory()")
+	}
+
 	_, err = OpenDirectory(rootPath, testKeyStoreSuite(t))
 	if err != backendAPI.ErrNotExist {
 		t.Errorf("opened non-existant key store: %v", err)
+	}
+
+	if IsKeyDirectory(rootPath) {
+		t.Errorf("OpenDirectory() should not create key directory")
 	}
 
 	_, err = OpenDirectoryRW(rootPath, testKeyStoreSuite(t))
@@ -94,6 +102,10 @@ func TestKeyStoreOpeningDir(t *testing.T) {
 	}
 	if !fi.IsDir() {
 		t.Errorf("root key directory is not directory")
+	}
+
+	if !IsKeyDirectory(rootPath) {
+		t.Errorf("OpenDirectoryRW() must create key directory")
 	}
 
 	_, err = OpenDirectory(rootPath, testKeyStoreSuite(t))

--- a/keystore/v2/keystore/keyRingUtils.go
+++ b/keystore/v2/keystore/keyRingUtils.go
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2020, Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package keystore
+
+import (
+	"crypto/rand"
+	"time"
+
+	"github.com/cossacklabs/acra/keystore/v2/keystore/api"
+	"github.com/cossacklabs/themis/gothemis/keys"
+)
+
+const defaultKeyCryptoperiod = 365 * 24 * time.Hour // 1 year
+
+func (s *ServerKeyStore) currentKeyPair(ring api.KeyRing) (*keys.Keypair, error) {
+	current, err := ring.CurrentKey()
+	if err != nil {
+		return nil, err
+	}
+	publicKey, err := ring.PublicKey(current, api.ThemisKeyPairFormat)
+	if err != nil {
+		return nil, err
+	}
+	privateKey, err := ring.PrivateKey(current, api.ThemisKeyPairFormat)
+	if err != nil {
+		return nil, err
+	}
+	return &keys.Keypair{
+		Public:  &keys.PublicKey{Value: publicKey},
+		Private: &keys.PrivateKey{Value: privateKey},
+	}, nil
+}
+
+func (s *ServerKeyStore) currentPairPublicKey(ring api.KeyRing) (*keys.PublicKey, error) {
+	current, err := ring.CurrentKey()
+	if err != nil {
+		return nil, err
+	}
+	publicKey, err := ring.PublicKey(current, api.ThemisKeyPairFormat)
+	if err != nil {
+		return nil, err
+	}
+	return &keys.PublicKey{Value: publicKey}, nil
+}
+
+func (s *ServerKeyStore) currentPairPrivateKey(ring api.KeyRing) (*keys.PrivateKey, error) {
+	current, err := ring.CurrentKey()
+	if err != nil {
+		return nil, err
+	}
+	privateKey, err := ring.PrivateKey(current, api.ThemisKeyPairFormat)
+	if err != nil {
+		return nil, err
+	}
+	return &keys.PrivateKey{Value: privateKey}, nil
+}
+
+func (s *ServerKeyStore) newCurrentKeyPair(ring api.MutableKeyRing) (*keys.Keypair, error) {
+	pair, err := keys.New(keys.TypeEC)
+	if err != nil {
+		return nil, err
+	}
+	err = s.addCurrentKeyPair(ring, pair)
+	if err != nil {
+		return nil, err
+	}
+	return pair, nil
+}
+
+func (s *ServerKeyStore) addCurrentKeyPair(ring api.MutableKeyRing, pair *keys.Keypair) error {
+	i, err := ring.AddKey(s.describeNewKeyPair(pair))
+	if err != nil {
+		return err
+	}
+	err = ring.SetCurrent(i)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *ServerKeyStore) describeNewKeyPair(keypair *keys.Keypair) api.KeyDescription {
+	return api.KeyDescription{
+		ValidSince: time.Now(),
+		ValidUntil: time.Now().Add(defaultKeyCryptoperiod),
+		Data: []api.KeyData{
+			api.KeyData{
+				Format:     api.ThemisKeyPairFormat,
+				PublicKey:  keypair.Public.Value,
+				PrivateKey: keypair.Private.Value,
+			},
+		},
+	}
+}
+
+const symmtricKeyBytes = 32
+
+// TODO: replace with keys.NewSymetricKey() once GoThemis 0.13 is released
+func (s *ServerKeyStore) newSymmetricKey() ([]byte, error) {
+	randomBytes := make([]byte, symmtricKeyBytes)
+	_, err := rand.Read(randomBytes)
+	if err != nil {
+		return nil, err
+	}
+	return randomBytes, nil
+}
+
+func (s *ServerKeyStore) currentSymmetricKey(ring api.KeyRing) ([]byte, error) {
+	current, err := ring.CurrentKey()
+	if err != nil {
+		return nil, err
+	}
+	key, err := ring.SymmetricKey(current, api.ThemisSymmetricKeyFormat)
+	if err != nil {
+		return nil, err
+	}
+	return key, nil
+}
+
+func (s *ServerKeyStore) newCurrentSymmetricKey(ring api.MutableKeyRing) ([]byte, error) {
+	key, err := s.newSymmetricKey()
+	if err != nil {
+		return nil, err
+	}
+	i, err := ring.AddKey(s.describeNewSymmetricKey(key))
+	if err != nil {
+		return nil, err
+	}
+	err = ring.SetCurrent(i)
+	if err != nil {
+		return nil, err
+	}
+	return key, nil
+}
+
+func (s *ServerKeyStore) describeNewSymmetricKey(key []byte) api.KeyDescription {
+	return api.KeyDescription{
+		ValidSince: time.Now(),
+		ValidUntil: time.Now().Add(defaultKeyCryptoperiod),
+		Data: []api.KeyData{
+			api.KeyData{
+				Format:       api.ThemisSymmetricKeyFormat,
+				SymmetricKey: key,
+			},
+		},
+	}
+}
+
+func (s *ServerKeyStore) hasCurrentKey(ring api.KeyRing) (bool, error) {
+	_, err := ring.CurrentKey()
+	if err == api.ErrNoCurrentKey {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}

--- a/keystore/v2/keystore/poison.go
+++ b/keystore/v2/keystore/poison.go
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020, Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package keystore
+
+import (
+	"github.com/cossacklabs/acra/keystore/v2/keystore/api"
+	"github.com/cossacklabs/themis/gothemis/keys"
+)
+
+//
+// PoisonKeyStore interface
+//
+
+const poisonKeyPath = "poison-record"
+
+// GetPoisonKeyPair retrieves current poison record key pair.
+// The keypair is created if it does not exist yet.
+func (s *ServerKeyStore) GetPoisonKeyPair() (*keys.Keypair, error) {
+	ring, err := s.OpenKeyRingRW(poisonKeyPath)
+	if err != nil {
+		s.log.WithError(err).WithField("path", poisonKeyPath).
+			Debug("failed to open poison key ring")
+		return nil, err
+	}
+	keypair, err := s.currentKeyPair(ring)
+	if err == api.ErrNoCurrentKey {
+		s.log.Info("generate poison record key pair")
+		return s.newCurrentKeyPair(ring)
+	}
+	if err != nil {
+		s.log.WithError(err).Debug("failed to get current poison record key pair")
+		return nil, err
+	}
+	return keypair, nil
+}

--- a/keystore/v2/keystore/storage_client.go
+++ b/keystore/v2/keystore/storage_client.go
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2020, Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package keystore
+
+import (
+	"fmt"
+
+	"github.com/cossacklabs/themis/gothemis/keys"
+)
+
+//
+// PublicKeyStore interface (clients)
+//
+
+// GetClientIDEncryptionPublicKey retrieves public key used to encrypt data by given client.
+func (s *ServerKeyStore) GetClientIDEncryptionPublicKey(clientID []byte) (*keys.PublicKey, error) {
+	log := s.log.WithField("clientID", clientID)
+	ring, err := s.OpenKeyRing(s.clientStorageKeyPairPath(clientID))
+	if err != nil {
+		log.WithError(err).Debug("failed to open storage key ring for client")
+		return nil, err
+	}
+	publicKey, err := s.currentPairPublicKey(ring)
+	if err != nil {
+		log.WithError(err).Debug("failed to get current storage public key for client")
+		return nil, err
+	}
+	return publicKey, nil
+}
+
+//
+// PrivateKeyStore interface (clients)
+//
+
+// GetServerDecryptionPrivateKey retrieves private key used to decrypt data by given client.
+func (s *ServerKeyStore) GetServerDecryptionPrivateKey(clientID []byte) (*keys.PrivateKey, error) {
+	log := s.log.WithField("clientID", clientID)
+	ring, err := s.OpenKeyRing(s.clientStorageKeyPairPath(clientID))
+	if err != nil {
+		log.WithError(err).Debug("failed to open storage key ring for client")
+		return nil, err
+	}
+	privateKey, err := s.currentPairPrivateKey(ring)
+	if err != nil {
+		log.WithError(err).Debug("failed to get current storage private key for client")
+		return nil, err
+	}
+	return privateKey, nil
+}
+
+//
+// StorageKeyCreation interface (clients)
+//
+
+func (s *ServerKeyStore) clientStorageKeyPairPath(clientID []byte) string {
+	return fmt.Sprintf("client/%s/storage", string(clientID))
+}
+
+// GenerateDataEncryptionKeys generates new storage keypair used by given client.
+func (s *ServerKeyStore) GenerateDataEncryptionKeys(clientID []byte) error {
+	log := s.log.WithField("clientID", clientID)
+	ring, err := s.OpenKeyRingRW(s.clientStorageKeyPairPath(clientID))
+	if err != nil {
+		log.WithError(err).Debug("failed to open storage key ring for client")
+		return err
+	}
+	_, err = s.newCurrentKeyPair(ring)
+	if err != nil {
+		log.WithError(err).Debug("failed to generate storage key pair for client")
+		return err
+	}
+	return nil
+}
+
+// SaveDataEncryptionKeys overwrites storage keypair used by given client.
+func (s *ServerKeyStore) SaveDataEncryptionKeys(clientID []byte, keypair *keys.Keypair) error {
+	log := s.log.WithField("clientID", clientID)
+	ring, err := s.OpenKeyRingRW(s.clientStorageKeyPairPath(clientID))
+	if err != nil {
+		log.WithError(err).Debug("failed to open storage key ring for client")
+		return err
+	}
+	err = s.addCurrentKeyPair(ring, keypair)
+	if err != nil {
+		log.WithError(err).Debug("failed to set storage key pair for client")
+		return err
+	}
+	return nil
+}

--- a/keystore/v2/keystore/storage_zone.go
+++ b/keystore/v2/keystore/storage_zone.go
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2020, Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package keystore
+
+import (
+	"fmt"
+
+	"github.com/cossacklabs/acra/utils"
+	"github.com/cossacklabs/acra/zone"
+	"github.com/cossacklabs/themis/gothemis/keys"
+)
+
+//
+// PublicKeyStore interface (zones)
+//
+
+// GetZonePublicKey retrieves public key used to encrypt data in given zone.
+func (s *ServerKeyStore) GetZonePublicKey(zoneID []byte) (*keys.PublicKey, error) {
+	log := s.log.WithField("zoneID", zoneID)
+	ring, err := s.OpenKeyRing(s.zoneStorageKeyPairPath(zoneID))
+	if err != nil {
+		log.WithError(err).Debug("failed to open storage key ring for zone")
+		return nil, err
+	}
+	publicKey, err := s.currentPairPublicKey(ring)
+	if err != nil {
+		log.WithError(err).Debug("failed to get current storage public key for zone")
+		return nil, err
+	}
+	return publicKey, nil
+}
+
+//
+// PrivateKeyStore interface (zones)
+//
+
+// GetZonePrivateKey retrieves private key used to decrypt data in given zone.
+func (s *ServerKeyStore) GetZonePrivateKey(zoneID []byte) (*keys.PrivateKey, error) {
+	log := s.log.WithField("zoneID", zoneID)
+	ring, err := s.OpenKeyRing(s.zoneStorageKeyPairPath(zoneID))
+	if err != nil {
+		log.WithError(err).Debug("failed to open storage key ring for zone")
+		return nil, err
+	}
+	privateKey, err := s.currentPairPrivateKey(ring)
+	if err != nil {
+		log.WithError(err).Debug("failed to get current storage private key for zone")
+		return nil, err
+	}
+	return privateKey, nil
+}
+
+// HasZonePrivateKey returns true if there is a private key used to decrypt data in given zone.
+func (s *ServerKeyStore) HasZonePrivateKey(zoneID []byte) bool {
+	ring, err := s.OpenKeyRing(s.zoneStorageKeyPairPath(zoneID))
+	if err != nil {
+		return false
+	}
+	present, _ := s.hasCurrentKey(ring)
+	return present
+}
+
+//
+// StorageKeyCreation interface (zones)
+//
+
+func (s *ServerKeyStore) zoneStorageKeyPairPath(zoneID []byte) string {
+	return fmt.Sprintf("zone/%s/storage", string(zoneID))
+}
+
+// GenerateZoneKey generates new zone and a storage key for it.
+// Returns zone ID followed by public key data.
+func (s *ServerKeyStore) GenerateZoneKey() ([]byte, []byte, error) {
+	var zoneID []byte
+	for {
+		zoneID = zone.GenerateZoneID()
+		if !s.HasZonePrivateKey(zoneID) {
+			break
+		}
+	}
+	log := s.log.WithField("zoneID", zoneID)
+	ring, err := s.OpenKeyRingRW(s.zoneStorageKeyPairPath(zoneID))
+	if err != nil {
+		log.WithError(err).Debug("failed to open storage key ring for zone")
+		return nil, nil, err
+	}
+	pair, err := s.newCurrentKeyPair(ring)
+	if err != nil {
+		log.WithError(err).Debug("failed to generate storage key pair for zone")
+		return nil, nil, err
+	}
+	utils.FillSlice(0, pair.Private.Value)
+	return zoneID, pair.Public.Value, nil
+}
+
+// SaveZoneKeypair overwrites storage keypair used in given zone.
+func (s *ServerKeyStore) SaveZoneKeypair(zoneID []byte, keypair *keys.Keypair) error {
+	log := s.log.WithField("zoneID", zoneID)
+	ring, err := s.OpenKeyRingRW(s.zoneStorageKeyPairPath(zoneID))
+	if err != nil {
+		log.WithError(err).Debug("failed to open storage key ring for zone")
+		return err
+	}
+	err = s.addCurrentKeyPair(ring, keypair)
+	if err != nil {
+		log.WithError(err).Debug("failed to set storage key pair for zone")
+		return err
+	}
+	return nil
+}
+
+// RotateZoneKey generates a new storage key pair for given zone.
+// Returns new public key data.
+func (s *ServerKeyStore) RotateZoneKey(zoneID []byte) ([]byte, error) {
+	log := s.log.WithField("zoneID", zoneID)
+	ring, err := s.OpenKeyRingRW(s.zoneStorageKeyPairPath(zoneID))
+	if err != nil {
+		log.WithError(err).Debug("failed to open storage key ring for zone")
+		return nil, err
+	}
+	pair, err := s.newCurrentKeyPair(ring)
+	if err != nil {
+		log.WithError(err).Debug("failed to rotate storage key pair for zone")
+		return nil, err
+	}
+	utils.FillSlice(0, pair.Private.Value)
+	return pair.Public.Value, nil
+}

--- a/keystore/v2/keystore/transport_connector.go
+++ b/keystore/v2/keystore/transport_connector.go
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2020, Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package keystore
+
+import (
+	"fmt"
+
+	connectorMode "github.com/cossacklabs/acra/cmd/acra-connector/connector-mode"
+	"github.com/cossacklabs/themis/gothemis/keys"
+)
+
+//
+// TransportKeyStore interface (AcraConnector)
+//
+
+// GetPeerPublicKey retrieves AcraConnector transport public key, depending on AcraConnector mode:
+// - AcraServerMode: transport public key for AcraServer
+// - AcraTranslatorMode: transport public key for AcraTranslator
+// The "clientID" argument is ignored. It always uses AcraConnector's clientID.
+func (c *ConnectorKeyStore) GetPeerPublicKey([]byte) (*keys.PublicKey, error) {
+	log := c.log.WithField("clientID", c.clientID).WithField("mode", c.mode)
+	var path string
+	switch c.mode {
+	case connectorMode.AcraServerMode:
+		path = c.serverTransportKeyPairPath(c.clientID)
+	case connectorMode.AcraTranslatorMode:
+		path = c.translatorTransportKeyPairPath(c.clientID)
+	default:
+		return nil, fmt.Errorf("unsupported ConnectorMode: %v", c.mode)
+	}
+	ring, err := c.OpenKeyRing(path)
+	if err != nil {
+		log.WithError(err).Debug("failed to open connector transport key ring")
+		return nil, err
+	}
+	publicKey, err := c.currentPairPublicKey(ring)
+	if err != nil {
+		log.WithError(err).Debug("failed to get current connector transport public key")
+		return nil, err
+	}
+	return publicKey, nil
+}
+
+// GetPrivateKey retrieves AcraConnector transport private key for given clientID.
+func (c *ConnectorKeyStore) GetPrivateKey(clientID []byte) (*keys.PrivateKey, error) {
+	log := c.log.WithField("clientID", clientID)
+	ring, err := c.OpenKeyRing(c.connectorTransportKeyPairPath(clientID))
+	if err != nil {
+		log.WithError(err).Debug("failed to open connector transport key ring for client")
+		return nil, err
+	}
+	privateKey, err := c.currentPairPrivateKey(ring)
+	if err != nil {
+		log.WithError(err).Debug("failed to get current connector transport private key for client")
+		return nil, err
+	}
+	return privateKey, nil
+}
+
+// CheckIfPrivateKeyExists returns true if there is an AcraConnector transport private key for given clientID.
+func (c *ConnectorKeyStore) CheckIfPrivateKeyExists(clientID []byte) (bool, error) {
+	log := c.log.WithField("clientID", clientID)
+	ring, err := c.OpenKeyRing(c.connectorTransportKeyPairPath(clientID))
+	if err != nil {
+		log.WithError(err).Debug("failed to open connector transport key ring for client")
+		return false, err
+	}
+	return c.hasCurrentKey(ring)
+}
+
+//
+// TransportKeyCreation interface (AcraConnector)
+//
+
+func (s *ServerKeyStore) connectorTransportKeyPairPath(clientID []byte) string {
+	return fmt.Sprintf("client/%s/transport/connector", string(clientID))
+}
+
+// GenerateConnectorKeys generates new AcraConnector transport keypair for given clientID.
+func (s *ServerKeyStore) GenerateConnectorKeys(clientID []byte) error {
+	log := s.log.WithField("clientID", clientID)
+	ring, err := s.OpenKeyRingRW(s.connectorTransportKeyPairPath(clientID))
+	if err != nil {
+		log.WithError(err).Debug("failed to open connector transport key ring for client")
+		return err
+	}
+	_, err = s.newCurrentKeyPair(ring)
+	if err != nil {
+		log.WithError(err).Debug("failed to generate connector transport key pair for client")
+		return err
+	}
+	return nil
+}
+
+// SaveConnectorKeypair overwrites AcraConnector transport keypair for given clientID.
+func (s *ServerKeyStore) SaveConnectorKeypair(clientID []byte, keypair *keys.Keypair) error {
+	log := s.log.WithField("clientID", clientID)
+	ring, err := s.OpenKeyRingRW(s.connectorTransportKeyPairPath(clientID))
+	if err != nil {
+		log.WithError(err).Debug("failed to open connector transport key ring for client")
+		return err
+	}
+	err = s.addCurrentKeyPair(ring, keypair)
+	if err != nil {
+		log.WithError(err).Debug("failed to set connector transport key pair for client")
+		return err
+	}
+	return nil
+}

--- a/keystore/v2/keystore/transport_server.go
+++ b/keystore/v2/keystore/transport_server.go
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2020, Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package keystore
+
+import (
+	"fmt"
+
+	"github.com/cossacklabs/themis/gothemis/keys"
+)
+
+//
+// TransportKeyStore interface (AcraServer)
+//
+
+// GetPeerPublicKey retrieves AcraServer transport public key for given clientID.
+// This is public key corresponding to AcraConnector's private key.
+func (s *ServerKeyStore) GetPeerPublicKey(clientID []byte) (*keys.PublicKey, error) {
+	log := s.log.WithField("clientID", clientID)
+	ring, err := s.OpenKeyRing(s.connectorTransportKeyPairPath(clientID))
+	if err != nil {
+		log.WithError(err).Debug("failed to open transport key ring for client")
+		return nil, err
+	}
+	publicKey, err := s.currentPairPublicKey(ring)
+	if err != nil {
+		log.WithError(err).Debug("failed to get current transport public key for client")
+		return nil, err
+	}
+	return publicKey, nil
+}
+
+// GetPrivateKey retrieves AcraServer transport private key for given clientID.
+func (s *ServerKeyStore) GetPrivateKey(clientID []byte) (*keys.PrivateKey, error) {
+	log := s.log.WithField("clientID", clientID)
+	ring, err := s.OpenKeyRing(s.serverTransportKeyPairPath(clientID))
+	if err != nil {
+		log.WithError(err).Debug("failed to open transport key ring for client")
+		return nil, err
+	}
+	privateKey, err := s.currentPairPrivateKey(ring)
+	if err != nil {
+		log.WithError(err).Debug("failed to get current transport private key for client")
+		return nil, err
+	}
+	return privateKey, nil
+}
+
+// CheckIfPrivateKeyExists returns true if there is an AcraServer transport private key for given clientID.
+func (s *ServerKeyStore) CheckIfPrivateKeyExists(clientID []byte) (bool, error) {
+	log := s.log.WithField("clientID", clientID)
+	ring, err := s.OpenKeyRing(s.serverTransportKeyPairPath(clientID))
+	if err != nil {
+		log.WithError(err).Debug("failed to open transport key ring for client")
+		return false, err
+	}
+	return s.hasCurrentKey(ring)
+}
+
+//
+// TransportKeyCreation interface (AcraServer)
+//
+
+func (s *ServerKeyStore) serverTransportKeyPairPath(clientID []byte) string {
+	return fmt.Sprintf("client/%s/transport/server", string(clientID))
+}
+
+// GenerateServerKeys generates new AcraServer transport keypair for given clientID.
+func (s *ServerKeyStore) GenerateServerKeys(clientID []byte) error {
+	log := s.log.WithField("clientID", clientID)
+	ring, err := s.OpenKeyRingRW(s.serverTransportKeyPairPath(clientID))
+	if err != nil {
+		log.WithError(err).Debug("failed to open transport key ring for client")
+		return err
+	}
+	_, err = s.newCurrentKeyPair(ring)
+	if err != nil {
+		log.WithError(err).Debug("failed to generate transport key pair for client")
+		return err
+	}
+	return nil
+}
+
+// SaveServerKeypair overwrites AcraServer transport keypair for given clientID.
+func (s *ServerKeyStore) SaveServerKeypair(clientID []byte, keypair *keys.Keypair) error {
+	log := s.log.WithField("clientID", clientID)
+	ring, err := s.OpenKeyRingRW(s.serverTransportKeyPairPath(clientID))
+	if err != nil {
+		log.WithError(err).Debug("failed to open transport key ring for client")
+		return err
+	}
+	err = s.addCurrentKeyPair(ring, keypair)
+	if err != nil {
+		log.WithError(err).Debug("failed to set transport key pair for client")
+		return err
+	}
+	return nil
+}

--- a/keystore/v2/keystore/transport_translator.go
+++ b/keystore/v2/keystore/transport_translator.go
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2020, Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package keystore
+
+import (
+	"fmt"
+
+	"github.com/cossacklabs/themis/gothemis/keys"
+)
+
+//
+// TransportKeyStore interface (AcraTranslator)
+//
+
+// GetPeerPublicKey retrieves AcraTranslator transport public key for given clientID.
+// This is public key corresponding to AcraConnector's private key.
+func (t *TranslatorKeyStore) GetPeerPublicKey(clientID []byte) (*keys.PublicKey, error) {
+	log := t.log.WithField("clientID", clientID)
+	ring, err := t.OpenKeyRing(t.connectorTransportKeyPairPath(clientID))
+	if err != nil {
+		log.WithError(err).Debug("failed to open translator transport key ring for client")
+		return nil, err
+	}
+	publicKey, err := t.currentPairPublicKey(ring)
+	if err != nil {
+		log.WithError(err).Debug("failed to get current translator transport public key for client")
+		return nil, err
+	}
+	return publicKey, nil
+}
+
+// GetPrivateKey retrieves AcraTranslator transport private key for given clientID.
+func (t *TranslatorKeyStore) GetPrivateKey(clientID []byte) (*keys.PrivateKey, error) {
+	log := t.log.WithField("clientID", clientID)
+	ring, err := t.OpenKeyRing(t.translatorTransportKeyPairPath(clientID))
+	if err != nil {
+		log.WithError(err).Debug("failed to open translator transport key ring for client")
+		return nil, err
+	}
+	privateKey, err := t.currentPairPrivateKey(ring)
+	if err != nil {
+		log.WithError(err).Debug("failed to get current translator transport private key for client")
+		return nil, err
+	}
+	return privateKey, nil
+}
+
+// CheckIfPrivateKeyExists returns true if there is an AcraTranslator transport private key for given clientID.
+func (t *TranslatorKeyStore) CheckIfPrivateKeyExists(clientID []byte) (bool, error) {
+	log := t.log.WithField("clientID", clientID)
+	ring, err := t.OpenKeyRing(t.translatorTransportKeyPairPath(clientID))
+	if err != nil {
+		log.WithError(err).Debug("failed to open translator transport key ring for client")
+		return false, err
+	}
+	return t.hasCurrentKey(ring)
+}
+
+//
+// TransportKeyCreation interface (AcraTranslator)
+//
+
+func (s *ServerKeyStore) translatorTransportKeyPairPath(clientID []byte) string {
+	return fmt.Sprintf("client/%s/transport/translator", string(clientID))
+}
+
+// GenerateTranslatorKeys generates new AcraTranslator transport keypair for given clientID.
+func (s *ServerKeyStore) GenerateTranslatorKeys(clientID []byte) error {
+	log := s.log.WithField("clientID", clientID)
+	ring, err := s.OpenKeyRingRW(s.translatorTransportKeyPairPath(clientID))
+	if err != nil {
+		log.WithError(err).Debug("failed to open translator transport key ring for client")
+		return err
+	}
+	_, err = s.newCurrentKeyPair(ring)
+	if err != nil {
+		log.WithError(err).Debug("failed to generate translator transport key pair for client")
+		return err
+	}
+	return nil
+}
+
+// SaveTranslatorKeypair overwrites AcraTranslator transport keypair for given clientID.
+func (s *ServerKeyStore) SaveTranslatorKeypair(clientID []byte, keypair *keys.Keypair) error {
+	log := s.log.WithField("clientID", clientID)
+	ring, err := s.OpenKeyRingRW(s.translatorTransportKeyPairPath(clientID))
+	if err != nil {
+		log.WithError(err).Debug("failed to open translator transport key ring for client")
+		return err
+	}
+	err = s.addCurrentKeyPair(ring, keypair)
+	if err != nil {
+		log.WithError(err).Debug("failed to set translator transport key pair for client")
+		return err
+	}
+	return nil
+}

--- a/keystore/v2/keystore/webConfig.go
+++ b/keystore/v2/keystore/webConfig.go
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020, Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package keystore
+
+import (
+	"github.com/cossacklabs/acra/keystore/v2/keystore/api"
+)
+
+//
+// WebConfigKeyStore interface
+//
+
+const authKeyPath = "authentication"
+
+// GetAuthKey retrieves current symmetric key for Acra Web Config.
+// The key is created it if it does not exist yet, or recreated if "remove" is true.
+func (s *ServerKeyStore) GetAuthKey(remove bool) ([]byte, error) {
+	ring, err := s.OpenKeyRingRW(authKeyPath)
+	if err != nil {
+		s.log.WithError(err).WithField("path", authKeyPath).
+			Debug("failed to open authentication key ring")
+		return nil, err
+	}
+	if remove {
+		s.log.Info("new authentication key for AcraWebconfig requested")
+		return s.newCurrentSymmetricKey(ring)
+	}
+	key, err := s.currentSymmetricKey(ring)
+	if err == api.ErrNoCurrentKey {
+		s.log.Info("generate authentication key for AcraWebconfig")
+		return s.newCurrentSymmetricKey(ring)
+	}
+	if err != nil {
+		s.log.WithError(err).Debug("failed to get current authentication key")
+		return nil, err
+	}
+	return key, nil
+}


### PR DESCRIPTION
Teach all Acra CE tools to store and retrieve their keys in Key Store v2.

The tools will use Key Store v2 only when `--keystore=v2` option is passed on the command-line. By default, Key Store v1 is used. At some point in the future v2 will become the new default. You can explicitly request v1 with `--keystore=v1`.

Key Store v2 uses _two_ master keys passed via environment variables:

  - `ACRA_MASTER_ENCRYPTION_KEY` — used to encrypt private and symmetric keys
  - `ACRA_MASTER_SIGNATURE_KEY` — used to sign key ring content

`ACRA_MASTER_KEY` variable is ignored by Key Store v2.

You can use **acra-keymaker** tool to generate suitable keys, just don't forget to put them into separate files.

### Testing

I have manually tested AcraServer, AcraConnector, AcraTranslator with Key Store v2 and they appear to work fine. Further testing of other tools is pending but I guess they'll be fine too.

Since this feature is behind a feature flag, the branch may be even merged into master from this point. However, I'd like to stabilize and test it more before that.

I have tried tricking the automated integration tests to use Key Store v2 but it's not that easy. Some issues that need to be resolved before it can be tested automatically:

- We need to pass `--keystore=v2` to enable it. I've made this a command-line argument so that this experimental feature cannot be accidentally enabled by forgetting to unset some environment variables. However, it also interferes with test harness which now needs to be taught to support Key Store v2.
- A lot of testing tools expect to be able to read keys directly from the key store (see [`test/utils.py`](https://github.com/cossacklabs/acra/blob/2b88682b775e171e218088e99725d349e35df443/tests/utils.py#L107)). This isn't that simple with v2 now. I guess the best way would be to remove those hacks from Python code and provide some utility to access Key Store using the same Go code.
- It's still to be defined how broad the testing matrix should be. Should it be enough to test some cases with v1 and v2? All of them? Should we test v1—v2 integration as well?

Anyhow, automated testing of key store v2 is out of scope for this PR.

### Implementation notes

Like Key Store v1, `keystore` package exports three basic key stores:

  - `ServerKeyStore` — used almost everywhere
  - `ConnectorKeyStore` — used by AcraConnector, differs in TransportKeyStore implementation
  - `TranslatorKeyStore` — used by AcraTranslator, differs in TransportKeyStore implementation

The implementation is spread over multiple files which makes it easier to track what keys are used where. The transport key usage is particularly convoluted:

| Method           | ServerKeyStore | ConnectorKeyStore | TranslatorKeyStore |
| ---------------- | -------------- | ----------------- | ------------------ |
| GetPrivateKey    | `server`       | `connector`       | `translator`       |
| GetPeerPublicKey | `connector`    | `server`/`translator` <sup>*</sup> | `connector`  |

<sup>*</sup> Depends on the _mode_ in which AcraConnector is running.

Other key types are more or less straightforward.

Here's also the layout of key store in the filesystem:

```
.acrakeys
├── client              client-specific keys, partitioned by ID
│   ├── Alice
│   │   ├── storage.keyring     storage key pair
│   │   └── transport           transport key pairs
│   │       ├── connector.keyring
│   │       ├── translator.keyring
│   │       └── server.keyring
│   └── Bob
│       └── ...
├── zone                zone-specific keys, partitioned by ID
│   ├── AAAAAA
│   │   └── storage.keyring     storage key pair
│   └── BBBBBB
│       └── ...
├── authentication.keyring      WebConfig access symmetric key
└── poison-record.keyring       poison record key pair
```

For now, we put keys into those key rings and do not touch them after that. The keys always remain in the _pre-active_ state. The keys also have a default cryptoperiod of 365 days which is stored, but ignored. You can rotate the keys without reencrypting data by running acra-keymaker again, but the tools currently ignore historical keys and use only the current one.