### PR TITLE
acra-migrate-keys tool

### DIFF
--- a/cmd/acra-migrate-keys/acra-migrate-keys.go
+++ b/cmd/acra-migrate-keys/acra-migrate-keys.go
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2020, Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package main is entry point for Acra key migration utility (`acra-migrate-keys`).
+// It is used to convert between key store formats used by Acra.
+//
+// https://docs.cossacklabs.com/pages/documentation-acra/#key-management
+package main
+
+import (
+	"errors"
+	"flag"
+
+	"github.com/cossacklabs/acra/cmd"
+	keystoreV1 "github.com/cossacklabs/acra/keystore"
+	filesystemV1 "github.com/cossacklabs/acra/keystore/filesystem"
+	keystoreV2 "github.com/cossacklabs/acra/keystore/v2/keystore"
+	keystoreApiV2 "github.com/cossacklabs/acra/keystore/v2/keystore/api"
+	filesystemV2 "github.com/cossacklabs/acra/keystore/v2/keystore/filesystem"
+	"github.com/cossacklabs/acra/logging"
+	"github.com/cossacklabs/acra/utils"
+	log "github.com/sirupsen/logrus"
+)
+
+var (
+	defaultConfigPath = utils.GetConfigPathByName("acra-migrate-keys")
+	serviceName       = "acra-migrate-keys"
+
+	defaultSrcDir       = keystoreV1.DefaultKeyDirShort
+	defaultDstDirSuffix = ".migrated"
+)
+
+// CommandLineParams - command-line options.
+type CommandLineParams struct {
+	Src, Dst KeyStoreParams
+	Misc     MiscParams
+}
+
+// KeyStoreParams - key store parameters.
+type KeyStoreParams struct {
+	KeyStoreVersion string
+	KeyDir          string
+	KeyDirPublic    string
+}
+
+// MiscParams - miscellaneous parameters.
+type MiscParams struct {
+	DryRun bool
+	Force  bool
+
+	LogDebug   bool
+	LogVerbose bool
+}
+
+// OpenMode - whether key store is source or destination.
+type OpenMode int
+
+// OpenMode constant values:
+const (
+	OpenSrc OpenMode = iota
+	OpenDst
+)
+
+// RegisterCommandLineParams registers command-line options for parsing.
+func RegisterCommandLineParams() *CommandLineParams {
+	params := &CommandLineParams{}
+	// Source key store
+	flag.StringVar(&params.Src.KeyStoreVersion, "src_keystore", "v1", "key store format to use: v1 (current), v2 (experimental)")
+	flag.StringVar(&params.Src.KeyDir, "src_keys_dir", defaultSrcDir, "path to source key directory")
+	flag.StringVar(&params.Src.KeyDirPublic, "src_keys_dir_public", defaultSrcDir, "path to source key directory for public keys")
+	// Destination key store
+	flag.StringVar(&params.Dst.KeyStoreVersion, "dst_keystore", "v2", "key store format to use: v1 (current), v2 (experimental)")
+	flag.StringVar(&params.Dst.KeyDir, "dst_keys_dir", "", "path to destination key directory (default \".acrakeys.migrated\")")
+	flag.StringVar(&params.Dst.KeyDirPublic, "dst_keys_dir_public", "", "path to destination key directory for public keys (default \".acrakeys.migrated\")")
+	// Miscellaneous
+	flag.BoolVar(&params.Misc.DryRun, "dry_run", false, "try migration without writing to the output key store")
+	flag.BoolVar(&params.Misc.Force, "force", false, "write to output key store even if it exists")
+	flag.BoolVar(&params.Misc.LogDebug, "d", false, "log debug messages to stderr")
+	flag.BoolVar(&params.Misc.LogVerbose, "v", false, "log everything to stderr")
+	return params
+}
+
+// SetDefaults initializes default paramater values.
+func (params *CommandLineParams) SetDefaults() {
+	if params.Misc.LogDebug {
+		log.SetLevel(log.DebugLevel)
+	}
+	if params.Misc.LogVerbose {
+		log.SetLevel(log.TraceLevel)
+	}
+
+	if params.Dst.KeyDir == "" {
+		params.Dst.KeyDir = params.Src.KeyDir + defaultDstDirSuffix
+	}
+	if params.Dst.KeyDirPublic == "" {
+		params.Dst.KeyDirPublic = params.Src.KeyDirPublic + defaultDstDirSuffix
+	}
+}
+
+func main() {
+	params := RegisterCommandLineParams()
+	err := cmd.Parse(defaultConfigPath, serviceName)
+	if err != nil {
+		log.WithError(err).
+			WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantReadServiceConfig).
+			Fatal("Cannot parse arguments")
+	}
+	params.SetDefaults()
+
+	if params.Src.KeyStoreVersion == "v1" && params.Dst.KeyStoreVersion == "v2" {
+		keyStoreV1, err := OpenKeyStoreV1(OpenSrc, params.Src, params.Misc)
+		if err != nil {
+			log.WithError(err).Fatal("Failed to open keystore v1 (src)")
+		}
+		keyStoreV2, err := OpenKeyStoreV2(OpenDst, params.Dst, params.Misc)
+		if err != nil {
+			log.WithError(err).Fatal("Failed to open keystore v2 (dst)")
+		}
+		err = MigrateV1toV2(keyStoreV1, keyStoreV2, params.Misc)
+		if err != nil {
+			log.WithError(err).Fatal("Migration failed")
+		}
+		log.Infof("Migration complete")
+		log.Infof("Old key store: %s", params.Src.KeyDir)
+		log.Infof("New key store: %s", params.Dst.KeyDir)
+		if params.Misc.DryRun {
+			log.Infof("Run without --dry_run to actually write key data")
+		}
+		return
+	}
+
+	log.WithFields(log.Fields{"src": params.Src.KeyStoreVersion, "dst": params.Dst.KeyStoreVersion}).
+		Fatal("Key store conversion not supported")
+}
+
+// MigrateV1toV2 transfers keys from key store v1 to v2.
+func MigrateV1toV2(srcV1 filesystemV1.KeyExport, dstV2 keystoreV2.KeyFileImportV1, params MiscParams) error {
+	log.Trace("Enumerating keys for export")
+	keys, err := srcV1.EnumerateExportedKeys()
+	if err != nil {
+		log.WithError(err).Debug("Failed to enumerate exported keys")
+		return err
+	}
+	log.Trace("Key enumeration complete")
+
+	// We are going to import multiple keys. Some of them may not be successful.
+	// Since we cannot rollback partial import, go on with processing remaining
+	// keys on error. However, make sure that the operation as a whole fails if
+	// not all keys have been imported successfully.
+	actual := 0
+	expected := len(keys)
+
+	log.Tracef("Importing %d keys from keystore v1", expected)
+	for _, key := range keys {
+		log := log.WithField("purpose", key.Purpose).WithField("id", key.ID)
+		err := dstV2.ImportKeyFileV1(srcV1, key)
+		if err != nil {
+			log.WithError(err).Warn("Failed to import key")
+			continue
+		}
+		actual++
+	}
+	log.Tracef("Imported %d/%d keys from keystore v1", actual, expected)
+
+	if actual != expected {
+		return errors.New("Incomplete key import")
+	}
+
+	return nil
+}
+
+// OpenKeyStoreV1 opens key store v1 for given purpose.
+func OpenKeyStoreV1(mode OpenMode, store KeyStoreParams, params MiscParams) (*filesystemV1.KeyStore, error) {
+	masterKey, err := keystoreV1.GetMasterKeyFromEnvironment()
+	if err != nil {
+		log.WithError(err).Error("Cannot load master key")
+		return nil, err
+	}
+	encryptor, err := keystoreV1.NewSCellKeyEncryptor(masterKey)
+	if err != nil {
+		log.WithError(err).Error("Cannot init Secure Cell encryptor")
+		return nil, err
+	}
+	var keyStore *filesystemV1.KeyStore
+	if store.KeyDir != store.KeyDirPublic {
+		keyStore, err = filesystemV1.NewFilesystemKeyStoreTwoPath(store.KeyDir, store.KeyDirPublic, encryptor)
+	} else {
+		keyStore, err = filesystemV1.NewFilesystemKeyStore(store.KeyDir, encryptor)
+	}
+	if err != nil {
+		log.WithError(err).Error("Cannot init key store")
+		return nil, err
+	}
+	return keyStore, nil
+}
+
+// OpenKeyStoreV2 opens key store v2 for given purpose.
+func OpenKeyStoreV2(mode OpenMode, store KeyStoreParams, params MiscParams) (*keystoreV2.ServerKeyStore, error) {
+	encryption, signature, err := keystoreV2.GetMasterKeysFromEnvironment()
+	if err != nil {
+		log.WithError(err).Error("Cannot read master keys from environment")
+		return nil, err
+	}
+	suite, err := keystoreV2.NewSCellSuite(encryption, signature)
+	if err != nil {
+		log.WithError(err).Error("Failed to initialize Secure Cell crypto suite")
+		return nil, err
+	}
+	path := store.KeyDir
+	if mode == OpenDst {
+		if filesystemV2.IsKeyDirectory(path) && !params.Force {
+			log.WithField("path", path).Error("Key directory already exists")
+			log.Info("Run with --force to import into existing directory")
+			return nil, errors.New("destination exists")
+		}
+	}
+	var keyDir keystoreApiV2.MutableKeyStore
+	if mode == OpenDst && params.DryRun {
+		keyDir, err = filesystemV2.NewInMemory(suite)
+		if err != nil {
+			log.WithError(err).Error("Cannot create in-memory key store")
+			return nil, err
+		}
+	} else {
+		keyDir, err = filesystemV2.OpenDirectoryRW(path, suite)
+		if err != nil {
+			log.WithError(err).WithField("path", path).Error("Cannot open key directory")
+			return nil, err
+		}
+	}
+	return keystoreV2.NewServerKeyStore(keyDir), nil
+}

--- a/configs/acra-migrate-keys.yaml
+++ b/configs/acra-migrate-keys.yaml
@@ -1,0 +1,40 @@
+version: 0.85.0
+# path to config
+config_file: 
+
+# log debug messages to stderr
+d: false
+
+# try migration without writing to the output key store
+dry_run: false
+
+# path to destination key directory (default ".acrakeys.migrated")
+dst_keys_dir: 
+
+# path to destination key directory for public keys (default ".acrakeys.migrated")
+dst_keys_dir_public: 
+
+# key store format to use: v1 (current), v2 (experimental)
+dst_keystore: v2
+
+# dump config
+dump_config: false
+
+# write to output key store even if it exists
+force: false
+
+# Generate with yaml config markdown text file with descriptions of all args
+generate_markdown_args_table: false
+
+# path to source key directory
+src_keys_dir: .acrakeys
+
+# path to source key directory for public keys
+src_keys_dir_public: .acrakeys
+
+# key store format to use: v1 (current), v2 (experimental)
+src_keystore: v1
+
+# log everything to stderr
+v: false
+

--- a/configs/regenerate.sh
+++ b/configs/regenerate.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-binaries=(server connector translator addzone webconfig rollback keymaker poisonrecordmaker authmanager rotate)
+binaries=(server connector translator addzone webconfig rollback keymaker migrate-keys poisonrecordmaker authmanager rotate)
 
 args="--dump_config"
 

--- a/keystore/filesystem/filenames.go
+++ b/keystore/filesystem/filenames.go
@@ -22,8 +22,9 @@ import (
 
 // Default key folders' filenames
 const (
-	PoisonKeyFilename    = ".poison_key/poison_key"
-	BasicAuthKeyFilename = "auth_key"
+	PoisonKeyFilename       = ".poison_key/poison_key"
+	poisonKeyFilenamePublic = ".poison_key/poison_key.pub"
+	BasicAuthKeyFilename    = "auth_key"
 )
 
 // getZoneKeyFilename

--- a/keystore/filesystem/key_export.go
+++ b/keystore/filesystem/key_export.go
@@ -1,0 +1,323 @@
+/*
+ * Copyright 2020, Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package filesystem
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+
+	"github.com/cossacklabs/acra/utils"
+	"github.com/cossacklabs/themis/gothemis/keys"
+)
+
+// KeyExport allows to export plaintext key material by generic key description rather than specific purpose.
+type KeyExport interface {
+	EnumerateExportedKeys() ([]ExportedKey, error)
+	EnumerateExportedKeysByClass(classifier KeyFileClassifier) ([]ExportedKey, error)
+
+	ExportPublicKey(key ExportedKey) (*keys.PublicKey, error)
+	ExportPrivateKey(key ExportedKey) (*keys.PrivateKey, error)
+	ExportKeyPair(key ExportedKey) (*keys.Keypair, error)
+	ExportSymmetricKey(key ExportedKey) ([]byte, error)
+	ExportPlaintextSymmetricKey(key ExportedKey) ([]byte, error)
+}
+
+// KeyFileClassifier defines how to export keys stored in files.
+// It divines the purpose of the key by its path.
+// Return nil if the path should not be exported (e.g., if it's not a key).
+type KeyFileClassifier interface {
+	ClassifyExportedKey(path string) *ExportedKey
+}
+
+// ExportedKey describes a key that can be exported from key store.
+//
+// `Purpose` describes the purpose of this key.
+// This is one of the `Purpose...` constants exported by this module.
+//
+// `ID` is either client ID, or zone ID, or nil depending on the purpose.
+//
+// `*Path` fields will be empty when not applicable.
+// For example, symmetric keys will not have public or private parts,
+// and only public or private key of a key pair may be present.
+type ExportedKey struct {
+	Purpose string
+	ID      []byte
+
+	PublicPath    string
+	PrivatePath   string
+	SymmetricPath string
+}
+
+// Exported key purpose constants:
+const (
+	PurposeAuthenticationSymKey       = "auth_key"
+	PurposePoisonRecordKeyPair        = "poison_key"
+	PurposeStorageClientKeyPair       = "storage"
+	PurposeStorageZoneKeyPair         = "zone"
+	PurposeTransportConnectorKeyPair  = "connector"
+	PurposeTransportTranslatorKeyPair = "translator"
+	PurposeTransportServerKeyPair     = "server"
+)
+
+// ExportPublicKey loads a public key for export.
+func (store *KeyStore) ExportPublicKey(key ExportedKey) (*keys.PublicKey, error) {
+	if key.PublicPath == "" {
+		return nil, nil
+	}
+	// This is getPublicKeyByFilename() but without cache thrashing.
+	return utils.LoadPublicKey(key.PublicPath)
+}
+
+// ExportPrivateKey loads a private key for export.
+func (store *KeyStore) ExportPrivateKey(key ExportedKey) (*keys.PrivateKey, error) {
+	if key.PrivatePath == "" {
+		return nil, nil
+	}
+	// This is getPrivateKeyByFilename() but without cache thrashing.
+	privateKey, err := utils.LoadPrivateKey(key.PrivatePath)
+	if err != nil {
+		return nil, err
+	}
+	decryptedKey, err := store.encryptor.Decrypt(privateKey.Value, key.ID)
+	if err != nil {
+		return nil, err
+	}
+	privateKey.Value = decryptedKey
+	return privateKey, nil
+}
+
+// ExportKeyPair loads a key pair for export.
+func (store *KeyStore) ExportKeyPair(key ExportedKey) (*keys.Keypair, error) {
+	publicKey, err := store.ExportPublicKey(key)
+	if err != nil {
+		return nil, err
+	}
+	privateKey, err := store.ExportPrivateKey(key)
+	if err != nil {
+		return nil, err
+	}
+	return &keys.Keypair{Public: publicKey, Private: privateKey}, nil
+}
+
+// ExportSymmetricKey loads a symmetric key for export.
+func (store *KeyStore) ExportSymmetricKey(key ExportedKey) ([]byte, error) {
+	if key.SymmetricPath == "" {
+		return nil, nil
+	}
+	encrypted, err := utils.ReadFile(key.SymmetricPath)
+	if err != nil {
+		return nil, err
+	}
+	keyValue, err := store.encryptor.Decrypt(encrypted, key.ID)
+	if err != nil {
+		return nil, err
+	}
+	return keyValue, nil
+}
+
+// ExportPlaintextSymmetricKey loads an unencrypted symmetric key for export.
+func (store *KeyStore) ExportPlaintextSymmetricKey(key ExportedKey) ([]byte, error) {
+	if key.SymmetricPath == "" {
+		return nil, nil
+	}
+	return utils.ReadFile(key.SymmetricPath)
+}
+
+// DefaultKeyFileClassifier is a KeyFileClassifier for standard key types.
+type DefaultKeyFileClassifier struct{}
+
+// EnumerateExportedKeys prepares a list of keys that can be exported.
+// The keys are classified with default key file classifier.
+func (store *KeyStore) EnumerateExportedKeys() ([]ExportedKey, error) {
+	return store.EnumerateExportedKeysByClass(&DefaultKeyFileClassifier{})
+}
+
+// EnumerateExportedKeysByClass prepares a list of keys that can be exported.
+// The keys are classified with the provided classifier.
+func (store *KeyStore) EnumerateExportedKeysByClass(classifier KeyFileClassifier) ([]ExportedKey, error) {
+	keyPaths, err := store.enumerateKeyFiles()
+	if err != nil {
+		return nil, err
+	}
+
+	keyMap := make(map[string]*ExportedKey)
+	for _, path := range keyPaths {
+		if key := classifier.ClassifyExportedKey(path); key != nil {
+			id := key.fusedID()
+			keyInMap, exists := keyMap[id]
+			if exists {
+				keyInMap.addPathFrom(key)
+			} else {
+				keyMap[id] = key
+			}
+		}
+	}
+
+	exportedKeys := make([]ExportedKey, 0, len(keyMap))
+	for _, key := range keyMap {
+		exportedKeys = append(exportedKeys, *key)
+	}
+	return exportedKeys, nil
+}
+
+func (store *KeyStore) enumerateKeyFiles() ([]string, error) {
+	paths := make([]string, 0)
+
+	directories := []string{store.privateKeyDirectory}
+	if store.publicKeyDirectory != store.privateKeyDirectory {
+		directories = append(directories, store.publicKeyDirectory)
+	}
+	for i := 0; i < len(directories); i++ {
+		files, err := ioutil.ReadDir(directories[i])
+		if err != nil {
+			return nil, err
+		}
+		for _, file := range files {
+			path := filepath.Join(directories[i], file.Name())
+			if file.IsDir() {
+				directories = append(directories, path)
+			} else {
+				paths = append(paths, path)
+			}
+		}
+	}
+
+	return paths, nil
+}
+
+// Private and public keys may be stored in two separate directories. We need
+// to walk both of them but avoid duplicating ExportedKey entries: key pairs
+// must stay as single objects.
+//
+// We temporarily store ExportedKeys in a map so that we can keep track of
+// the keys that we have already seen. Since Go does not allow []byte as
+// map keys, we have to get a bit creative.
+
+func (key *ExportedKey) fusedID() string {
+	return key.Purpose + string(key.ID)
+}
+
+func (key *ExportedKey) addPathFrom(other *ExportedKey) {
+	if other.PublicPath != "" {
+		key.PublicPath = other.PublicPath
+	}
+	if other.PrivatePath != "" {
+		key.PrivatePath = other.PrivatePath
+	}
+	if other.SymmetricPath != "" {
+		key.SymmetricPath = other.SymmetricPath
+	}
+}
+
+// NewExportedSymmetricKey makes an ExportedKey for an unencrypted symmetric key file.
+func NewExportedSymmetricKey(symmetricPath string, context []byte, purpose string) *ExportedKey {
+	return &ExportedKey{
+		Purpose:       purpose,
+		ID:            context,
+		SymmetricPath: symmetricPath,
+	}
+}
+
+// NewExportedPlaintextSymmetricKey makes an ExportedKey for an unencrypted symmetric key file.
+func NewExportedPlaintextSymmetricKey(symmetricPath string, purpose string) *ExportedKey {
+	return &ExportedKey{
+		Purpose:       purpose,
+		SymmetricPath: symmetricPath,
+	}
+}
+
+// NewExportedPublicKey makes an ExportedKey for a public key file.
+func NewExportedPublicKey(publicPath string, id []byte, purpose string) *ExportedKey {
+	return &ExportedKey{
+		Purpose:    purpose,
+		ID:         id,
+		PublicPath: publicPath,
+	}
+}
+
+// NewExportedPrivateKey makes an ExportedKey for a private key file.
+func NewExportedPrivateKey(privatePath string, id []byte, purpose string) *ExportedKey {
+	return &ExportedKey{
+		Purpose:     purpose,
+		ID:          id,
+		PrivatePath: privatePath,
+	}
+}
+
+// ClassifyExportedKey tells how a key at given path should be exported.
+func (*DefaultKeyFileClassifier) ClassifyExportedKey(path string) *ExportedKey {
+	if strings.HasSuffix(path, BasicAuthKeyFilename) {
+		return NewExportedPlaintextSymmetricKey(path, PurposeAuthenticationSymKey)
+	}
+
+	// Poison key pairs use PoisonKeyFilename as context for encryption.
+	if strings.HasSuffix(path, poisonKeyFilenamePublic) {
+		id := []byte(PoisonKeyFilename)
+		return NewExportedPublicKey(path, id, PurposePoisonRecordKeyPair)
+	}
+	if strings.HasSuffix(path, PoisonKeyFilename) {
+		id := []byte(PoisonKeyFilename)
+		return NewExportedPrivateKey(path, id, PurposePoisonRecordKeyPair)
+	}
+
+	filename := filepath.Base(path)
+
+	if strings.HasSuffix(filename, "_storage.pub") {
+		id := []byte(strings.TrimSuffix(filename, "_storage.pub"))
+		return NewExportedPublicKey(path, id, PurposeStorageClientKeyPair)
+	}
+	if strings.HasSuffix(filename, "_storage") {
+		id := []byte(strings.TrimSuffix(filename, "_storage"))
+		return NewExportedPrivateKey(path, id, PurposeStorageClientKeyPair)
+	}
+
+	if strings.HasSuffix(filename, "_zone.pub") {
+		id := []byte(strings.TrimSuffix(filename, "_zone.pub"))
+		return NewExportedPublicKey(path, id, PurposeStorageZoneKeyPair)
+	}
+	if strings.HasSuffix(filename, "_zone") {
+		id := []byte(strings.TrimSuffix(filename, "_zone"))
+		return NewExportedPrivateKey(path, id, PurposeStorageZoneKeyPair)
+	}
+
+	if strings.HasSuffix(filename, "_server.pub") {
+		id := []byte(strings.TrimSuffix(filename, "_server.pub"))
+		return NewExportedPublicKey(path, id, PurposeTransportServerKeyPair)
+	}
+	if strings.HasSuffix(filename, "_server") {
+		id := []byte(strings.TrimSuffix(filename, "_server"))
+		return NewExportedPrivateKey(path, id, PurposeTransportServerKeyPair)
+	}
+
+	if strings.HasSuffix(filename, "_translator.pub") {
+		id := []byte(strings.TrimSuffix(filename, "_translator.pub"))
+		return NewExportedPublicKey(path, id, PurposeTransportTranslatorKeyPair)
+	}
+	if strings.HasSuffix(filename, "_translator") {
+		id := []byte(strings.TrimSuffix(filename, "_translator"))
+		return NewExportedPrivateKey(path, id, PurposeTransportTranslatorKeyPair)
+	}
+
+	// Connector key pairs are an edge case, test for them last.
+	if strings.HasSuffix(filename, ".pub") {
+		id := []byte(strings.TrimSuffix(filename, ".pub"))
+		return NewExportedPublicKey(path, id, PurposeTransportConnectorKeyPair)
+	}
+	id := []byte(filename)
+	return NewExportedPrivateKey(path, id, PurposeTransportConnectorKeyPair)
+}

--- a/keystore/filesystem/key_export.go
+++ b/keystore/filesystem/key_export.go
@@ -141,10 +141,12 @@ func (store *KeyStore) ExportPlaintextSymmetricKey(key ExportedKey) ([]byte, err
 // DefaultKeyFileClassifier is a KeyFileClassifier for standard key types.
 type DefaultKeyFileClassifier struct{}
 
+var defaultClassifier = &DefaultKeyFileClassifier{}
+
 // EnumerateExportedKeys prepares a list of keys that can be exported.
 // The keys are classified with default key file classifier.
 func (store *KeyStore) EnumerateExportedKeys() ([]ExportedKey, error) {
-	return store.EnumerateExportedKeysByClass(&DefaultKeyFileClassifier{})
+	return store.EnumerateExportedKeysByClass(defaultClassifier)
 }
 
 // EnumerateExportedKeysByClass prepares a list of keys that can be exported.

--- a/keystore/filesystem/server_keystore.go
+++ b/keystore/filesystem/server_keystore.go
@@ -404,7 +404,7 @@ func (store *KeyStore) Reset() {
 // Returns keypair or error if generation/decryption failed.
 func (store *KeyStore) GetPoisonKeyPair() (*keys.Keypair, error) {
 	privatePath := store.GetPrivateKeyFilePath(PoisonKeyFilename)
-	publicPath := store.GetPublicKeyFilePath(fmt.Sprintf("%s.pub", PoisonKeyFilename))
+	publicPath := store.GetPublicKeyFilePath(poisonKeyFilenamePublic)
 	privateExists, err := utils.FileExists(privatePath)
 	if err != nil {
 		return nil, err

--- a/keystore/v2/keystore/importV1.go
+++ b/keystore/v2/keystore/importV1.go
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2020, Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package keystore
+
+import (
+	"errors"
+
+	filesystemV1 "github.com/cossacklabs/acra/keystore/filesystem"
+	"github.com/cossacklabs/acra/utils"
+	"github.com/cossacklabs/themis/gothemis/keys"
+)
+
+// Errors returned by key import:
+var (
+	ErrUnknownPurpose = errors.New("unknown key purpose")
+)
+
+// KeyFileImportV1 defines how filesystem key store v1 keys are imported.
+type KeyFileImportV1 interface {
+	ImportKeyFileV1(oldKeyStore filesystemV1.KeyExport, key filesystemV1.ExportedKey) error
+}
+
+// ImportKeyFileV1 transfers key data from keystore version 1.
+func (s *ServerKeyStore) ImportKeyFileV1(oldKeyStore filesystemV1.KeyExport, key filesystemV1.ExportedKey) error {
+	log := s.log.WithField("purpose", key.Purpose).WithField("id", key.ID)
+	switch key.Purpose {
+	case filesystemV1.PurposeAuthenticationSymKey:
+		symkey, err := oldKeyStore.ExportPlaintextSymmetricKey(key)
+		if err != nil {
+			log.WithError(err).Debug("failed to export authentication key")
+			return err
+		}
+		defer zeroizeSymmetricKey(symkey)
+		err = s.saveAuthKey(symkey)
+		if err != nil {
+			log.WithError(err).Debug("failed to import authentication key")
+			return err
+		}
+	case filesystemV1.PurposePoisonRecordKeyPair:
+		keypair, err := oldKeyStore.ExportKeyPair(key)
+		if err != nil {
+			log.WithError(err).Debug("failed to export poison record key pair")
+			return err
+		}
+		defer zeroizeKeyPair(keypair)
+		err = s.savePoisonKeyPair(keypair)
+		if err != nil {
+			log.WithError(err).Debug("failed to import poison record key pair")
+			return err
+		}
+	case filesystemV1.PurposeStorageClientKeyPair:
+		keypair, err := oldKeyStore.ExportKeyPair(key)
+		if err != nil {
+			log.WithError(err).Debug("failed to export client storage key pair")
+			return err
+		}
+		defer zeroizeKeyPair(keypair)
+		err = s.SaveDataEncryptionKeys(key.ID, keypair)
+		if err != nil {
+			log.WithError(err).Debug("failed to import client storage key pair")
+			return err
+		}
+	case filesystemV1.PurposeStorageZoneKeyPair:
+		keypair, err := oldKeyStore.ExportKeyPair(key)
+		if err != nil {
+			log.WithError(err).Debug("failed to export zone storage key pair")
+			return err
+		}
+		defer zeroizeKeyPair(keypair)
+		err = s.SaveZoneKeypair(key.ID, keypair)
+		if err != nil {
+			log.WithError(err).Debug("failed to import zone storage key pair")
+			return err
+		}
+	case filesystemV1.PurposeTransportConnectorKeyPair:
+		keypair, err := oldKeyStore.ExportKeyPair(key)
+		if err != nil {
+			log.WithError(err).Debug("failed to export AcraConnector transport key pair")
+			return err
+		}
+		defer zeroizeKeyPair(keypair)
+		err = s.SaveConnectorKeypair(key.ID, keypair)
+		if err != nil {
+			log.WithError(err).Debug("failed to import AcraConnector transport key pair")
+			return err
+		}
+	case filesystemV1.PurposeTransportTranslatorKeyPair:
+		keypair, err := oldKeyStore.ExportKeyPair(key)
+		if err != nil {
+			log.WithError(err).Debug("failed to export AcraTranslator transport key pair")
+			return err
+		}
+		defer zeroizeKeyPair(keypair)
+		err = s.SaveTranslatorKeypair(key.ID, keypair)
+		if err != nil {
+			log.WithError(err).Debug("failed to import AcraTranslator transport key pair")
+			return err
+		}
+	case filesystemV1.PurposeTransportServerKeyPair:
+		keypair, err := oldKeyStore.ExportKeyPair(key)
+		if err != nil {
+			log.WithError(err).Debug("failed to export AcraServer transport key pair")
+			return err
+		}
+		defer zeroizeKeyPair(keypair)
+		err = s.SaveServerKeypair(key.ID, keypair)
+		if err != nil {
+			log.WithError(err).Debug("failed to import AcraServer transport key pair")
+			return err
+		}
+	default:
+		log.Debug("unknown key purpose")
+		return ErrUnknownPurpose
+	}
+	return nil
+}
+
+func zeroizeSymmetricKey(key []byte) {
+	utils.FillSlice(0, key)
+}
+
+func zeroizeKeyPair(keypair *keys.Keypair) {
+	if keypair.Private != nil {
+		utils.FillSlice(0, keypair.Private.Value)
+	}
+}

--- a/keystore/v2/keystore/importV1.go
+++ b/keystore/v2/keystore/importV1.go
@@ -21,7 +21,6 @@ import (
 
 	filesystemV1 "github.com/cossacklabs/acra/keystore/filesystem"
 	"github.com/cossacklabs/acra/utils"
-	"github.com/cossacklabs/themis/gothemis/keys"
 )
 
 // Errors returned by key import:
@@ -44,7 +43,7 @@ func (s *ServerKeyStore) ImportKeyFileV1(oldKeyStore filesystemV1.KeyExport, key
 			log.WithError(err).Debug("failed to export authentication key")
 			return err
 		}
-		defer zeroizeSymmetricKey(symkey)
+		defer utils.ZeroizeSymmetricKey(symkey)
 		err = s.saveAuthKey(symkey)
 		if err != nil {
 			log.WithError(err).Debug("failed to import authentication key")
@@ -56,7 +55,7 @@ func (s *ServerKeyStore) ImportKeyFileV1(oldKeyStore filesystemV1.KeyExport, key
 			log.WithError(err).Debug("failed to export poison record key pair")
 			return err
 		}
-		defer zeroizeKeyPair(keypair)
+		defer utils.ZeroizeKeyPair(keypair)
 		err = s.savePoisonKeyPair(keypair)
 		if err != nil {
 			log.WithError(err).Debug("failed to import poison record key pair")
@@ -68,7 +67,7 @@ func (s *ServerKeyStore) ImportKeyFileV1(oldKeyStore filesystemV1.KeyExport, key
 			log.WithError(err).Debug("failed to export client storage key pair")
 			return err
 		}
-		defer zeroizeKeyPair(keypair)
+		defer utils.ZeroizeKeyPair(keypair)
 		err = s.SaveDataEncryptionKeys(key.ID, keypair)
 		if err != nil {
 			log.WithError(err).Debug("failed to import client storage key pair")
@@ -80,7 +79,7 @@ func (s *ServerKeyStore) ImportKeyFileV1(oldKeyStore filesystemV1.KeyExport, key
 			log.WithError(err).Debug("failed to export zone storage key pair")
 			return err
 		}
-		defer zeroizeKeyPair(keypair)
+		defer utils.ZeroizeKeyPair(keypair)
 		err = s.SaveZoneKeypair(key.ID, keypair)
 		if err != nil {
 			log.WithError(err).Debug("failed to import zone storage key pair")
@@ -92,7 +91,7 @@ func (s *ServerKeyStore) ImportKeyFileV1(oldKeyStore filesystemV1.KeyExport, key
 			log.WithError(err).Debug("failed to export AcraConnector transport key pair")
 			return err
 		}
-		defer zeroizeKeyPair(keypair)
+		defer utils.ZeroizeKeyPair(keypair)
 		err = s.SaveConnectorKeypair(key.ID, keypair)
 		if err != nil {
 			log.WithError(err).Debug("failed to import AcraConnector transport key pair")
@@ -104,7 +103,7 @@ func (s *ServerKeyStore) ImportKeyFileV1(oldKeyStore filesystemV1.KeyExport, key
 			log.WithError(err).Debug("failed to export AcraTranslator transport key pair")
 			return err
 		}
-		defer zeroizeKeyPair(keypair)
+		defer utils.ZeroizeKeyPair(keypair)
 		err = s.SaveTranslatorKeypair(key.ID, keypair)
 		if err != nil {
 			log.WithError(err).Debug("failed to import AcraTranslator transport key pair")
@@ -116,7 +115,7 @@ func (s *ServerKeyStore) ImportKeyFileV1(oldKeyStore filesystemV1.KeyExport, key
 			log.WithError(err).Debug("failed to export AcraServer transport key pair")
 			return err
 		}
-		defer zeroizeKeyPair(keypair)
+		defer utils.ZeroizeKeyPair(keypair)
 		err = s.SaveServerKeypair(key.ID, keypair)
 		if err != nil {
 			log.WithError(err).Debug("failed to import AcraServer transport key pair")
@@ -127,14 +126,4 @@ func (s *ServerKeyStore) ImportKeyFileV1(oldKeyStore filesystemV1.KeyExport, key
 		return ErrUnknownPurpose
 	}
 	return nil
-}
-
-func zeroizeSymmetricKey(key []byte) {
-	utils.FillSlice(0, key)
-}
-
-func zeroizeKeyPair(keypair *keys.Keypair) {
-	if keypair.Private != nil {
-		utils.FillSlice(0, keypair.Private.Value)
-	}
 }

--- a/keystore/v2/keystore/importV1_test.go
+++ b/keystore/v2/keystore/importV1_test.go
@@ -1,0 +1,263 @@
+/*
+ * Copyright 2020, Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package keystore
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	connectorMode "github.com/cossacklabs/acra/cmd/acra-connector/connector-mode"
+	keystoreV1 "github.com/cossacklabs/acra/keystore"
+	filesystemV1 "github.com/cossacklabs/acra/keystore/filesystem"
+	cryptoV2 "github.com/cossacklabs/acra/keystore/v2/keystore/crypto"
+	filesystemV2 "github.com/cossacklabs/acra/keystore/v2/keystore/filesystem"
+	"github.com/cossacklabs/themis/gothemis/keys"
+)
+
+var (
+	testMasterKey     = []byte("test master key")
+	testEncryptionKey = []byte("test encryptionn key")
+	testSignatureKey  = []byte("test signature key")
+)
+
+func TestImportKeyStoreV1(t *testing.T) {
+	// Prepare root key store directory (for both versions)
+	rootDirectory, err := ioutil.TempDir(os.TempDir(), "import_test")
+	if err != nil {
+		t.Fatalf("failed to create key directory: %v", err)
+	}
+	defer os.RemoveAll(rootDirectory)
+	keyDirV1 := filepath.Join(rootDirectory, "v1")
+	keyDirV2 := filepath.Join(rootDirectory, "v2")
+
+	// Prepare key store v1
+	encryptor, err := keystoreV1.NewSCellKeyEncryptor(testMasterKey)
+	if err != nil {
+		t.Fatalf("failed to initialize encryptor: %v", err)
+	}
+	keyStoreV1, err := filesystemV1.NewFilesystemKeyStore(keyDirV1, encryptor)
+	if err != nil {
+		t.Fatalf("failed to initialize key store v1: %v", err)
+	}
+
+	clientID := []byte("Tweedledee and Tweedledum")
+
+	// Prepare key store v2
+	suite, err := cryptoV2.NewSCellSuite(testEncryptionKey, testSignatureKey)
+	if err != nil {
+		t.Fatalf("failed to initialize cryptosuite: %v", err)
+	}
+	keyDirectoryV2, err := filesystemV2.OpenDirectoryRW(keyDirV2, suite)
+	if err != nil {
+		t.Fatalf("failed to initialize key store v2: %v", err)
+	}
+	keyStoreV2 := NewServerKeyStore(keyDirectoryV2)
+	keyStoreV2connectorServer := NewConnectorKeyStore(keyDirectoryV2, clientID, connectorMode.AcraServerMode)
+	keyStoreV2connectorTranslator := NewConnectorKeyStore(keyDirectoryV2, clientID, connectorMode.AcraTranslatorMode)
+	keyStoreV2translator := NewTranslatorKeyStore(keyDirectoryV2)
+
+	// Prepare various keys for testing.
+	err = keyStoreV1.GenerateDataEncryptionKeys(clientID)
+	if err != nil {
+		t.Errorf("GetZonePublicKey() failed: %v", err)
+	}
+	storagePublicKeyV1, err := keyStoreV1.GetClientIDEncryptionPublicKey(clientID)
+	if err != nil {
+		t.Errorf("GetClientIDEncryptionPublicKey() failed: %v", err)
+	}
+	storagePrivateKeyV1, err := keyStoreV1.GetServerDecryptionPrivateKey(clientID)
+	if err != nil {
+		t.Errorf("GetServerDecryptionPrivateKey() failed: %v", err)
+	}
+	zoneID, _, err := keyStoreV1.GenerateZoneKey()
+	if err != nil {
+		t.Errorf("GenerateZoneKey() failed: %v", err)
+	}
+	zonePublicKeyV1, err := keyStoreV1.GetZonePublicKey(zoneID)
+	if err != nil {
+		t.Errorf("GetZonePublicKey() failed: %v", err)
+	}
+	zonePrivateKeyV1, err := keyStoreV1.GetZonePrivateKey(zoneID)
+	if err != nil {
+		t.Errorf("GetZonePrivateKey() failed: %v", err)
+	}
+	// Since we cannot access all generated key pairs via AcraServer key store,
+	// we generate them here and use Save... API
+	connectorKeyPairV1, err := keys.New(keys.TypeEC)
+	err = keyStoreV1.SaveConnectorKeypair(clientID, connectorKeyPairV1)
+	if err != nil {
+		t.Errorf("SaveConnectorKeypair() failed: %v", err)
+	}
+	serverKeyPairV1, err := keys.New(keys.TypeEC)
+	err = keyStoreV1.SaveServerKeypair(clientID, serverKeyPairV1)
+	if err != nil {
+		t.Errorf("SaveServerKeypair() failed: %v", err)
+	}
+	translatorKeyPairV1, err := keys.New(keys.TypeEC)
+	err = keyStoreV1.SaveTranslatorKeypair(clientID, translatorKeyPairV1)
+	if err != nil {
+		t.Errorf("SaveTranslatorKeypair() failed: %v", err)
+	}
+	// And some finishing touches...
+	authenticationKeyV1, err := keyStoreV1.GetAuthKey(true)
+	if err != nil {
+		t.Errorf("GetAuthKey() failed: %v", err)
+	}
+	poisonKeyPairV1, err := keyStoreV1.GetPoisonKeyPair()
+	if err != nil {
+		t.Errorf("GetPoisonKeyPair() failed: %v", err)
+	}
+
+	// Test setup complete, now we transfer the keys.
+	exportedKeys, err := keyStoreV1.EnumerateExportedKeys()
+	if err != nil {
+		t.Fatalf("EnumerateExportedKeys() failed: %v", err)
+	}
+	for i, key := range exportedKeys {
+		err = keyStoreV2.ImportKeyFileV1(keyStoreV1, key)
+		if err != nil {
+			t.Fatalf("ImportKeyFileV1[%d] failed: %v", i, err)
+		}
+	}
+
+	// Now, if this has been successful, verify keystore v2 contents.
+	authenticationKeyV2, err := keyStoreV2.GetAuthKey(false)
+	if err != nil {
+		t.Errorf("GetAuthKey() failed: %v", err)
+	}
+	if !bytes.Equal(authenticationKeyV1, authenticationKeyV2) {
+		t.Errorf("authentication key corrupted")
+	}
+	poisonKeyPairV2, err := keyStoreV2.GetPoisonKeyPair()
+	if err != nil {
+		t.Errorf("GetPoisonKeyPair() failed: %v", err)
+	}
+	if !equalKeyPairs(poisonKeyPairV1, poisonKeyPairV2) {
+		t.Errorf("poison record key pair corrupted")
+	}
+	// Pay close attention here, transport keys are a bit complicated.
+	// They cannot be all accessed via server key store alone.
+	serverPeerPublicKeyV2, err := keyStoreV2.GetPeerPublicKey(clientID)
+	if err != nil {
+		t.Errorf("GetPeerPublicKey() failed: %v", err)
+	}
+	serverPrivateKeyV2, err := keyStoreV2.GetPrivateKey(clientID)
+	if err != nil {
+		t.Errorf("GetPrivateKey() failed: %v", err)
+	}
+	if !equalPublicKeys(connectorKeyPairV1.Public, serverPeerPublicKeyV2) {
+		t.Errorf("server peer public key corrupted")
+	}
+	if !equalPrivateKeys(serverKeyPairV1.Private, serverPrivateKeyV2) {
+		t.Errorf("server private key corrupted")
+	}
+	connectorServerPeerPublicKeyV2, err := keyStoreV2connectorServer.GetPeerPublicKey(clientID)
+	if err != nil {
+		t.Errorf("GetPeerPublicKey() failed: %v", err)
+	}
+	connectorServerPrivateKeyV2, err := keyStoreV2connectorServer.GetPrivateKey(clientID)
+	if err != nil {
+		t.Errorf("GetPrivateKey() failed: %v", err)
+	}
+	if !equalPublicKeys(serverKeyPairV1.Public, connectorServerPeerPublicKeyV2) {
+		t.Errorf("server peer public key corrupted")
+	}
+	if !equalPrivateKeys(connectorKeyPairV1.Private, connectorServerPrivateKeyV2) {
+		t.Errorf("server private key corrupted")
+	}
+	connectorTranslatorPeerPublicKeyV2, err := keyStoreV2connectorTranslator.GetPeerPublicKey(clientID)
+	if err != nil {
+		t.Errorf("GetPeerPublicKey() failed: %v", err)
+	}
+	connectorTranslatorPrivateKeyV2, err := keyStoreV2connectorTranslator.GetPrivateKey(clientID)
+	if err != nil {
+		t.Errorf("GetPrivateKey() failed: %v", err)
+	}
+	if !equalPublicKeys(translatorKeyPairV1.Public, connectorTranslatorPeerPublicKeyV2) {
+		t.Errorf("server peer public key corrupted")
+	}
+	if !equalPrivateKeys(connectorKeyPairV1.Private, connectorTranslatorPrivateKeyV2) {
+		t.Errorf("server private key corrupted")
+	}
+	translatorPeerPublicKeyV2, err := keyStoreV2translator.GetPeerPublicKey(clientID)
+	if err != nil {
+		t.Errorf("GetPeerPublicKey() failed: %v", err)
+	}
+	translatorPrivateKeyV2, err := keyStoreV2translator.GetPrivateKey(clientID)
+	if err != nil {
+		t.Errorf("GetPrivateKey() failed: %v", err)
+	}
+	if !equalPublicKeys(connectorKeyPairV1.Public, translatorPeerPublicKeyV2) {
+		t.Errorf("server peer public key corrupted")
+	}
+	if !equalPrivateKeys(translatorKeyPairV1.Private, translatorPrivateKeyV2) {
+		t.Errorf("server private key corrupted")
+	}
+	// Storage keys are easier to comprehend.
+	storagePublicKeyV2, err := keyStoreV2.GetClientIDEncryptionPublicKey(clientID)
+	if err != nil {
+		t.Errorf("GetClientIDEncryptionPublicKey() failed: %v", err)
+	}
+	storagePrivateKeyV2, err := keyStoreV2.GetServerDecryptionPrivateKey(clientID)
+	if err != nil {
+		t.Errorf("GetServerDecryptionPrivateKey() failed: %v", err)
+	}
+	if !equalPublicKeys(storagePublicKeyV1, storagePublicKeyV2) {
+		t.Errorf("client storage public key corrupted")
+	}
+	if !equalPrivateKeys(storagePrivateKeyV1, storagePrivateKeyV2) {
+		t.Errorf("client storage private key corrupted")
+	}
+	zonePublicKeyV2, err := keyStoreV2.GetZonePublicKey(zoneID)
+	if err != nil {
+		t.Errorf("GetZonePublicKey() failed: %v", err)
+	}
+	zonePrivateKeyV2, err := keyStoreV2.GetZonePrivateKey(zoneID)
+	if err != nil {
+		t.Errorf("GetZonePrivateKey() failed: %v", err)
+	}
+	if !equalPublicKeys(zonePublicKeyV1, zonePublicKeyV2) {
+		t.Errorf("zone storage public key corrupted")
+	}
+	if !equalPrivateKeys(zonePrivateKeyV1, zonePrivateKeyV2) {
+		t.Errorf("zone storage private key corrupted")
+	}
+}
+
+func equalKeyPairs(a, b *keys.Keypair) bool {
+	if a != nil && b != nil {
+		return equalPublicKeys(a.Public, b.Public) && equalPrivateKeys(a.Private, b.Private)
+	}
+	return a == nil && b == nil
+}
+
+func equalPublicKeys(a, b *keys.PublicKey) bool {
+	if a != nil && b != nil {
+		return bytes.Equal(a.Value, b.Value)
+	}
+	return a == nil && b == nil
+}
+
+func equalPrivateKeys(a, b *keys.PrivateKey) bool {
+	if a != nil && b != nil {
+		return bytes.Equal(a.Value, b.Value)
+	}
+	return a == nil && b == nil
+}

--- a/keystore/v2/keystore/keyRingUtils.go
+++ b/keystore/v2/keystore/keyRingUtils.go
@@ -136,15 +136,23 @@ func (s *ServerKeyStore) newCurrentSymmetricKey(ring api.MutableKeyRing) ([]byte
 	if err != nil {
 		return nil, err
 	}
-	i, err := ring.AddKey(s.describeNewSymmetricKey(key))
-	if err != nil {
-		return nil, err
-	}
-	err = ring.SetCurrent(i)
+	err = s.addCurrentSymmetricKey(ring, key)
 	if err != nil {
 		return nil, err
 	}
 	return key, nil
+}
+
+func (s *ServerKeyStore) addCurrentSymmetricKey(ring api.MutableKeyRing, key []byte) error {
+	i, err := ring.AddKey(s.describeNewSymmetricKey(key))
+	if err != nil {
+		return err
+	}
+	err = ring.SetCurrent(i)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func (s *ServerKeyStore) describeNewSymmetricKey(key []byte) api.KeyDescription {

--- a/keystore/v2/keystore/poison.go
+++ b/keystore/v2/keystore/poison.go
@@ -47,3 +47,18 @@ func (s *ServerKeyStore) GetPoisonKeyPair() (*keys.Keypair, error) {
 	}
 	return keypair, nil
 }
+
+func (s *ServerKeyStore) savePoisonKeyPair(keypair *keys.Keypair) error {
+	ring, err := s.OpenKeyRingRW(poisonKeyPath)
+	if err != nil {
+		s.log.WithError(err).WithField("path", poisonKeyPath).
+			Debug("failed to open poison key ring")
+		return err
+	}
+	err = s.addCurrentKeyPair(ring, keypair)
+	if err != nil {
+		s.log.WithError(err).Debug("failed to set current poison record key pair")
+		return err
+	}
+	return nil
+}

--- a/keystore/v2/keystore/webConfig.go
+++ b/keystore/v2/keystore/webConfig.go
@@ -50,3 +50,18 @@ func (s *ServerKeyStore) GetAuthKey(remove bool) ([]byte, error) {
 	}
 	return key, nil
 }
+
+func (s *ServerKeyStore) saveAuthKey(key []byte) error {
+	ring, err := s.OpenKeyRingRW(authKeyPath)
+	if err != nil {
+		s.log.WithError(err).WithField("path", authKeyPath).
+			Debug("failed to open authentication key ring")
+		return err
+	}
+	err = s.addCurrentSymmetricKey(ring, key)
+	if err != nil {
+		s.log.WithError(err).Debug("failed to set current authentication key")
+		return err
+	}
+	return nil
+}

--- a/tests/test.py
+++ b/tests/test.py
@@ -416,6 +416,8 @@ BINARIES = [
            build_args=DEFAULT_BUILD_ARGS),
     Binary(name='acra-keymaker', from_version=DEFAULT_VERSION,
            build_args=DEFAULT_BUILD_ARGS),
+    Binary(name='acra-migrate-keys', from_version=DEFAULT_VERSION,
+           build_args=DEFAULT_BUILD_ARGS),
     Binary(name='acra-poisonrecordmaker', from_version=DEFAULT_VERSION,
            build_args=DEFAULT_BUILD_ARGS),
     Binary(name='acra-rollback', from_version=ACRAROLLBACK_MIN_VERSION,
@@ -4253,6 +4255,7 @@ class TestOutdatedServiceConfigs(BaseTestCase, FailedRunProcessMixin):
             default_args = {
                 'acra-server': ['-db_host=127.0.0.1'],
                 'acra-connector': ['-user_check_disable', '-acraserver_connection_host=127.0.0.1', '-client_id=keypair1'],
+                'acra-migrate-keys': ['--dry_run', '--src_keys_dir={}'.format(KEYS_FOLDER.name)],
             }
             for service in services:
                 config_param = '-config_file={}'.format(os.path.join(tmp_dir, '{}.yaml'.format(service)))
@@ -4275,6 +4278,7 @@ class TestOutdatedServiceConfigs(BaseTestCase, FailedRunProcessMixin):
             default_args = {
                 'acra-server': ['-db_host=127.0.0.1'],
                 'acra-connector': ['-user_check_disable', '-acraserver_connection_host=127.0.0.1', '-client_id=keypair1'],
+                'acra-migrate-keys': ['--dry_run', '--src_keys_dir={}'.format(KEYS_FOLDER.name)],
             }
             for service in services:
                 config_param = '-config_file={}'.format(os.path.join(tmp_dir, '{}.yaml'.format(service)))
@@ -4308,6 +4312,7 @@ class TestOutdatedServiceConfigs(BaseTestCase, FailedRunProcessMixin):
                                    'status': 1},
                 'acra-keymaker': ['-keys_output_dir={}'.format(tmp_dir),
                                   '-keys_public_output_dir={}'.format(tmp_dir)],
+                'acra-migrate-keys': ['--dry_run', '--src_keys_dir={}'.format(KEYS_FOLDER.name)],
                 'acra-poisonrecordmaker': ['-keys_dir={}'.format(tmp_dir)],
                 'acra-rollback': {'args': ['-keys_dir={}'.format(tmp_dir)],
                                   'status': 1},
@@ -4353,6 +4358,7 @@ class TestOutdatedServiceConfigs(BaseTestCase, FailedRunProcessMixin):
                                    'status': 1},
                 'acra-keymaker': ['-keys_output_dir={}'.format(tmp_dir),
                                   '-keys_public_output_dir={}'.format(tmp_dir)],
+                'acra-migrate-keys': ['--dry_run', '--src_keys_dir={}'.format(KEYS_FOLDER.name)],
                 'acra-poisonrecordmaker': ['-keys_dir={}'.format(tmp_dir)],
                 'acra-rollback': {'args': ['-keys_dir={}'.format(tmp_dir)],
                                   'status': 1},

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -137,6 +137,25 @@ func FillSlice(value byte, data []byte) {
 	}
 }
 
+// ZeroizeSymmetricKey wipes a symmetric key from memory, filling it with zero bytes.
+func ZeroizeSymmetricKey(key []byte) {
+	FillSlice(0, key)
+}
+
+// ZeroizePrivateKey wipes a private key from memory, filling it with zero bytes.
+func ZeroizePrivateKey(privateKey *keys.PrivateKey) {
+	if privateKey != nil {
+		FillSlice(0, privateKey.Value)
+	}
+}
+
+// ZeroizeKeyPair wipes a private key of a key pair from memory, filling it with zero bytes.
+func ZeroizeKeyPair(keypair *keys.Keypair) {
+	if keypair != nil {
+		ZeroizePrivateKey(keypair.Private)
+	}
+}
+
 // FileExists returns true if file exists from path, path can be relative
 func FileExists(path string) (bool, error) {
 	absPath, err := filepath.Abs(path)

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -16,9 +16,13 @@ limitations under the License.
 package utils_test
 
 import (
-	"github.com/cossacklabs/acra/utils"
+	"bytes"
+	"crypto/rand"
 	"os"
 	"testing"
+
+	"github.com/cossacklabs/acra/utils"
+	"github.com/cossacklabs/themis/gothemis/keys"
 )
 
 func TestFileExists(t *testing.T) {
@@ -36,4 +40,63 @@ func TestFileExists(t *testing.T) {
 	if !exists || err != nil {
 		t.Fatalf("File not exists or returned any error. err = %v\n", err)
 	}
+}
+
+func TestZeroizeSymmetricKey(t *testing.T) {
+	symKey := make([]byte, 32)
+	allZeros := make([]byte, 32)
+	rand.Read(symKey)
+
+	utils.ZeroizeSymmetricKey(symKey)
+
+	if !bytes.Equal(symKey, allZeros) {
+		t.Error("symmetrick key not zeroized")
+	}
+}
+
+func TestZeroizeNilSymmetricKey(t *testing.T) {
+	utils.ZeroizeSymmetricKey(nil) // no panic
+}
+
+func TestZeroizePrivateKey(t *testing.T) {
+	keypair, err := keys.New(keys.TypeEC)
+	if err != nil {
+		t.Fatalf("failed to generated key pair: %v", err)
+	}
+	allZeros := make([]byte, len(keypair.Private.Value))
+
+	utils.ZeroizePrivateKey(keypair.Private)
+
+	if !bytes.Equal(keypair.Private.Value, allZeros) {
+		t.Error("private key not zeroized")
+	}
+}
+
+func TestZeroizeNilPrivateKey(t *testing.T) {
+	utils.ZeroizePrivateKey(nil) // no panic
+	utils.ZeroizePrivateKey(&keys.PrivateKey{})
+}
+
+func TestZeroizeKeyPair(t *testing.T) {
+	keypair, err := keys.New(keys.TypeEC)
+	if err != nil {
+		t.Fatalf("failed to generated key pair: %v", err)
+	}
+	allZeros := make([]byte, len(keypair.Private.Value))
+	oldPublicValue := make([]byte, len(keypair.Public.Value))
+	copy(oldPublicValue, keypair.Public.Value)
+
+	utils.ZeroizeKeyPair(keypair)
+
+	if !bytes.Equal(keypair.Private.Value, allZeros) {
+		t.Error("private key not zeroized")
+	}
+	if !bytes.Equal(keypair.Public.Value, oldPublicValue) {
+		t.Error("public key has changed")
+	}
+}
+
+func TestZeroizeNilKeyPair(t *testing.T) {
+	utils.ZeroizeKeyPair(nil) // no panic
+	utils.ZeroizeKeyPair(&keys.Keypair{})
 }


### PR DESCRIPTION
Create a tool for migrating keys between key store formats. Currently it supports only v1 ⟹ v2 migration.

With default settings it is enough to simply run `acra-migrate-keys` to migrate keys from `.acrakeys` (v1) into `.acrakeys.migrated` (v2). After successful migration the administrator has to manually reconfigure Acra services to use the new key store. It is possible to explicitly specify migration details via `--src...` and `--dst...`  options if necessary.

There is a `--dry_run` option which performs migration in memory, without writing results to disk. You can use it to test that everything is in place, the keys can be read and understood.

By default the migration tool will refuse to write output into already existing key store. This is because the migration process is not transactional and idempotent. Migrating the same key store twice will result in duplicate keys, and failure to migrate some keys will still migrate other successful keys. This behavior can be overridden with `--force` option, allowing the migration to proceed.

Note that master keys are expected in environment variables, as usual. You will need to set all variables for successful migration:

  - ACRA_MASTER_KEY
  - ACRA_MASTER_ENCRYPTION_KEY
  - ACRA_MASTER_SIGNATURE_KEY

More implementation details are in commit messages. The code is structured in a way that should easy its reuse in Acra EE with its extended key store support (both v1 and v2).