### PR TITLE
Use key store paths as specified by user [keystore v2]

### DIFF
--- a/keystore/v2/keystore/filesystem/backend/filesystem.go
+++ b/keystore/v2/keystore/filesystem/backend/filesystem.go
@@ -67,12 +67,6 @@ func CreateDirectoryBackend(root string) (*DirectoryBackend, error) {
 		"subsystem": directorySubsystemName,
 	})
 	errLog := newLog.WithField("path", root)
-	// Make sure the root directory stays the same even if somene changes current directory.
-	root, err := filepath.Abs(root)
-	if err != nil {
-		errLog.WithError(err).Debug("failed to get absolute root key directory")
-		return nil, err
-	}
 	fi, err := os.Stat(root)
 	if err == nil {
 		if !fi.IsDir() {
@@ -123,12 +117,6 @@ func OpenDirectoryBackend(root string) (*DirectoryBackend, error) {
 		"subsystem": directorySubsystemName,
 	})
 	errLog := newLog.WithField("path", root)
-	// Make sure the root directory stays the same even if somene changes current directory.
-	root, err := filepath.Abs(root)
-	if err != nil {
-		errLog.WithError(err).Debug("failed to get absolute root key directory")
-		return nil, err
-	}
 	fi, err := os.Stat(root)
 	if err != nil {
 		errLog.WithError(err).Debug("failed to stat root key directory")


### PR DESCRIPTION
Similar change to master: https://github.com/cossacklabs/acra/pull/367

This works for (real) filesystem key stores but may cause compatibility issues with other key-value backends if the filesystem path somehow make it to the "key" values. This can make keys inaccessible and locked into whatever absolute path was used during key generation. Remove this "fix" before the feature lands into master.

This updates only v2-specific additions. We'll pull fixes from master later.