### PR TITLE
Technical changes in logging customization

### DIFF
--- a/cmd/acra-connector/acra-connector.go
+++ b/cmd/acra-connector/acra-connector.go
@@ -209,8 +209,6 @@ type Config struct {
 }
 
 func main() {
-	log.WithField("version", utils.VERSION).Infof("Starting service %v [pid=%v]", ServiceName, os.Getpid())
-
 	loggingFormat := flag.String("logging_format", "plaintext", "Logging format: plaintext, json or CEF")
 	keysDir := flag.String("keys_dir", keystore.DefaultKeyDirShort, "Folder from which will be loaded keys")
 	clientID := flag.String("client_id", "", "Client ID")
@@ -255,7 +253,11 @@ func main() {
 		os.Exit(1)
 	}
 
-	logging.Customize().SetFormat(*loggingFormat).SetServiceName(ServiceName).Complete()
+	// Start customizing logs here (directly after command line arguments parsing)
+	formatter := logging.CreateFormatter(*loggingFormat)
+	logging.SetServiceName(formatter, ServiceName)
+
+	log.WithField("version", utils.VERSION).Infof("Starting service %v [pid=%v]", ServiceName, os.Getpid())
 	log.Infof("Validating service configuration...")
 
 	if err = checkDependencies(); err != nil {

--- a/cmd/acra-connector/acra-connector.go
+++ b/cmd/acra-connector/acra-connector.go
@@ -255,7 +255,7 @@ func main() {
 
 	// Start customizing logs here (directly after command line arguments parsing)
 	formatter := logging.CreateFormatter(*loggingFormat)
-	logging.SetServiceName(formatter, ServiceName)
+	formatter.SetServiceName(ServiceName)
 	log.SetOutput(os.Stderr)
 
 	log.WithField("version", utils.VERSION).Infof("Starting service %v [pid=%v]", ServiceName, os.Getpid())

--- a/cmd/acra-connector/acra-connector.go
+++ b/cmd/acra-connector/acra-connector.go
@@ -256,6 +256,7 @@ func main() {
 	// Start customizing logs here (directly after command line arguments parsing)
 	formatter := logging.CreateFormatter(*loggingFormat)
 	logging.SetServiceName(formatter, ServiceName)
+	log.SetOutput(os.Stderr)
 
 	log.WithField("version", utils.VERSION).Infof("Starting service %v [pid=%v]", ServiceName, os.Getpid())
 	log.Infof("Validating service configuration...")

--- a/cmd/acra-server/acra-server.go
+++ b/cmd/acra-server/acra-server.go
@@ -139,7 +139,7 @@ func main() {
 
 	// Start customizing logs here (directly after command line arguments parsing)
 	formatter := logging.CreateFormatter(*loggingFormat)
-	logging.SetServiceName(formatter, ServiceName)
+	formatter.SetServiceName(ServiceName)
 	log.SetOutput(os.Stderr)
 
 	log.WithField("version", utils.VERSION).Infof("Starting service %v [pid=%v]", ServiceName, os.Getpid())

--- a/cmd/acra-server/acra-server.go
+++ b/cmd/acra-server/acra-server.go
@@ -76,8 +76,6 @@ var ErrWaitTimeout = errors.New("timeout")
 
 func main() {
 	loggingFormat := flag.String("logging_format", "plaintext", "Logging format: plaintext, json or CEF")
-	log.WithField("version", utils.VERSION).Infof("Starting service %v [pid=%v]", ServiceName, os.Getpid())
-
 	dbHost := flag.String("db_host", "", "Host to db")
 	dbPort := flag.Int("db_port", 5432, "Port to db")
 
@@ -139,7 +137,12 @@ func main() {
 		os.Exit(1)
 	}
 
-	logging.Customize().SetFormat(*loggingFormat).SetServiceName(ServiceName).Complete()
+	// Start customizing logs here (directly after command line arguments parsing)
+	formatter := logging.CreateFormatter(*loggingFormat)
+	logging.SetServiceName(formatter, ServiceName)
+	log.SetOutput(os.Stderr)
+
+	log.WithField("version", utils.VERSION).Infof("Starting service %v [pid=%v]", ServiceName, os.Getpid())
 
 	config, err := NewConfig()
 	if err != nil {

--- a/cmd/acra-translator/acra-translator.go
+++ b/cmd/acra-translator/acra-translator.go
@@ -88,6 +88,7 @@ func main() {
 	logging.SetServiceName(formatter, ServiceName)
 	log.SetOutput(os.Stderr)
 
+	log.WithField("version", utils.VERSION).Infof("Starting service %v [pid=%v]", ServiceName, os.Getpid())
 	log.Infof("Validating service configuration...")
 	cmd.ValidateClientID(*secureSessionID)
 

--- a/cmd/acra-translator/acra-translator.go
+++ b/cmd/acra-translator/acra-translator.go
@@ -83,7 +83,10 @@ func main() {
 		os.Exit(1)
 	}
 
-	logging.Customize().SetFormat(*loggingFormat).SetServiceName(ServiceName).Complete()
+	// Start customizing logs here (directly after command line arguments parsing)
+	formatter := logging.CreateFormatter(*loggingFormat)
+	logging.SetServiceName(formatter, ServiceName)
+	log.SetOutput(os.Stderr)
 
 	log.Infof("Validating service configuration...")
 	cmd.ValidateClientID(*secureSessionID)

--- a/cmd/acra-translator/acra-translator.go
+++ b/cmd/acra-translator/acra-translator.go
@@ -85,7 +85,7 @@ func main() {
 
 	// Start customizing logs here (directly after command line arguments parsing)
 	formatter := logging.CreateFormatter(*loggingFormat)
-	logging.SetServiceName(formatter, ServiceName)
+	formatter.SetServiceName(ServiceName)
 	log.SetOutput(os.Stderr)
 
 	log.WithField("version", utils.VERSION).Infof("Starting service %v [pid=%v]", ServiceName, os.Getpid())

--- a/cmd/acra-webconfig/acra-webconfig.go
+++ b/cmd/acra-webconfig/acra-webconfig.go
@@ -403,7 +403,7 @@ func main() {
 
 	// Start customizing logs here (directly after command line arguments parsing)
 	formatter := logging.CreateFormatter(*loggingFormat)
-	logging.SetServiceName(formatter, ServiceName)
+	formatter.SetServiceName(ServiceName)
 	log.SetOutput(os.Stderr)
 
 	log.Infof("Starting service %v [pid=%v]", ServiceName, os.Getpid())

--- a/cmd/acra-webconfig/acra-webconfig.go
+++ b/cmd/acra-webconfig/acra-webconfig.go
@@ -389,7 +389,6 @@ func main() {
 	host = flag.String("incoming_connection_host", cmd.DefaultWebConfigHost, "Host for AcraWebconfig HTTP endpoint")
 	port = flag.Int("incoming_connection_port", cmd.DefaultWebConfigPort, "Port for AcraWebconfig HTTP endpoint")
 	loggingFormat := flag.String("logging_format", "plaintext", "Logging format: plaintext, json or CEF")
-	log.Infof("Starting service %v [pid=%v]", ServiceName, os.Getpid())
 	destinationHost = flag.String("destination_host", "localhost", "Host for AcraServer HTTP endpoint or AcraConnector")
 	destinationPort = flag.Int("destination_port", cmd.DefaultAcraConnectorAPIPort, "Port for AcraServer HTTP endpoint or AcraConnector")
 	staticPath = flag.String("static_path", cmd.DefaultWebConfigStatic, "Path to static content")
@@ -402,7 +401,12 @@ func main() {
 		os.Exit(1)
 	}
 
-	logging.Customize().SetFormat(*loggingFormat).SetServiceName(ServiceName).Complete()
+	// Start customizing logs here (directly after command line arguments parsing)
+	formatter := logging.CreateFormatter(*loggingFormat)
+	logging.SetServiceName(formatter, ServiceName)
+	log.SetOutput(os.Stderr)
+
+	log.Infof("Starting service %v [pid=%v]", ServiceName, os.Getpid())
 	log.Infof("Validating service configuration")
 
 	if *debug {

--- a/logging/hooks_test.go
+++ b/logging/hooks_test.go
@@ -84,8 +84,8 @@ func demoHooks(t *testing.T) []FormatterHook {
 }
 
 func TestHooksPlaintext(t *testing.T) {
-	f := TextFormatter(demoHooks(t))
-
+	f := TextFormatter()
+	f.SetHooks(demoHooks(t))
 	serialized, err := f.Format(demoLogEntry())
 	if err != nil {
 		t.Errorf("formatting failed: %v", err)
@@ -98,29 +98,31 @@ func TestHooksPlaintext(t *testing.T) {
 }
 
 func TestHooksCEF(t *testing.T) {
-	f := CEFFormatter(log.Fields{"CEF": "yes"}, demoHooks(t))
-
+	f := CEFFormatter()
+	f.SetServiceName("add one more field to cef formatter")
+	f.SetHooks(demoHooks(t))
 	serialized, err := f.Format(demoLogEntry())
 	if err != nil {
 		t.Errorf("formatting failed: %v", err)
 	}
 
 	logLine := strings.TrimSpace(string(serialized))
-	if logLine != `CEF:0|cossacklabs|acra|0.85.0|100|test error please ignore|6|CEF=yes a-field=value A extra=field unixTime=528854399.000 z-field=value Z  (total: 9 fields)` {
+	if logLine != `CEF:0|cossacklabs|add one more field to cef formatter|0.85.0|100|test error please ignore|6|a-field=value A extra=field unixTime=528854399.000 z-field=value Z  (total: 8 fields)` {
 		t.Errorf("incorrect log line: %v", logLine)
 	}
 }
 
 func TestHooksJSON(t *testing.T) {
-	f := JSONFormatter(log.Fields{"JSON": "uh-huh"}, demoHooks(t))
-
+	f := JSONFormatter()
+	f.SetServiceName("add one more field to json formatter")
+	f.SetHooks(demoHooks(t))
 	serialized, err := f.Format(demoLogEntry())
 	if err != nil {
 		t.Errorf("formatting failed: %v", err)
 	}
 
 	logLine := strings.TrimSpace(string(serialized))
-	if logLine != `{"JSON":"uh-huh","a-field":"value A","extra":"field","level":"error","msg":"test error please ignore","product":"acra","timestamp":"1986-10-04T23:59:59Z","unixTime":"528854399.000","version":"0.85.0","z-field":"value Z"} (total: 7 fields)` {
+	if logLine != `{"a-field":"value A","extra":"field","level":"error","msg":"test error please ignore","product":"add one more field to json formatter","timestamp":"1986-10-04T23:59:59Z","unixTime":"528854399.000","version":"0.85.0","z-field":"value Z"} (total: 6 fields)` {
 		t.Errorf("incorrect log line: %v", logLine)
 	}
 }
@@ -132,7 +134,8 @@ func TestHooksWillFail(t *testing.T) {
 			return thisError
 		},
 	}}
-	f := TextFormatter(hooks)
+	f := TextFormatter()
+	f.SetHooks(hooks)
 
 	serialized, err := f.Format(demoLogEntry())
 	if err != thisError {
@@ -147,7 +150,8 @@ func TestHooksDidFail(t *testing.T) {
 			return thisError
 		},
 	}}
-	f := TextFormatter(hooks)
+	f := TextFormatter()
+	f.SetHooks(hooks)
 
 	serialized, err := f.Format(demoLogEntry())
 	if err != thisError {

--- a/logging/log_formatters.go
+++ b/logging/log_formatters.go
@@ -32,7 +32,7 @@ import (
 // ----------
 
 // TextFormatter returns a default logrus.TextFormatter with specific settings
-func TextFormatter() FormatterWrapper {
+func TextFormatter() Formatter {
 	return &AcraTextFormatter{
 		Formatter: &logrus.TextFormatter{
 			FullTimestamp:    true,
@@ -43,7 +43,7 @@ func TextFormatter() FormatterWrapper {
 	}
 }
 
-func JSONFormatter() FormatterWrapper {
+func JSONFormatter() Formatter {
 	return &AcraJSONFormatter{
 		Formatter: &logrus.JSONFormatter{
 			FieldMap:        JSONFieldMap,
@@ -54,7 +54,7 @@ func JSONFormatter() FormatterWrapper {
 	}
 }
 
-func CEFFormatter() FormatterWrapper {
+func CEFFormatter() Formatter {
 	return &AcraCEFFormatter{
 		CEFTextFormatter: CEFTextFormatter{
 			TimestampFormat: time.RFC3339,

--- a/logging/log_formatters.go
+++ b/logging/log_formatters.go
@@ -32,55 +32,35 @@ import (
 // ----------
 
 // TextFormatter returns a default logrus.TextFormatter with specific settings
-func TextFormatter(hooks []FormatterHook) logrus.Formatter {
+func TextFormatter() FormatterWrapper {
 	return &AcraTextFormatter{
 		Formatter: &logrus.TextFormatter{
 			FullTimestamp:    true,
 			TimestampFormat:  time.RFC3339,
 			QuoteEmptyFields: true,
 		},
-		Hooks: hooks,
+		Hooks: nil,
 	}
 }
 
-// JSONFormatter returns a AcraJSONFormatter
-func JSONFormatter(fields logrus.Fields, hooks []FormatterHook) logrus.Formatter {
-	for k, v := range extraJSONFields {
-		if _, ok := fields[k]; !ok {
-			fields[k] = v
-		}
-	}
-
-	return AcraJSONFormatter{
+func JSONFormatter() FormatterWrapper {
+	return &AcraJSONFormatter{
 		Formatter: &logrus.JSONFormatter{
 			FieldMap:        JSONFieldMap,
 			TimestampFormat: time.RFC3339,
 		},
-		Fields: fields,
-		Hooks:  hooks,
+		Hooks:  nil,
+		Fields: nil,
 	}
 }
 
-// CEFFormatter returns a AcraCEFFormatter
-func CEFFormatter(fields logrus.Fields, hooks []FormatterHook) logrus.Formatter {
-	for k, v := range extraJSONFields {
-		if _, ok := fields[k]; !ok {
-			fields[k] = v
-		}
-	}
-
-	for k, v := range extraCEFFields {
-		if _, ok := fields[k]; !ok {
-			fields[k] = v
-		}
-	}
-
+func CEFFormatter() FormatterWrapper {
 	return &AcraCEFFormatter{
 		CEFTextFormatter: CEFTextFormatter{
 			TimestampFormat: time.RFC3339,
 		},
-		Fields: fields,
-		Hooks:  hooks,
+		Fields: nil,
+		Hooks:  nil,
 	}
 }
 
@@ -126,6 +106,14 @@ type AcraTextFormatter struct {
 	Hooks []FormatterHook
 }
 
+func (f *AcraTextFormatter) SetServiceName(serviceName string) {
+	// service name is ignored by plaintext formatter, so just do nothing
+}
+
+func (f *AcraTextFormatter) SetHooks(hooks []FormatterHook) {
+	f.Hooks = hooks
+}
+
 // AcraJSONFormatter represents a format with specific fields.
 //
 // It has logrus.Formatter which formats the entry and logrus.Fields which
@@ -140,6 +128,20 @@ type AcraJSONFormatter struct {
 	Hooks []FormatterHook
 }
 
+func (f *AcraJSONFormatter) SetServiceName(serviceName string) {
+	fields := log.Fields{FieldKeyProduct: serviceName}
+	for k, v := range extraJSONFields {
+		if _, ok := fields[k]; !ok {
+			fields[k] = v
+		}
+	}
+	f.Fields = fields
+}
+
+func (f *AcraJSONFormatter) SetHooks(hooks []FormatterHook) {
+	f.Hooks = hooks
+}
+
 // AcraCEFFormatter is based on CEFTextFormatter with extra logrus fields.
 //
 // Hooks may be used for more fine-tuned post-processing of entries.
@@ -147,6 +149,25 @@ type AcraCEFFormatter struct {
 	CEFTextFormatter
 	logrus.Fields
 	Hooks []FormatterHook
+}
+
+func (f *AcraCEFFormatter) SetServiceName(serviceName string) {
+	fields := log.Fields{FieldKeyProduct: serviceName}
+	for k, v := range extraJSONFields {
+		if _, ok := fields[k]; !ok {
+			fields[k] = v
+		}
+	}
+	for k, v := range extraCEFFields {
+		if _, ok := fields[k]; !ok {
+			fields[k] = v
+		}
+	}
+	f.Fields = fields
+}
+
+func (f *AcraCEFFormatter) SetHooks(hooks []FormatterHook) {
+	f.Hooks = hooks
 }
 
 // Constants showing extra filed added to loggers by default

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -106,17 +106,6 @@ func CreateFormatter(format string) Formatter {
 	return formatter
 }
 
-// SetServiceName adds service-name label to log entries
-// (plaintext formatter ignores it)
-func SetServiceName(formatter Formatter, serviceName string) {
-	formatter.SetServiceName(serviceName)
-}
-
-// SetHooks allows further customizations for logging
-func SetHooks(formatter Formatter, hooks []FormatterHook) {
-	formatter.SetHooks(hooks)
-}
-
 // GetLogLevel gets logrus log level and returns int Acra log level
 func GetLogLevel() int {
 	if log.GetLevel() == log.DebugLevel {

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -69,6 +69,9 @@ func IsDebugLevel(logger *log.Entry) bool {
 	return logger.Level == log.DebugLevel
 }
 
+// FormatterWrapper wraps log.Formatter interface and adds functions for customizations.
+// Intention for this interface is to provide ability to customize logging by accustomed:
+// `logging.SetServiceName` / `logging.SetHooks` from main function of Acra services
 type FormatterWrapper interface {
 	log.Formatter
 	SetServiceName(serviceName string)
@@ -88,6 +91,7 @@ func SetLogLevel(level int) {
 	}
 }
 
+// CreateFormatter creates formatter object
 func CreateFormatter(format string) FormatterWrapper {
 	var formatter FormatterWrapper
 	switch strings.ToLower(format) {
@@ -102,10 +106,13 @@ func CreateFormatter(format string) FormatterWrapper {
 	return formatter
 }
 
+// SetServiceName adds service-name label to log entries
+// (plaintext formatter ignores it)
 func SetServiceName(formatter FormatterWrapper, serviceName string) {
 	formatter.SetServiceName(serviceName)
 }
 
+// SetHooks allows further customizations for logging
 func SetHooks(formatter FormatterWrapper, hooks []FormatterHook) {
 	formatter.SetHooks(hooks)
 }

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -69,10 +69,10 @@ func IsDebugLevel(logger *log.Entry) bool {
 	return logger.Level == log.DebugLevel
 }
 
-// FormatterWrapper wraps log.Formatter interface and adds functions for customizations.
+// Formatter wraps log.Formatter interface and adds functions for customizations.
 // Intention for this interface is to provide ability to customize logging by accustomed:
 // `logging.SetServiceName` / `logging.SetHooks` from main function of Acra services
-type FormatterWrapper interface {
+type Formatter interface {
 	log.Formatter
 	SetServiceName(serviceName string)
 	SetHooks(hooks []FormatterHook)
@@ -92,8 +92,8 @@ func SetLogLevel(level int) {
 }
 
 // CreateFormatter creates formatter object
-func CreateFormatter(format string) FormatterWrapper {
-	var formatter FormatterWrapper
+func CreateFormatter(format string) Formatter {
+	var formatter Formatter
 	switch strings.ToLower(format) {
 	case JsonFormatString:
 		formatter = JSONFormatter()
@@ -108,12 +108,12 @@ func CreateFormatter(format string) FormatterWrapper {
 
 // SetServiceName adds service-name label to log entries
 // (plaintext formatter ignores it)
-func SetServiceName(formatter FormatterWrapper, serviceName string) {
+func SetServiceName(formatter Formatter, serviceName string) {
 	formatter.SetServiceName(serviceName)
 }
 
 // SetHooks allows further customizations for logging
-func SetHooks(formatter FormatterWrapper, hooks []FormatterHook) {
+func SetHooks(formatter Formatter, hooks []FormatterHook) {
 	formatter.SetHooks(hooks)
 }
 

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -25,8 +25,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
-	"os"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -40,9 +38,9 @@ const (
 )
 
 const (
-	LoggingFormatPlaintext = "plaintext"
-	LoggingFormatJSON      = "json"
-	LoggingFormatCEF       = "cef"
+	PlaintextFormatString = "plaintext"
+	JsonFormatString      = "json"
+	CefFormatString       = "cef"
 )
 
 // LoggerSetter abstract types that provide way to set logger which they should use
@@ -71,6 +69,12 @@ func IsDebugLevel(logger *log.Entry) bool {
 	return logger.Level == log.DebugLevel
 }
 
+type FormatterWrapper interface {
+	log.Formatter
+	SetServiceName(serviceName string)
+	SetHooks(hooks []FormatterHook)
+}
+
 // SetLogLevel sets logging level
 func SetLogLevel(level int) {
 	if level == LogDebug {
@@ -84,6 +88,28 @@ func SetLogLevel(level int) {
 	}
 }
 
+func CreateFormatter(format string) FormatterWrapper {
+	var formatter FormatterWrapper
+	switch strings.ToLower(format) {
+	case JsonFormatString:
+		formatter = JSONFormatter()
+	case CefFormatString:
+		formatter = CEFFormatter()
+	default:
+		formatter = TextFormatter()
+	}
+	log.SetFormatter(formatter)
+	return formatter
+}
+
+func SetServiceName(formatter FormatterWrapper, serviceName string) {
+	formatter.SetServiceName(serviceName)
+}
+
+func SetHooks(formatter FormatterWrapper, hooks []FormatterHook) {
+	formatter.SetHooks(hooks)
+}
+
 // GetLogLevel gets logrus log level and returns int Acra log level
 func GetLogLevel() int {
 	if log.GetLevel() == log.DebugLevel {
@@ -93,70 +119,6 @@ func GetLogLevel() int {
 		return LogVerbose
 	}
 	return LogDiscard
-}
-
-// CustomizeBuilder allows to customize logging process
-type CustomizeBuilder struct {
-	writer        io.Writer
-	serviceName   string
-	loggingFormat string
-	hooks         []FormatterHook
-}
-
-// Customize is a global function for logging customization.
-// Example of usage: Customize().SetServiceName(...).SetFormat(...).SetOutput(...).Complete()
-func Customize() *CustomizeBuilder {
-	return &CustomizeBuilder{}
-}
-
-// SetOutput specifies where logs should be written (stderr, file, etc.)
-func (c *CustomizeBuilder) SetOutput(w io.Writer) *CustomizeBuilder {
-	c.writer = w
-	return c
-}
-
-// SetServiceName specifies global name of service that produces logs
-func (c *CustomizeBuilder) SetServiceName(serviceName string) *CustomizeBuilder {
-	c.serviceName = serviceName
-	return c
-}
-
-// SetFormat specifies actual format
-func (c *CustomizeBuilder) SetFormat(loggingFormat string) *CustomizeBuilder {
-	c.loggingFormat = loggingFormat
-	return c
-}
-
-// SetHooks specifies additional pre-/post-processing actions with log entries
-func (c *CustomizeBuilder) SetHooks(hooks []FormatterHook) *CustomizeBuilder {
-	c.hooks = hooks
-	return c
-}
-
-// Complete finishes logging customization.
-// For default logging use Customize().Complete()
-func (c *CustomizeBuilder) Complete() {
-	if c.writer == nil {
-		c.writer = os.Stderr
-	}
-	if c.loggingFormat == "" {
-		c.loggingFormat = LoggingFormatPlaintext
-	}
-	/* We do not check hooks field, since it can be nil (standard log entry processing) */
-	log.SetOutput(c.writer)
-	log.SetFormatter(logFormatterFor(c.loggingFormat, c.serviceName, c.hooks))
-	log.Debugf("Changed logging format to %s", c.loggingFormat)
-}
-
-func logFormatterFor(loggingFormat string, serviceName string, hooks []FormatterHook) log.Formatter {
-	switch strings.ToLower(loggingFormat) {
-	case LoggingFormatJSON:
-		return JSONFormatter(log.Fields{FieldKeyProduct: serviceName}, hooks)
-	case LoggingFormatCEF:
-		return CEFFormatter(log.Fields{FieldKeyProduct: serviceName}, hooks)
-	default:
-		return TextFormatter(hooks)
-	}
 }
 
 // SetLoggerToContext sets logger to corresponded context


### PR DESCRIPTION
These changes are rather technical. 

Main point is soonest customization for logging process (as we discussed by voice - it is critical 1) to preserve format for logging in error cases, even if not all parameters for customization have been already loaded, and 2) to start logging only when format is customized). 

Since format is specified by actual formatter object (`CefFormatter`, `JsonFormatter`, `TextFormatter`), it is necessary to create this object first, and then to perform customization on it. For this reason - `SetFormat(*loggingFormat)` function (that previously returns nothing) is changed onto function `logging.CreateFormatter(*loggingFormat)` that returns actual formatter object with empty fields. Then, as long as parameters become ready (basically hooks and service name - which is actually known but applying it requires formatter object whatever) - those fields are initialised. 

Mentioned "approach" is applied for each service instead of previous customization via builder