### PR TITLE
Forbid v2 master keys to be the same

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -733,12 +733,10 @@ class Psycopg2Executor(QueryExecutor):
 class KeyMakerTest(unittest.TestCase):
     def test_key_length(self):
         key_size = 32
-        short_key = b64encode((key_size - 1)*b'a')
-        short_master_keys = {var: short_key for var in get_master_keys().keys()}
-        standard_key = b64encode(key_size * b'a')
-        standard_master_keys = {var: standard_key for var in get_master_keys().keys()}
-        long_key = b64encode((key_size * 2) * b'a')
-        long_master_keys = {var: long_key for var in get_master_keys().keys()}
+
+        def random_keys(size):
+            return {var: b64encode(os.urandom(size))
+                    for var in get_master_keys().keys()}
 
         with tempfile.TemporaryDirectory() as folder:
             with self.assertRaises(subprocess.CalledProcessError) as exc:
@@ -746,21 +744,21 @@ class KeyMakerTest(unittest.TestCase):
                     ['./acra-keymaker', '--keystore={}'.format(KEYSTORE_VERSION),
                      '--keys_output_dir={}'.format(folder),
                      '--keys_public_output_dir={}'.format(folder)],
-                    env=short_master_keys)
+                    env=random_keys(key_size - 1))
 
         with tempfile.TemporaryDirectory() as folder:
             subprocess.check_output(
                     ['./acra-keymaker', '--keystore={}'.format(KEYSTORE_VERSION),
                      '--keys_output_dir={}'.format(folder),
                      '--keys_public_output_dir={}'.format(folder)],
-                    env=standard_master_keys)
+                    env=random_keys(key_size))
 
         with tempfile.TemporaryDirectory() as folder:
             subprocess.check_output(
                     ['./acra-keymaker', '--keystore={}'.format(KEYSTORE_VERSION),
                      '--keys_output_dir={}'.format(folder),
                      '--keys_public_output_dir={}'.format(folder)],
-                    env=long_master_keys)
+                    env=random_keys(key_size * 2))
 
 
 class PrometheusMixin(object):


### PR DESCRIPTION
Keys should not be reused for multiple purposes, that's why key store v2 uses two distinct keys: one for encrypting private key data, and one for signing all key store data. Let's detect configuration errors and refuse to create or open a key store if both keys are the same.

Since the key store does not have direct access to the keys and cannot check for that, the only place where we can still do it is when the keys are retrieved from the environment. This also gives us a chance to point out to the user what exactly is wrong with the environment.