### PR TITLE
Improve error message style (Key Store v2)

### DIFF
--- a/keystore/v2/keystore/api/key.go
+++ b/keystore/v2/keystore/api/key.go
@@ -25,13 +25,13 @@ import (
 
 // Errors returned by KeyRing methods accessing key data:
 var (
-	ErrFormatDuplicated    = errors.New("KeyStore: key format used multiple times")
-	ErrFormatMissing       = errors.New("KeyStore: key format not available")
-	ErrKeyNotExist         = errors.New("KeyStore: no key with such seqnum")
-	ErrNoKeyData           = errors.New("KeyStore: no key data")
-	ErrInvalidFormat       = errors.New("KeyStore: invalid key format")
-	ErrInvalidState        = errors.New("KeyStore: invalid state transition")
-	ErrInvalidCryptoperiod = errors.New("KeyStore: invalid key cryptoperiod")
+	ErrFormatDuplicated    = errors.New("key format used multiple times")
+	ErrFormatMissing       = errors.New("key format not available")
+	ErrKeyNotExist         = errors.New("no key with such seqnum")
+	ErrNoKeyData           = errors.New("no key data")
+	ErrInvalidFormat       = errors.New("invalid key format")
+	ErrInvalidState        = errors.New("invalid state transition")
+	ErrInvalidCryptoperiod = errors.New("invalid key cryptoperiod")
 )
 
 // KeyFormat describes key material format.

--- a/keystore/v2/keystore/api/keyRing.go
+++ b/keystore/v2/keystore/api/keyRing.go
@@ -23,7 +23,7 @@ import (
 
 // Errors returned by KeyRing methods:
 var (
-	ErrNoCurrentKey = errors.New("KeyStore: key ring has no current key")
+	ErrNoCurrentKey = errors.New("key ring has no current key")
 )
 
 // KeyRing is a bunch of keys, with currently active one.

--- a/keystore/v2/keystore/asn1/asn1.go
+++ b/keystore/v2/keystore/asn1/asn1.go
@@ -25,7 +25,7 @@ import (
 
 // Errors returned by ASN.1 processing:
 var (
-	ErrExtraData = fmt.Errorf("KeyStore: unexpected extra data")
+	ErrExtraData = fmt.Errorf("unexpected extra ASN.1 data")
 )
 
 // Miscellaneous ASN.1 constants:

--- a/keystore/v2/keystore/filesystem/backend/api/backend.go
+++ b/keystore/v2/keystore/filesystem/backend/api/backend.go
@@ -26,9 +26,9 @@ const PathSeparator = "/"
 
 // Errors returned by filesystem.Backend:
 var (
-	ErrNotExist    = errors.New("KeyStore: key path does not exist")
-	ErrExist       = errors.New("KeyStore: key path already exists")
-	ErrInvalidPath = errors.New("KeyStore: invalid key path")
+	ErrNotExist    = errors.New("key path does not exist")
+	ErrExist       = errors.New("key path already exists")
+	ErrInvalidPath = errors.New("invalid key path")
 )
 
 // Backend defines how KeyStore persists internal key data.

--- a/keystore/v2/keystore/filesystem/backend/filesystem.go
+++ b/keystore/v2/keystore/filesystem/backend/filesystem.go
@@ -41,9 +41,9 @@ const (
 
 // Errors returned by DirectoryBackend:
 var (
-	ErrNotDirectory       = errors.New("KeyStore: root directory is not a directory")
-	ErrInvalidPermissions = errors.New("KeyStore: invalid access permissions")
-	ErrInvalidVersion     = errors.New("KeyStore: invalid version file content")
+	ErrNotDirectory       = errors.New("root key directory is not a directory")
+	ErrInvalidPermissions = errors.New("invalid key directory access permissions")
+	ErrInvalidVersion     = errors.New("invalid key store version file content")
 )
 
 // DirectoryBackend keeps data in filesystem directory hierarchy.

--- a/keystore/v2/keystore/filesystem/keyRing.go
+++ b/keystore/v2/keystore/filesystem/keyRing.go
@@ -44,7 +44,7 @@ type KeyRing struct {
 // Construction
 //
 
-var errInvalidCurrentIndex = errors.New("KeyStore: invalid Current index in key ring")
+var errInvalidCurrentIndex = errors.New("invalid Current index in key ring")
 
 func newKeyRing(store *KeyStore, path string) *KeyRing {
 	ring := &KeyRing{

--- a/keystore/v2/keystore/filesystem/keyRingTX.go
+++ b/keystore/v2/keystore/filesystem/keyRingTX.go
@@ -32,10 +32,10 @@ type keyRingTX interface {
 
 // Errors returned by transactions:
 var (
-	errTxConcurrentModification = errors.New("KeyStore: concurrent modification")
-	errTxOOORollback            = errors.New("KeyStore BUG: out-of-order rollback")
-	errTxKeyNotFound            = errors.New("KeyStore: no key with such seqnum")
-	errTxKeyExists              = errors.New("KeyStore: duplicate key with seqnum")
+	errTxConcurrentModification = errors.New("concurrent key store modification")
+	errTxOOORollback            = errors.New("out-of-order key store rollback")
+	errTxKeyNotFound            = errors.New("no key with such seqnum in key ring")
+	errTxKeyExists              = errors.New("duplicate key with seqnum in key ring")
 )
 
 type txSetKeyCurrent struct {

--- a/keystore/v2/keystore/filesystem/keyStore.go
+++ b/keystore/v2/keystore/filesystem/keyStore.go
@@ -166,8 +166,8 @@ func (s *KeyStore) keyRingSignatureContext(path string) []byte {
 
 // Errors returned by signature verification:
 var (
-	errIncorrectContentType = errors.New("KeyStore: incorrect ASN.1 ContentType")
-	errUnsupportedVersion   = errors.New("KeyStore: unsupported ASN.1 Version")
+	errIncorrectContentType = errors.New("incorrect ASN.1 ContentType")
+	errUnsupportedVersion   = errors.New("unsupported ASN.1 Version")
 )
 
 func (s *KeyStore) signKeyRing(ring *asn1.KeyRing, path string) ([]byte, []asn1.Signature, error) {

--- a/keystore/v2/keystore/signature/notary.go
+++ b/keystore/v2/keystore/signature/notary.go
@@ -32,9 +32,9 @@ const notarySubsystemName = "notary"
 
 // Errors produced by signature verification:
 var (
-	ErrNoAlgorithms   = errors.New("KeyStore: no signing algorithms")
-	ErrNoSignature    = errors.New("KeyStore: missing signature")
-	ErrSignatureError = errors.New("KeyStore: invalid signature")
+	ErrNoAlgorithms   = errors.New("no key ring signing algorithms")
+	ErrNoSignature    = errors.New("missing key ring signature")
+	ErrSignatureError = errors.New("invalid key ring signature")
 )
 
 // Algorithm interface defines a particular signing algorithm for Notary.


### PR DESCRIPTION
As much as I dislike whole code base commits, let's do it before this branch lands into master.

Update error messages used by key store v2 to conform to Go style. Remove all `KeyStore` prefixes, start the messages with a lowercase letter, and provide enough context in the message itself to see where the problem has originated.