### PR TITLE
Protect key store flock with sync.Mutex

### DIFF
--- a/keystore/v2/keystore/filesystem/backend/api/backend.go
+++ b/keystore/v2/keystore/filesystem/backend/api/backend.go
@@ -56,9 +56,12 @@ type Backend interface {
 	// RLock acquires a shared lock on the store, suitable for reading.
 	// This call blocks until the lock is acquired.
 	RLock() error
-	// Unlock releases the lock currently held by the process.
-	// It is an error to call it without calling Lock() or Unlock() first.
+	// Unlock releases the exclusive lock currently held by the process.
+	// It is an error to call it without calling Lock() first.
 	Unlock() error
+	// RUnlock releases the shared lock currently held by the process.
+	// It is an error to call it without calling RLock() first.
+	RUnlock() error
 
 	// Close this backend instance, freeing any associated resources.
 	// This implicitly unlocks the store if any locks are held.

--- a/keystore/v2/keystore/filesystem/backend/api/tests/backend.go
+++ b/keystore/v2/keystore/filesystem/backend/api/tests/backend.go
@@ -283,14 +283,9 @@ func testLockingExclusive(t *testing.T, newBackend NewBackend) {
 func testLockingShared(t *testing.T, newBackend NewBackend) {
 	b := newBackend(t)
 
-	// We can grab a shared lock multiple times in a row.
 	err := b.RLock()
 	if err != nil {
 		t.Fatalf("A: failed to grab shared lock: %v", err)
-	}
-	err = b.RLock()
-	if err != nil {
-		t.Fatalf("A: failed to grab shared lock again: %v", err)
 	}
 
 	// We can also grab an exclusive lock (in a separate goroutine),
@@ -321,17 +316,7 @@ func testLockingShared(t *testing.T, newBackend NewBackend) {
 		t.Errorf("A: Get() seems to succeed: %v", err)
 	}
 
-	// And even after we have released the lock once, the file does not exist yet.
-	err = b.RUnlock()
-	if err != nil {
-		t.Fatalf("A: failed to release shared lock: %v", err)
-	}
-	_, err = b.Get("a file")
-	if err != api.ErrNotExist {
-		t.Errorf("A: Get() seems to succeed (after Unlock x1): %v", err)
-	}
-
-	// We need to release the lock once more, then wait for the goroutine to complete,
+	// We need to release the lock, then wait for the goroutine to complete,
 	// and only then the file should be visible to us.
 	err = b.RUnlock()
 	if err != nil {

--- a/keystore/v2/keystore/filesystem/backend/api/tests/backend.go
+++ b/keystore/v2/keystore/filesystem/backend/api/tests/backend.go
@@ -322,7 +322,7 @@ func testLockingShared(t *testing.T, newBackend NewBackend) {
 	}
 
 	// And even after we have released the lock once, the file does not exist yet.
-	err = b.Unlock()
+	err = b.RUnlock()
 	if err != nil {
 		t.Fatalf("A: failed to release shared lock: %v", err)
 	}
@@ -333,7 +333,7 @@ func testLockingShared(t *testing.T, newBackend NewBackend) {
 
 	// We need to release the lock once more, then wait for the goroutine to complete,
 	// and only then the file should be visible to us.
-	err = b.Unlock()
+	err = b.RUnlock()
 	if err != nil {
 		t.Fatalf("A: failed to release shared lock: %v", err)
 	}

--- a/keystore/v2/keystore/filesystem/backend/file_lock.go
+++ b/keystore/v2/keystore/filesystem/backend/file_lock.go
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2020, Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package backend
+
+import (
+	"os"
+	"sync"
+	"syscall"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// fileLock is an interprocess read-write lock that serializes access to filesystem.
+//
+// This lock is implemented with BSD flock(2) and has corresponding semantics.
+//
+// Note that this is an advisory lock. That is, this lock can be used to guard
+// access to some filesystem resource by cooperating processes, but it does not
+// guarantee correct serialization of filesystem accesses by itself.
+//
+// Also note that flock(2) has subtly different semantics from POSIX record locks
+// created by fcntl(2). Read corresponding system manual pages for details.
+type fileLock struct {
+	lockFile *os.File
+	path     string
+	// Here's a thing: BSD file locks are per-process. That is, they are shared
+	// between threads like fds. Furthermore, they can be 'transparently'
+	// upgraded: if the process holds a shared lock and grabs it again as exclusive,
+	// the system will upgrade the lock to exclusive (possibly by releasing and
+	// re-grabbing it). This is not what we want, so keep a regular lock here
+	// to make sure that goroutines are correctly synchronized among themselves.
+	lockSync sync.Mutex
+}
+
+// newFileLock creates a lock anchored at given file path.
+func newFileLock(path string) (*fileLock, error) {
+	lock, err := os.Create(path)
+	if err != nil {
+		return nil, err
+	}
+	return &fileLock{lockFile: lock, path: path}, nil
+}
+
+// Close the lock. This releases the lock if it is held.
+func (l *fileLock) Close() error {
+	return l.lockFile.Close()
+}
+
+// We need to juggle *two* locks here -- the mutex and the file lock -- and
+// this is hard. So hard that we are using a regular sync.Mutex here rather
+// than seemingly more natural sync.RWMutex. Lock contention within the
+// process should be fairly minimal, and different processes still use the
+// read-write semantics, so it's okay.
+//
+// The reason for this complexity is that unlocking the flock can fail and
+// this leaves the flock in a broken state for this process. We still unlock
+// the local mutex to prevent the deadlock, but the flock is placed into
+// a special "poisoned" state. We will (try to) recover from the poisoned
+// state the next time the lock is grabbed.
+//
+// Checking for poisoning needs only a read lock, but poisoning and recovery
+// require write lock to be held. This means that we might need a write lock
+// when the user call RLock(). Upgrading and downgrading sync.RWMutex is hard
+// to do correctly so we go with a simple synx.Mutex instead.
+
+func (l *fileLock) isPoisoned() bool {
+	return l.lockFile == nil
+}
+
+func (l *fileLock) poisonLock(reason error) {
+	log := log.WithField("path", l.path)
+	log.WithError(reason).Warn("Poisoning lock")
+	err := l.lockFile.Close()
+	if err != nil {
+		// We can't do much about an error here and we can't use the file anymore.
+		log.WithError(err).Warn("Failed to close poisoned lock")
+	}
+	l.lockFile = nil
+}
+
+func (l *fileLock) recoverLock() error {
+	log.WithField("path", l.path).Warn("Recovering poisoned lock")
+	newLockFile, err := os.Create(l.path)
+	if err != nil {
+		return err
+	}
+	l.lockFile = newLockFile
+	return nil
+}
+
+func (l *fileLock) Lock() error {
+	l.lockSync.Lock()
+	if l.isPoisoned() {
+		err := l.recoverLock()
+		if err != nil {
+			l.lockSync.Unlock()
+			return err
+		}
+	}
+	err := syscall.Flock(int(l.lockFile.Fd()), syscall.LOCK_EX)
+	if err != nil {
+		l.lockSync.Unlock()
+		return err
+	}
+	return nil
+}
+
+func (l *fileLock) Unlock() error {
+	defer l.lockSync.Unlock()
+	err := syscall.Flock(int(l.lockFile.Fd()), syscall.LOCK_UN)
+	if err != nil {
+		l.poisonLock(err)
+		return err
+	}
+	return nil
+}
+
+func (l *fileLock) RLock() error {
+	l.lockSync.Lock()
+	if l.isPoisoned() {
+		err := l.recoverLock()
+		if err != nil {
+			l.lockSync.Unlock()
+			return err
+		}
+	}
+	err := syscall.Flock(int(l.lockFile.Fd()), syscall.LOCK_SH)
+	if err != nil {
+		l.lockSync.Unlock()
+		return err
+	}
+	return nil
+}
+
+func (l *fileLock) RUnlock() error {
+	defer l.lockSync.Unlock()
+	err := syscall.Flock(int(l.lockFile.Fd()), syscall.LOCK_UN)
+	if err != nil {
+		l.poisonLock(err)
+		return err
+	}
+	return nil
+}

--- a/keystore/v2/keystore/filesystem/backend/filesystem.go
+++ b/keystore/v2/keystore/filesystem/backend/filesystem.go
@@ -22,7 +22,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
 
 	"github.com/cossacklabs/acra/keystore/v2/keystore/filesystem/backend/api"
 	log "github.com/sirupsen/logrus"
@@ -50,7 +49,7 @@ var (
 type DirectoryBackend struct {
 	root string
 	log  *log.Entry
-	lock *os.File
+	lock *fileLock
 }
 
 const (
@@ -104,7 +103,7 @@ func CreateDirectoryBackend(root string) (*DirectoryBackend, error) {
 		errLog.WithError(err).Debug("failed to create version file")
 		return nil, err
 	}
-	lock, err := os.Create(filepath.Join(root, lockFile))
+	lock, err := newFileLock(filepath.Join(root, lockFile))
 	if err != nil {
 		errLog.WithError(err).Debug("failed to create lock file")
 		return nil, err
@@ -154,7 +153,7 @@ func OpenDirectoryBackend(root string) (*DirectoryBackend, error) {
 		errLog.WithError(err).Debug("not a key store")
 		return nil, err
 	}
-	lock, err := os.Create(filepath.Join(root, lockFile))
+	lock, err := newFileLock(filepath.Join(root, lockFile))
 	if err != nil {
 		errLog.WithError(err).Debug("failed to create lock file")
 		return nil, err
@@ -252,17 +251,22 @@ func (b *DirectoryBackend) osPath(path string) (string, error) {
 
 // Lock acquires an exclusive lock on the store.
 func (b *DirectoryBackend) Lock() error {
-	return syscall.Flock(int(b.lock.Fd()), syscall.LOCK_EX)
+	return b.lock.Lock()
+}
+
+// Unlock releases currently held exclusive lock.
+func (b *DirectoryBackend) Unlock() error {
+	return b.lock.Unlock()
 }
 
 // RLock acquires a shared lock on the store.
 func (b *DirectoryBackend) RLock() error {
-	return syscall.Flock(int(b.lock.Fd()), syscall.LOCK_SH)
+	return b.lock.RLock()
 }
 
-// Unlock releases currently held lock.
-func (b *DirectoryBackend) Unlock() error {
-	return syscall.Flock(int(b.lock.Fd()), syscall.LOCK_UN)
+// RUnlock releases currently held shared lock.
+func (b *DirectoryBackend) RUnlock() error {
+	return b.lock.RUnlock()
 }
 
 // Get data at given path.

--- a/keystore/v2/keystore/filesystem/backend/memory.go
+++ b/keystore/v2/keystore/filesystem/backend/memory.go
@@ -27,7 +27,6 @@ import (
 type InMemory struct {
 	storage map[string][]byte
 	lock    sync.RWMutex
-	read    bool
 }
 
 // NewInMemory makes a new empty in-memory backend.
@@ -40,24 +39,24 @@ func NewInMemory() *InMemory {
 // Lock acquires an exclusive lock on the store.
 func (m *InMemory) Lock() error {
 	m.lock.Lock()
-	m.read = false
+	return nil
+}
+
+// Unlock releases currently held exclusive lock.
+func (m *InMemory) Unlock() error {
+	m.lock.Unlock()
 	return nil
 }
 
 // RLock acquires a shared lock on the store.
 func (m *InMemory) RLock() error {
 	m.lock.RLock()
-	m.read = true
 	return nil
 }
 
-// Unlock releases currently held lock.
-func (m *InMemory) Unlock() error {
-	if m.read {
-		m.lock.RUnlock()
-	} else {
-		m.lock.Unlock()
-	}
+// RUnlock releases currently held shared lock.
+func (m *InMemory) RUnlock() error {
+	m.lock.RUnlock()
 	return nil
 }
 

--- a/keystore/v2/keystore/filesystem/keyStoreLoad.go
+++ b/keystore/v2/keystore/filesystem/keyStoreLoad.go
@@ -34,7 +34,7 @@ func (s *KeyStore) readKeyRing(ring *KeyRing) (err error) {
 		return err
 	}
 	defer func() {
-		err2 := s.fs.Unlock()
+		err2 := s.fs.RUnlock()
 		if err2 != nil {
 			s.log.WithError(err2).Debug("failed to unlock store")
 			if err == nil {


### PR DESCRIPTION
CI builds for keystore-v2 branch have been intermittently failing on the unit test for key store file locking. It turns out that synchronization is damn hard and I still have not learned how to write it correctly. This PR attempts to solve the issue that caused test failures.

BSD-style flocks are per-process. I have incorrectly assumed that these are "Linux kernel processes" (= per-thread), however this turned out to be incorrect. These locks are per-PID. Furthermore, they are recursive in a weird way: if a process requests a shared lock when holding an exclusive lock (or vice versa), the lock is transformed into the new type in a non-atomic way (that is, the lock is released and re-grabbed). And finally, goroutines do not map directly onto system threads, so even if flocks did work per-thread, this would still be incorrect in Go.

Effectively, this means that we should keep track of whether we have the lock locked and in which way. Add a sync.Mutex which will ensure that at most one goroutine in the process keeps `os.File` locked.

With these changes it does not make sense to have a single Unlock() call to unlock after both Lock() and RLock(). Introduce RUnlock() method that mirrors `sync.RWMutex`.