### PR TITLE
Run integration tests with key store v2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,6 +102,54 @@ jobs:
       - store_artifacts:
           path: /home/user/tests_output
 
+  postgresql-keystoreV2:
+    docker:
+      - image: cossacklabs/android-build
+      - image: postgres:11-alpine
+        environment:
+          POSTGRES_PASSWORD: test
+          POSTGRES_USER: test
+          POSTGRES_DB: test
+    environment:
+      FILEPATH_ERROR_FLAG: /tmp/test_fail
+      VERSIONS: 1.11.5 1.12
+      TEST_DB_PORT: 5432
+      GOPATH_FOLDER: gopath
+      TEST_RANDOM_DATA_FOLDER: /tmp/test_data
+      TEST_TLS: "off"
+      TEST_KEYSTORE: v2
+      # $HOME/$GOPATH_FOLDER
+      GOPATH: /home/user/gopath
+      # set default goroot instead system available
+      GOROOT: /home/user/go_root_1.11.5/go
+      GO111MODULE: "on"
+    steps:
+      - checkout
+      - run:
+          name: Prepare test harness
+          command: .circleci/prepare.sh
+      - run:
+          name: Prepare PostgreSQL client
+          command: |
+            sudo apt-get install -y postgresql-client
+            pg_isready -U${POSTGRES_USER} -d${POSTGRES_DB} -h127.0.0.1
+      - run:
+          name: Generate test data for integration tests
+          command: python3 tests/generate_random_data.py
+      - run:
+          name: Run integration tests
+          command: |
+            .circleci/integration.sh
+            if [[ -e "$FILEPATH_ERROR_FLAG" ]]; then
+              cat "$FILEPATH_ERROR_FLAG"
+              rm "$FILEPATH_ERROR_FLAG"
+              exit 1
+            fi
+      - store_test_results:
+          path: /home/user/tests_output
+      - store_artifacts:
+          path: /home/user/tests_output
+
   mariadb-ssl:
     docker:
     - image: cossacklabs/android-build
@@ -271,6 +319,7 @@ workflows:
       - general_validation
       - postgresql
       - postgresql-ssl
+      - postgresql-keystoreV2
       - mysql
       - mysql-ssl
       - mariadb

--- a/cmd/acra-read-key/acra-read-key.go
+++ b/cmd/acra-read-key/acra-read-key.go
@@ -71,7 +71,7 @@ type commandLineParams struct {
 var params commandLineParams
 
 func main() {
-	flag.StringVar(&params.KeyStoreVersion, "keystore", "", "force key store format: v1 (current), v2 (experimental)")
+	flag.StringVar(&params.KeyStoreVersion, "keystore", "", "force key store format: v1 (current), v2 (new)")
 	flag.StringVar(&params.KeyDir, "keys_dir", defaultKeyDir, "path to key directory")
 	flag.StringVar(&params.KeyDirPublic, "keys_dir_public", "", "path to key directory for public keys")
 	flag.StringVar(&params.ClientID, "client_id", "", "client ID for which to retrieve key")

--- a/cmd/acra-read-key/acra-read-key.go
+++ b/cmd/acra-read-key/acra-read-key.go
@@ -105,6 +105,8 @@ func main() {
 
 	var keyBytes []byte
 	switch params.KeyKind {
+	case "":
+		// no key requested, do nothing
 	case keyPoisonPublic:
 		keypair, err := keyStore.GetPoisonKeyPair()
 		if err != nil {

--- a/cmd/acra-read-key/acra-read-key.go
+++ b/cmd/acra-read-key/acra-read-key.go
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2020, Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package main is entry point for acra-read-key test utility.
+// It is used by integration tests to read arbitrary keys from the key store.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/cossacklabs/acra/cmd"
+	"github.com/cossacklabs/acra/keystore"
+	keystoreV1 "github.com/cossacklabs/acra/keystore"
+	"github.com/cossacklabs/acra/keystore/filesystem"
+	keystoreV2 "github.com/cossacklabs/acra/keystore/v2/keystore"
+	filesystemV2 "github.com/cossacklabs/acra/keystore/v2/keystore/filesystem"
+	"github.com/cossacklabs/acra/logging"
+	"github.com/cossacklabs/acra/utils"
+	log "github.com/sirupsen/logrus"
+)
+
+var (
+	serviceName       = "acra-read-key"
+	defaultConfigPath = utils.GetConfigPathByName("acra-read-key")
+	defaultKeyDir     = keystoreV1.DefaultKeyDirShort
+)
+
+const (
+	keyStoragePublic  = "storage-public"
+	keyStoragePrivate = "storage-private"
+	keyZonePublic     = "zone-public"
+	keyZonePrivate    = "zone-private"
+)
+
+var keyKinds = strings.Join([]string{
+	keyStoragePublic,
+	keyStoragePrivate,
+	keyZonePublic,
+	keyZonePrivate,
+}, ", ")
+
+type commandLineParams struct {
+	KeyStoreVersion string
+	KeyDir          string
+	KeyDirPublic    string
+	ClientID        string
+	ZoneID          string
+	KeyKind         string
+}
+
+var params commandLineParams
+
+func main() {
+	flag.StringVar(&params.KeyStoreVersion, "keystore", "", "force key store format: v1 (current), v2 (experimental)")
+	flag.StringVar(&params.KeyDir, "keys_dir", defaultKeyDir, "path to key directory")
+	flag.StringVar(&params.KeyDirPublic, "keys_dir_public", "", "path to key directory for public keys")
+	flag.StringVar(&params.ClientID, "client_id", "", "client ID for which to retrieve key")
+	flag.StringVar(&params.ZoneID, "zone_id", "", "zone ID for which to retrieve key")
+	flag.StringVar(&params.KeyKind, "key", "", "key kind to read, one of: "+keyKinds)
+	err := cmd.Parse(defaultConfigPath, serviceName)
+	if err != nil {
+		log.WithError(err).
+			WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantReadServiceConfig).
+			Fatal("Cannot parse arguments")
+	}
+
+	if params.ClientID != "" && params.ZoneID != "" {
+		log.Fatal("--client_id and --zone_id cannot be used simultaneously")
+	}
+	if params.KeyStoreVersion == "" {
+		if filesystemV2.IsKeyDirectory(params.KeyDir) {
+			params.KeyStoreVersion = "v2"
+		} else {
+			params.KeyStoreVersion = "v1"
+		}
+	}
+	if params.KeyDirPublic == "" {
+		params.KeyDirPublic = params.KeyDir
+	}
+
+	keyStore, err := openKeyStore()
+	if err != nil {
+		log.Fatalf("Failed to open key store: %v", err)
+	}
+
+	var keyBytes []byte
+	switch params.KeyKind {
+	case keyStoragePublic:
+		if params.ClientID == "" {
+			log.Fatal("--key " + keyStoragePublic + " requires --client_id")
+		}
+		key, err := keyStore.GetClientIDEncryptionPublicKey([]byte(params.ClientID))
+		if err != nil {
+			log.WithError(err).Fatal("Cannot read client storage public key")
+		}
+		keyBytes = key.Value
+	case keyStoragePrivate:
+		if params.ClientID == "" {
+			log.Fatal("--key " + keyStoragePrivate + " requires --client_id")
+		}
+		key, err := keyStore.GetServerDecryptionPrivateKey([]byte(params.ClientID))
+		if err != nil {
+			log.WithError(err).Fatal("Cannot read client storage private key")
+		}
+		keyBytes = key.Value
+	case keyZonePublic:
+		if params.ZoneID == "" {
+			log.Fatal("--key " + keyZonePublic + " requires --zone_id")
+		}
+		key, err := keyStore.GetZonePublicKey([]byte(params.ZoneID))
+		if err != nil {
+			log.WithError(err).Fatal("Cannot read zone storage public key")
+		}
+		keyBytes = key.Value
+	case keyZonePrivate:
+		if params.ZoneID == "" {
+			log.Fatal("--key " + keyZonePrivate + " requires --zone_id")
+		}
+		key, err := keyStore.GetZonePrivateKey([]byte(params.ZoneID))
+		if err != nil {
+			log.WithError(err).Fatal("Cannot read zone storage private key")
+		}
+		keyBytes = key.Value
+	default:
+		log.Fatalf("Unknown key kind: %v, allowed values: %s", params.KeyKind, keyKinds)
+	}
+
+	_, err = os.Stdout.Write(keyBytes)
+	if err != nil {
+		log.Fatalf("Failed to write key bytes: %v", err)
+	}
+}
+
+func openKeyStore() (keystore.ServerKeyStore, error) {
+	switch params.KeyStoreVersion {
+	case "v1":
+		return openKeyStoreV1()
+	case "v2":
+		return openKeyStoreV2()
+	default:
+		return nil, fmt.Errorf("unknown keystore option: %v", params.KeyStoreVersion)
+	}
+}
+
+func openKeyStoreV1() (keystore.ServerKeyStore, error) {
+	symmetricKey, err := keystore.GetMasterKeyFromEnvironment()
+	if err != nil {
+		log.WithError(err).Errorln("Cannot read master keys from environment")
+		return nil, err
+	}
+	scellEncryptor, err := keystore.NewSCellKeyEncryptor(symmetricKey)
+	if err != nil {
+		log.WithError(err).Errorln("Failed to initialize Secure Cell encryptor")
+		return nil, err
+	}
+	var store keystore.ServerKeyStore
+	if params.KeyDir != params.KeyDirPublic {
+		store, err = filesystem.NewFilesystemKeyStoreTwoPath(params.KeyDir, params.KeyDirPublic, scellEncryptor)
+	} else {
+		store, err = filesystem.NewFilesystemKeyStore(params.KeyDir, scellEncryptor)
+	}
+	if err != nil {
+		log.WithError(err).Errorln("Failed to initialize key")
+		return nil, err
+	}
+	return store, nil
+}
+
+func openKeyStoreV2() (keystore.ServerKeyStore, error) {
+	encryption, signature, err := keystoreV2.GetMasterKeysFromEnvironment()
+	if err != nil {
+		log.WithError(err).Error("Cannot read master keys from environment")
+		return nil, err
+	}
+	suite, err := keystoreV2.NewSCellSuite(encryption, signature)
+	if err != nil {
+		log.WithError(err).Error("Failed to initialize Secure Cell crypto suite")
+		return nil, err
+	}
+	keyDir, err := filesystemV2.OpenDirectoryRW(params.KeyDir, suite)
+	if err != nil {
+		log.WithError(err).WithField("path", params.KeyDir).Error("Cannot open key directory")
+		return nil, err
+	}
+	return keystoreV2.NewServerKeyStore(keyDir), nil
+}

--- a/cmd/acra-read-key/acra-read-key.go
+++ b/cmd/acra-read-key/acra-read-key.go
@@ -42,6 +42,8 @@ var (
 )
 
 const (
+	keyPoisonPublic   = "poison-public"
+	keyPoisonPrivate  = "poison-private"
 	keyStoragePublic  = "storage-public"
 	keyStoragePrivate = "storage-private"
 	keyZonePublic     = "zone-public"
@@ -49,6 +51,8 @@ const (
 )
 
 var keyKinds = strings.Join([]string{
+	keyPoisonPublic,
+	keyPoisonPrivate,
 	keyStoragePublic,
 	keyStoragePrivate,
 	keyZonePublic,
@@ -101,6 +105,18 @@ func main() {
 
 	var keyBytes []byte
 	switch params.KeyKind {
+	case keyPoisonPublic:
+		keypair, err := keyStore.GetPoisonKeyPair()
+		if err != nil {
+			log.WithError(err).Fatal("Cannot read poison record key pair")
+		}
+		keyBytes = keypair.Public.Value
+	case keyPoisonPrivate:
+		keypair, err := keyStore.GetPoisonKeyPair()
+		if err != nil {
+			log.WithError(err).Fatal("Cannot read poison record key pair")
+		}
+		keyBytes = keypair.Private.Value
 	case keyStoragePublic:
 		if params.ClientID == "" {
 			log.Fatal("--key " + keyStoragePublic + " requires --client_id")

--- a/configs/acra-read-key.yaml
+++ b/configs/acra-read-key.yaml
@@ -20,9 +20,8 @@ keys_dir: .acrakeys
 # path to key directory for public keys
 keys_dir_public: 
 
-# force key store format: v1 (current), v2 (experimental)
+# force key store format: v1 (current), v2 (new)
 keystore: 
 
 # zone ID for which to retrieve key
 zone_id: 
-

--- a/configs/acra-read-key.yaml
+++ b/configs/acra-read-key.yaml
@@ -1,0 +1,28 @@
+version: 0.85.0
+# client ID for which to retrieve key
+client_id: 
+
+# path to config
+config_file: 
+
+# dump config
+dump_config: false
+
+# Generate with yaml config markdown text file with descriptions of all args
+generate_markdown_args_table: false
+
+# key kind to read, one of: poison-public, poison-private, storage-public, storage-private, zone-public, zone-private
+key: 
+
+# path to key directory
+keys_dir: .acrakeys
+
+# path to key directory for public keys
+keys_dir_public: 
+
+# force key store format: v1 (current), v2 (experimental)
+keystore: 
+
+# zone ID for which to retrieve key
+zone_id: 
+

--- a/configs/regenerate.sh
+++ b/configs/regenerate.sh
@@ -1,13 +1,20 @@
 #!/usr/bin/env bash
-
-binaries=(server connector translator addzone webconfig rollback keymaker migrate-keys poisonrecordmaker authmanager rotate)
+#
+# Regenerate example configuration files.
+#
+# Run as
+#
+#     ./configs/regenerate.sh [dst-dir]
+#
+# from repository root. If dst-dir is not specified then configs are written
+# into the default directory (./configs).
 
 args="--dump_config"
+extra=
 
-
-for cmd in "${binaries[@]}"; do
- if [[ "$#" == "1" ]]; then
-    args="--dump_config --config_file=$1/acra-${cmd}.yaml"
- fi
- go run ./cmd/acra-${cmd}/*.go `echo ${args}`
+for cmd in $(ls ./cmd/ | grep ^acra-); do
+    if [[ $# == 1 ]]; then
+        extra="--config_file=$1/${cmd}.yaml"
+    fi
+    go run ./cmd/$cmd $args $extra
 done

--- a/tests/test.py
+++ b/tests/test.py
@@ -127,7 +127,6 @@ ZONE_PUBLIC_KEY = 'public_key'
 
 zones = []
 poison_record = None
-master_key = None
 master_keys = None
 KEYS_FOLDER = None
 ACRA_MASTER_KEY_VAR_NAME = 'ACRA_MASTER_KEY'
@@ -273,23 +272,6 @@ def get_connect_args(port=5432, sslmode=None, **kwargs):
 
 
 KEYSTORE_VERSION = os.environ.get('TEST_KEYSTORE', 'v1')
-
-
-def get_master_key():
-    """
-    return master key in base64 format if generated or generate and return
-    """
-    global master_key
-    if not master_key:
-        master_key = os.environ.get(ACRA_MASTER_KEY_VAR_NAME)
-        if not master_key:
-            subprocess.check_output([
-                './acra-keymaker', '--generate_master_key={}'.format(MASTER_KEY_PATH),
-                '--keys_output_dir={}'.format(KEYS_FOLDER.name),
-                '--keys_public_output_dir={}'.format(KEYS_FOLDER.name)])
-            with open(MASTER_KEY_PATH, 'rb') as f:
-                master_key = b64encode(f.read()).decode('ascii')
-    return master_key
 
 
 def get_master_keys():

--- a/tests/test.py
+++ b/tests/test.py
@@ -1689,6 +1689,9 @@ class TestConnectionClosing(BaseTestCase):
 class TestKeyNonExistence(BaseTestCase):
     def setUp(self):
         self.checkSkip()
+        # FIXME(ilammy, 2020-03-20): implement key removal for v2
+        if KEYSTORE_VERSION == 'v2':
+            self.skipTest('key store v2 does not support key removal')
         try:
             if not self.EXTERNAL_ACRA:
                 self.acra = self.fork_acra()
@@ -2207,6 +2210,9 @@ class TestCheckLogPoisonRecord(AcraCatchLogsMixin, BasePoisonRecordTest):
 class TestKeyStorageClearing(BaseTestCase):
     def setUp(self):
         self.checkSkip()
+        # FIXME(ilammy, 2020-03-20): implement key removal for v2
+        if KEYSTORE_VERSION == 'v2':
+            self.skipTest('key store v2 does not support key removal')
         try:
             self.key_name = 'clearing_keypair'
             create_client_keypair(self.key_name)

--- a/tests/test.py
+++ b/tests/test.py
@@ -4287,6 +4287,7 @@ class TestOutdatedServiceConfigs(BaseTestCase, FailedRunProcessMixin):
                 'acra-server': ['-db_host=127.0.0.1'],
                 'acra-connector': ['-user_check_disable', '-acraserver_connection_host=127.0.0.1', '-client_id=keypair1'],
                 'acra-migrate-keys': ['--dry_run', '--src_keys_dir={}'.format(KEYS_FOLDER.name)],
+                'acra-read-key': ['--keys_dir={}'.format(KEYS_FOLDER.name)],
             }
             for service in services:
                 config_param = '-config_file={}'.format(os.path.join(tmp_dir, '{}.yaml'.format(service)))
@@ -4310,6 +4311,7 @@ class TestOutdatedServiceConfigs(BaseTestCase, FailedRunProcessMixin):
                 'acra-server': ['-db_host=127.0.0.1'],
                 'acra-connector': ['-user_check_disable', '-acraserver_connection_host=127.0.0.1', '-client_id=keypair1'],
                 'acra-migrate-keys': ['--dry_run', '--src_keys_dir={}'.format(KEYS_FOLDER.name)],
+                'acra-read-key': ['--keys_dir={}'.format(KEYS_FOLDER.name)],
             }
             for service in services:
                 config_param = '-config_file={}'.format(os.path.join(tmp_dir, '{}.yaml'.format(service)))
@@ -4345,6 +4347,7 @@ class TestOutdatedServiceConfigs(BaseTestCase, FailedRunProcessMixin):
                                   '-keys_public_output_dir={}'.format(tmp_dir),
                                   '--keystore={}'.format(KEYSTORE_VERSION)],
                 'acra-migrate-keys': ['--dry_run', '--src_keys_dir={}'.format(KEYS_FOLDER.name)],
+                'acra-read-key': ['--keys_dir={}'.format(KEYS_FOLDER.name)],
                 'acra-poisonrecordmaker': ['-keys_dir={}'.format(tmp_dir),
                                            '--keystore={}'.format(KEYSTORE_VERSION)],
                 'acra-rollback': {'args': ['-keys_dir={}'.format(tmp_dir),
@@ -4395,6 +4398,7 @@ class TestOutdatedServiceConfigs(BaseTestCase, FailedRunProcessMixin):
                                   '-keys_public_output_dir={}'.format(tmp_dir),
                                   '--keystore={}'.format(KEYSTORE_VERSION)],
                 'acra-migrate-keys': ['--dry_run', '--src_keys_dir={}'.format(KEYS_FOLDER.name)],
+                'acra-read-key': ['--keys_dir={}'.format(KEYS_FOLDER.name)],
                 'acra-poisonrecordmaker': ['-keys_dir={}'.format(tmp_dir),
                                            '--keystore={}'.format(KEYSTORE_VERSION)],
                 'acra-rollback': {'args': ['-keys_dir={}'.format(tmp_dir),

--- a/tests/test.py
+++ b/tests/test.py
@@ -57,12 +57,13 @@ from sqlalchemy.dialects.postgresql import BYTEA
 from sqlalchemy.dialects import mysql as mysql_dialect
 from sqlalchemy.dialects import postgresql as postgresql_dialect
 
-from utils import (read_storage_public_key, decrypt_acrastruct,
-                   decrypt_private_key, read_zone_public_key,
+from utils import (read_storage_public_key, read_storage_private_key,
+                   read_zone_public_key, read_zone_private_key,
+                   decrypt_acrastruct,
                    load_random_data_config, get_random_data_files,
                    clean_test_data, safe_string, prepare_encryptor_config,
                    get_encryptor_config, abs_path, get_test_encryptor_config, send_signal_by_process_name,
-                   load_yaml_config, dump_yaml_config, read_storage_private_key, read_zone_private_key)
+                   load_yaml_config, dump_yaml_config)
 
 import sys
 # add to path our wrapper until not published to PYPI

--- a/tests/test.py
+++ b/tests/test.py
@@ -268,6 +268,9 @@ def get_connect_args(port=5432, sslmode=None, **kwargs):
     return args
 
 
+KEYSTORE_VERSION = os.environ.get('TEST_KEYSTORE', 'v1')
+
+
 def get_master_key():
     """
     return master key in base64 format if generated or generate and return
@@ -290,15 +293,18 @@ def get_poison_record():
     for new records"""
     global poison_record
     if not poison_record:
-        poison_record = b64decode(subprocess.check_output(
-            ['./acra-poisonrecordmaker', '--keys_dir={}'.format(KEYS_FOLDER.name)], timeout=PROCESS_CALL_TIMEOUT))
+        poison_record = b64decode(subprocess.check_output([
+            './acra-poisonrecordmaker', '--keys_dir={}'.format(KEYS_FOLDER.name),
+            '--keystore={}'.format(KEYSTORE_VERSION)],
+            timeout=PROCESS_CALL_TIMEOUT))
     return poison_record
 
 
 def create_client_keypair(name, only_server=False, only_client=False):
     args = ['./acra-keymaker', '-client_id={}'.format(name),
             '-keys_output_dir={}'.format(KEYS_FOLDER.name),
-            '--keys_public_output_dir={}'.format(KEYS_FOLDER.name)]
+            '--keys_public_output_dir={}'.format(KEYS_FOLDER.name),
+            '--keystore={}'.format(KEYSTORE_VERSION)]
     if only_server:
         args.append('-acra-server')
     elif only_client:
@@ -310,6 +316,7 @@ def manage_basic_auth_user(action, user_name, user_password):
             '--file={}'.format(ACRAWEBCONFIG_AUTH_DB_PATH),
             '--user={}'.format(user_name),
             '--keys_dir={}'.format(KEYS_FOLDER.name),
+            '--keystore={}'.format(KEYSTORE_VERSION),
             '--password={}'.format(user_password)]
     return subprocess.call(args, cwd=os.getcwd(), timeout=PROCESS_CALL_TIMEOUT)
 
@@ -3578,7 +3585,8 @@ class TestAcraRotate(TestAcraRotateWithZone):
                 ['./acra-keymaker',
                  '--client_id={}'.format(client_id),
                  '--keys_output_dir={}'.format(keys_folder),
-                 '--keys_public_output_dir={}'.format(keys_folder)],
+                 '--keys_public_output_dir={}'.format(keys_folder),
+                 '--keystore={}'.format(KEYSTORE_VERSION)],
                 cwd=os.getcwd(),
                 timeout=PROCESS_CALL_TIMEOUT).decode('utf-8')
             # create acrastructs with this client_id
@@ -4311,12 +4319,16 @@ class TestOutdatedServiceConfigs(BaseTestCase, FailedRunProcessMixin):
                                    'args': ['-keys_dir={}'.format(KEYS_FOLDER.name)],
                                    'status': 1},
                 'acra-keymaker': ['-keys_output_dir={}'.format(tmp_dir),
-                                  '-keys_public_output_dir={}'.format(tmp_dir)],
+                                  '-keys_public_output_dir={}'.format(tmp_dir),
+                                  '--keystore={}'.format(KEYSTORE_VERSION)],
                 'acra-migrate-keys': ['--dry_run', '--src_keys_dir={}'.format(KEYS_FOLDER.name)],
-                'acra-poisonrecordmaker': ['-keys_dir={}'.format(tmp_dir)],
-                'acra-rollback': {'args': ['-keys_dir={}'.format(tmp_dir)],
+                'acra-poisonrecordmaker': ['-keys_dir={}'.format(tmp_dir),
+                                           '--keystore={}'.format(KEYSTORE_VERSION)],
+                'acra-rollback': {'args': ['-keys_dir={}'.format(tmp_dir),
+                                           '--keystore={}'.format(KEYSTORE_VERSION)],
                                   'status': 1},
-                'acra-rotate': {'args': ['-keys_dir={}'.format(tmp_dir)],
+                'acra-rotate': {'args': ['-keys_dir={}'.format(tmp_dir),
+                                         '--keystore={}'.format(KEYSTORE_VERSION)],
                                 'status': 0},
                 'acra-translator': {'connection': 'connection_string',
                                    'args': ['-keys_dir={}'.format(KEYS_FOLDER.name),
@@ -4357,12 +4369,16 @@ class TestOutdatedServiceConfigs(BaseTestCase, FailedRunProcessMixin):
                                    'args': ['-keys_dir={}'.format(KEYS_FOLDER.name)],
                                    'status': 1},
                 'acra-keymaker': ['-keys_output_dir={}'.format(tmp_dir),
-                                  '-keys_public_output_dir={}'.format(tmp_dir)],
+                                  '-keys_public_output_dir={}'.format(tmp_dir),
+                                  '--keystore={}'.format(KEYSTORE_VERSION)],
                 'acra-migrate-keys': ['--dry_run', '--src_keys_dir={}'.format(KEYS_FOLDER.name)],
-                'acra-poisonrecordmaker': ['-keys_dir={}'.format(tmp_dir)],
-                'acra-rollback': {'args': ['-keys_dir={}'.format(tmp_dir)],
+                'acra-poisonrecordmaker': ['-keys_dir={}'.format(tmp_dir),
+                                           '--keystore={}'.format(KEYSTORE_VERSION)],
+                'acra-rollback': {'args': ['-keys_dir={}'.format(tmp_dir),
+                                           '--keystore={}'.format(KEYSTORE_VERSION)],
                                   'status': 1},
-                'acra-rotate': {'args': ['-keys_dir={}'.format(tmp_dir)],
+                'acra-rotate': {'args': ['-keys_dir={}'.format(tmp_dir),
+                                         '--keystore={}'.format(KEYSTORE_VERSION)],
                                 'status': 0},
                 'acra-translator': {'connection': 'connection_string',
                                     'args': ['-keys_dir={}'.format(KEYS_FOLDER.name),

--- a/tests/test.py
+++ b/tests/test.py
@@ -59,6 +59,7 @@ from sqlalchemy.dialects import postgresql as postgresql_dialect
 
 from utils import (read_storage_public_key, read_storage_private_key,
                    read_zone_public_key, read_zone_private_key,
+                   read_poison_public_key, read_poison_private_key,
                    decrypt_acrastruct,
                    load_random_data_config, get_random_data_files,
                    clean_test_data, safe_string, prepare_encryptor_config,
@@ -1109,31 +1110,52 @@ class BaseTestCase(PrometheusMixin, unittest.TestCase):
         send_signal_by_process_name('acra-server', signal.SIGKILL)
         send_signal_by_process_name('acra-connector', signal.SIGKILL)
 
-    def log(self, acra_key_name, data, expected):
+    def log(self, data, expected=b'<no expected value>',
+            storage_client_id=None, zone_id=None,
+            poison_key=False):
         """this function for printing data which used in test and for
         reproducing error with them if any error detected"""
         if not self.TEST_DATA_LOG:
             return
-        with open('{}/{}_zone'.format(KEYS_FOLDER.name, zones[0][ZONE_ID]), 'rb') as f:
-            zone_private = f.read()
-        with open('{}/{}'.format(KEYS_FOLDER.name, acra_key_name), 'rb') as f:
-            private_key = f.read()
-        with open('{}/{}.pub'.format(KEYS_FOLDER.name, acra_key_name), 'rb') as f:
-            public_key = f.read()
-        logging.debug("test log: {}".format(json.dumps(
-            {
-                'master_keys': get_master_keys(),
-                'key_name': acra_key_name,
-                'private_key': b64encode(private_key).decode('ascii'),
-                'public_key': b64encode(public_key).decode('ascii'),
-                'data': b64encode(data).decode('ascii'),
-                'expected': b64encode(expected).decode('ascii'),
-                'zone_private': b64encode(zone_private).decode('ascii'),
-                'zone_public': zones[0][ZONE_PUBLIC_KEY],
-                'zone_id': zones[0][ZONE_ID],
-                'poison_record': b64encode(get_poison_record()).decode('ascii'),
-            }
-        )))
+
+        def key_name():
+            if storage_client_id:
+                return 'client storage, id={}'.format(storage_client_id)
+            elif zone_id:
+                return 'zone storage, id={}'.format(zone_id)
+            elif poison_key:
+                return 'poison record key'
+            else:
+                return 'unknown'
+
+        log_entry = {
+            'master_keys': get_master_keys(),
+            'key_name': key_name(),
+            'data': b64encode(data).decode('ascii'),
+            'expected': b64encode(expected).decode('ascii'),
+        }
+
+        if storage_client_id:
+            public_key = read_storage_public_key(storage_client_id, KEYS_FOLDER.name)
+            private_key = read_storage_private_key(KEYS_FOLDER.name, storage_client_id)
+            log_entry['public_key'] = b64encode(public_key).decode('ascii')
+            log_entry['private_key'] = b64encode(private_key).decode('ascii')
+
+        if zone_id:
+            public_key = read_zone_public_key(storage_client_id, KEYS_FOLDER.name)
+            private_key = read_zone_private_key(KEYS_FOLDER.name, storage_client_id)
+            log_entry['zone_public'] = b64encode(public_key).decode('ascii')
+            log_entry['zone_private'] = b64encode(private_key).decode('ascii')
+            log_entry['zone_id'] = zone_id
+
+        if poison_key:
+            public_key = read_poison_public_key(KEYS_FOLDER.name)
+            private_key = read_poison_private_key(KEYS_FOLDER.name)
+            log_entry['public_key'] = b64encode(public_key).decode('ascii')
+            log_entry['private_key'] = b64encode(private_key).decode('ascii')
+            log_entry['poison_record'] = b64encode(get_poison_record()).decode('ascii')
+
+        logging.debug("test log: {}".format(json.dumps(log_entry)))
 
 
 class HexFormatTest(BaseTestCase):
@@ -1141,14 +1163,15 @@ class HexFormatTest(BaseTestCase):
     def testConnectorRead(self):
         """test decrypting with correct acra-connector and not decrypting with
         incorrect acra-connector or using direct connection to db"""
-        keyname = 'keypair1_storage'
-        server_public1 = read_storage_public_key('keypair1', KEYS_FOLDER.name)
+        client_id = 'keypair1'
+        server_public1 = read_storage_public_key(client_id, KEYS_FOLDER.name)
         data = get_pregenerated_random_data()
         acra_struct = create_acrastruct(
             data.encode('ascii'), server_public1)
         row_id = get_random_id()
 
-        self.log(keyname, acra_struct, data.encode('ascii'))
+        self.log(storage_client_id=client_id,
+                 data=acra_struct, expected=data.encode('ascii'))
 
         self.engine1.execute(
             test_table.insert(),
@@ -1179,8 +1202,8 @@ class HexFormatTest(BaseTestCase):
     def testReadAcrastructInAcrastruct(self):
         """test correct decrypting acrastruct when acrastruct concatenated to
         partial another acrastruct"""
-        keyname = 'keypair1_storage'
-        server_public1 = read_storage_public_key('keypair1', KEYS_FOLDER.name)
+        client_id = 'keypair1'
+        server_public1 = read_storage_public_key(client_id, KEYS_FOLDER.name)
         incorrect_data = get_pregenerated_random_data()
         correct_data = get_pregenerated_random_data()
         suffix_data = get_pregenerated_random_data()[:10]
@@ -1193,7 +1216,9 @@ class HexFormatTest(BaseTestCase):
         correct_data = correct_data + suffix_data
         row_id = get_random_id()
 
-        self.log(keyname, data, fake_acra_struct+correct_data.encode('ascii'))
+        self.log(storage_client_id=client_id,
+                 data=data,
+                 expected=fake_acra_struct+correct_data.encode('ascii'))
 
         self.engine1.execute(
             test_table.insert(),
@@ -1379,7 +1404,8 @@ class ZoneHexFormatTest(BaseTestCase):
             data.encode('ascii'), zone_public,
             context=zones[0][ZONE_ID].encode('ascii'))
         row_id = get_random_id()
-        self.log(zones[0][ZONE_ID]+'_zone', acra_struct, data.encode('ascii'))
+        self.log(zone_id=zones[0][ZONE_ID],
+                 data=acra_struct, expected=data.encode('ascii'))
         self.engine1.execute(
             test_table.insert(),
             {'id': row_id, 'data': acra_struct, 'raw_data': data})
@@ -1413,7 +1439,9 @@ class ZoneHexFormatTest(BaseTestCase):
             correct_data.encode('ascii'), zone_public, context=zones[0][ZONE_ID].encode('ascii'))
         data = fake_acra_struct + inner_acra_struct + suffix_data.encode('ascii')
         correct_data = correct_data + suffix_data
-        self.log(zones[0][ZONE_ID]+'_zone', data, fake_acra_struct+correct_data.encode('ascii'))
+        self.log(zone_id=zones[0][ZONE_ID],
+                 data=data,
+                 expected=fake_acra_struct+correct_data.encode('ascii'))
         row_id = get_random_id()
         self.engine1.execute(
             test_table.insert(),
@@ -1786,8 +1814,7 @@ class BasePoisonRecordTest(BaseTestCase):
     def setUp(self):
         super(BasePoisonRecordTest, self).setUp()
         try:
-            self.log(POISON_KEY_PATH, get_poison_record(),
-                     b'no matter because poison record')
+            self.log(poison_key=True, data=get_poison_record())
         except:
             self.tearDown()
             raise
@@ -1957,7 +1984,7 @@ class TestShutdownPoisonRecordWithZone(TestPoisonRecordShutdown):
         begin_tag = poison_record[:4]
         # test with extra long begin tag
         data = os.urandom(100) + begin_tag + poison_record + os.urandom(100)
-        self.log(POISON_KEY_PATH, data, data)
+        self.log(poison_key=True, data=data, expected=data)
         self.engine1.execute(
             test_table.insert(),
             {'id': row_id, 'data': data, 'raw_data': 'poison_record'})
@@ -2025,7 +2052,7 @@ class TestShutdownPoisonRecordWithZoneOffStatus(TestPoisonRecordShutdown):
         begin_tag = poison_record[:4]
         # test with extra long begin tag
         testData = os.urandom(100) + begin_tag + poison_record + os.urandom(100)
-        self.log(POISON_KEY_PATH, testData, testData)
+        self.log(poison_key=True, data=testData, expected=testData)
         self.engine1.execute(
             test_table.insert(),
             {'id': row_id, 'data': testData, 'raw_data': 'poison_record'})
@@ -2828,14 +2855,15 @@ class BasePrepareStatementMixin:
     def testConnectorRead(self):
         """test decrypting with correct acra-connector and not decrypting with
         incorrect acra-connector or using direct connection to db"""
-        keyname = 'keypair1_storage'
-        server_public1 = read_storage_public_key('keypair1', KEYS_FOLDER.name)
+        client_id = 'keypair1'
+        server_public1 = read_storage_public_key(client_id, KEYS_FOLDER.name)
         data = get_pregenerated_random_data()
         acra_struct = create_acrastruct(
             data.encode('ascii'), server_public1)
         row_id = get_random_id()
 
-        self.log(keyname, acra_struct, data.encode('ascii'))
+        self.log(storage_client_id=client_id,
+                 data=acra_struct, expected=data.encode('ascii'))
 
         self.engine1.execute(
             test_table.insert(),
@@ -2866,8 +2894,8 @@ class BasePrepareStatementMixin:
     def testReadAcrastructInAcrastruct(self):
         """test correct decrypting acrastruct when acrastruct concatenated to
         partial another acrastruct"""
-        keyname = 'keypair1_storage'
-        server_public1 = read_storage_public_key('keypair1', KEYS_FOLDER.name)
+        client_id = 'keypair1'
+        server_public1 = read_storage_public_key(client_id, KEYS_FOLDER.name)
         incorrect_data = get_pregenerated_random_data()
         correct_data = get_pregenerated_random_data()
         suffix_data = get_pregenerated_random_data()[:10]
@@ -2880,7 +2908,9 @@ class BasePrepareStatementMixin:
         correct_data = correct_data + suffix_data
         row_id = get_random_id()
 
-        self.log(keyname, data, fake_acra_struct+correct_data.encode('ascii'))
+        self.log(storage_client_id=client_id,
+                 data=data,
+                 expected=fake_acra_struct+correct_data.encode('ascii'))
 
         self.engine1.execute(
             test_table.insert(),

--- a/tests/test.py
+++ b/tests/test.py
@@ -732,26 +732,35 @@ class Psycopg2Executor(QueryExecutor):
 
 class KeyMakerTest(unittest.TestCase):
     def test_key_length(self):
-        with tempfile.TemporaryDirectory() as folder:
-            key_size = 32
-            short_key = b64encode((key_size - 1)*b'a')
-            standard_key = b64encode(key_size * b'a')
-            long_key = b64encode((key_size * 2) * b'a')
+        key_size = 32
+        short_key = b64encode((key_size - 1)*b'a')
+        short_master_keys = {var: short_key for var in get_master_keys().keys()}
+        standard_key = b64encode(key_size * b'a')
+        standard_master_keys = {var: standard_key for var in get_master_keys().keys()}
+        long_key = b64encode((key_size * 2) * b'a')
+        long_master_keys = {var: long_key for var in get_master_keys().keys()}
 
+        with tempfile.TemporaryDirectory() as folder:
             with self.assertRaises(subprocess.CalledProcessError) as exc:
                 subprocess.check_output(
-                    ['./acra-keymaker', '--keys_output_dir={}'.format(folder),
+                    ['./acra-keymaker', '--keystore={}'.format(KEYSTORE_VERSION),
+                     '--keys_output_dir={}'.format(folder),
                      '--keys_public_output_dir={}'.format(folder)],
-                    env={'ACRA_MASTER_KEY': short_key})
+                    env=short_master_keys)
 
+        with tempfile.TemporaryDirectory() as folder:
             subprocess.check_output(
-                    ['./acra-keymaker', '--keys_output_dir={}'.format(folder),
+                    ['./acra-keymaker', '--keystore={}'.format(KEYSTORE_VERSION),
+                     '--keys_output_dir={}'.format(folder),
                      '--keys_public_output_dir={}'.format(folder)],
-                    env={'ACRA_MASTER_KEY': standard_key})
+                    env=standard_master_keys)
+
+        with tempfile.TemporaryDirectory() as folder:
             subprocess.check_output(
-                    ['./acra-keymaker', '--keys_output_dir={}'.format(folder),
+                    ['./acra-keymaker', '--keystore={}'.format(KEYSTORE_VERSION),
+                     '--keys_output_dir={}'.format(folder),
                      '--keys_public_output_dir={}'.format(folder)],
-                    env={'ACRA_MASTER_KEY': long_key})
+                    env=long_master_keys)
 
 
 class PrometheusMixin(object):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -104,14 +104,23 @@ def load_default_config(service_name):
     return config
 
 
+def read_key(kind, client_id=None, zone_id=None, keys_dir='.acrakeys'):
+    """Reads key from Key Store with read-key utility."""
+    args = ['./acra-read-key', '--key={}'.format(kind),
+        '--keys_dir={}'.format(keys_dir)]
+    if client_id is not None:
+        args.append('--client_id={}'.format(client_id))
+    if zone_id is not None:
+        args.append('--zone_id={}'.format(zone_id))
+    return subprocess.check_output(args)
+
+
 def read_storage_public_key(client_id, keys_dir='.acrakeys'):
-    with open(abs_path('{}/{}_storage.pub'.format(keys_dir, client_id)), 'rb') as f:
-            return f.read()
+    return read_key('storage-public', client_id=client_id, keys_dir=keys_dir)
 
 
 def read_zone_public_key(zone_id, keys_dir='.acrakeys'):
-    with open(abs_path('{}/{}_zone.pub'.format(keys_dir, zone_id)), 'rb') as f:
-        return f.read()
+    return read_key('zone-public', zone_id=zone_id, keys_dir=keys_dir)
 
 
 def decrypt_acrastruct(data, private_key, client_id=None, zone_id=None):
@@ -130,14 +139,12 @@ def decrypt_private_key(private_key, key_id, master_key):
     return scell.SCellSeal(master_key).decrypt(private_key, key_id)
 
 
-def read_storage_private_key(keys_folder, key_id, master_key_b64):
-    with open(os.path.join(keys_folder, '{}_storage'.format(key_id)), 'rb') as f:
-        return decrypt_private_key(f.read(), key_id.encode("ascii"), b64decode(master_key_b64))
+def read_storage_private_key(keys_folder, key_id):
+    return read_key('storage-private', client_id=key_id, keys_dir=keys_folder)
 
 
-def read_zone_private_key(keys_folder, key_id, master_key_b64):
-    with open(os.path.join(keys_folder, '{}_zone'.format(key_id)), 'rb') as f:
-        return decrypt_private_key(f.read(), key_id.encode("ascii"), b64decode(master_key_b64))
+def read_zone_private_key(keys_folder, key_id):
+    return read_key('zone-private', zone_id=key_id, keys_dir=keys_folder)
 
 
 def prepare_encryptor_config(zone_id, config_path):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -135,10 +135,6 @@ def decrypt_acrastruct(data, private_key, client_id=None, zone_id=None):
         return scell.SCellSeal(symmetric).decrypt(encrypted_data)
 
 
-def decrypt_private_key(private_key, key_id, master_key):
-    return scell.SCellSeal(master_key).decrypt(private_key, key_id)
-
-
 def read_storage_private_key(keys_folder, key_id):
     return read_key('storage-private', client_id=key_id, keys_dir=keys_folder)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -143,6 +143,14 @@ def read_zone_private_key(keys_folder, key_id):
     return read_key('zone-private', zone_id=key_id, keys_dir=keys_folder)
 
 
+def read_poison_public_key(keys_dir):
+    return read_key('poison-public', keys_dir=keys_dir)
+
+
+def read_poison_private_key(keys_dir):
+    return read_key('poison-private', keys_dir=keys_dir)
+
+
 def prepare_encryptor_config(zone_id, config_path):
     with open(config_path, 'r') as f:
         config = yaml.safe_load(f)


### PR DESCRIPTION
This patch series teaches CircleCI to run integration test suite with key store v2.

The test suite now reacts to the `TEST_KEYSTORE` environment variable. If it is not set or set to `v1`, the test suite runs with current key store (v1). If that variable is set to `v2`, the tests run with new experimental key store (v2). This is meant for complete integration test suite run from scratch.

The test suite has been too tightly coupled with key store v1, hardwiring the expected environment variables, key store layout and data format, etc. All of this has been abstracted out where necessary. The tests now read keys using a new **acra-read-key** tool, which currently can read storage keys (by client and zone ID) and the poison record key. It somewhat intersects with key export tool, but works with both v1 and v2 and output keys in plaintext. It is intended only for test usage.

There are also multiple minor tweaks in tests to support key store v2. See commit messages for details.

What is lacking and may be improved later:

- Migration v1 → v2 is not tested right now whatsoever. New tests need to be written for this.
- Tests for key removal are currently disabled. Key store v2 does not support that (yet).
- Tests are running only with PostgreSQL. Other jobs pass with v2, but it's inconvenient to run them.