### PR TITLE
Test key removal in key store v2

### DIFF
--- a/cmd/acra-key-tool/acra-key-tool.go
+++ b/cmd/acra-key-tool/acra-key-tool.go
@@ -128,15 +128,21 @@ func main() {
 	checkParameterConsistency()
 
 	if params.ReadKeyKind != "" {
-		keyBytes := readKeyBytes()
-		_, err = os.Stdout.Write(keyBytes)
-		if err != nil {
-			log.Fatalf("Failed to write key bytes: %v", err)
-		}
+		printKey()
 	}
 
 	if params.DestroyKeyKind != "" {
 		destroyKey()
+	}
+}
+
+func printKey() {
+	keyBytes := readKeyBytes()
+	defer utils.ZeroizeSymmetricKey(keyBytes)
+
+	_, err := os.Stdout.Write(keyBytes)
+	if err != nil {
+		log.Fatalf("Failed to write key bytes: %v", err)
 	}
 }
 

--- a/configs/acra-key-tool.yaml
+++ b/configs/acra-key-tool.yaml
@@ -11,9 +11,6 @@ dump_config: false
 # Generate with yaml config markdown text file with descriptions of all args
 generate_markdown_args_table: false
 
-# key kind to read, one of: poison-public, poison-private, storage-public, storage-private, zone-public, zone-private
-key: 
-
 # path to key directory
 keys_dir: .acrakeys
 
@@ -22,6 +19,9 @@ keys_dir_public:
 
 # force key store format: v1 (current), v2 (new)
 keystore: 
+
+# key kind to read, one of: poison-public, poison-private, storage-public, storage-private, zone-public, zone-private
+read_key: 
 
 # zone ID for which to retrieve key
 zone_id: 

--- a/configs/acra-key-tool.yaml
+++ b/configs/acra-key-tool.yaml
@@ -5,6 +5,9 @@ client_id:
 # path to config
 config_file: 
 
+# key kind to destroy, one of: transport-connector, transport-server, transport-translator
+destroy_key: 
+
 # dump config
 dump_config: false
 

--- a/keystore/keystore.go
+++ b/keystore/keystore.go
@@ -148,12 +148,15 @@ type TransportKeyStore interface {
 type TransportKeyCreation interface {
 	GenerateConnectorKeys(id []byte) error
 	SaveConnectorKeypair(id []byte, keypair *keys.Keypair) error
+	DestroyConnectorKeypair(id []byte) error
 
 	GenerateServerKeys(id []byte) error
 	SaveServerKeypair(id []byte, keypair *keys.Keypair) error
+	DestroyServerKeypair(id []byte) error
 
 	GenerateTranslatorKeys(id []byte) error
 	SaveTranslatorKeypair(id []byte, keypair *keys.Keypair) error
+	DestroyTranslatorKeypair(id []byte) error
 }
 
 // PublicKeyStore provides access to storage public keys, used to encrypt data for storage.

--- a/keystore/v2/keystore/api/key.go
+++ b/keystore/v2/keystore/api/key.go
@@ -28,6 +28,7 @@ var (
 	ErrFormatDuplicated    = errors.New("key format used multiple times")
 	ErrFormatMissing       = errors.New("key format not available")
 	ErrKeyNotExist         = errors.New("no key with such seqnum")
+	ErrKeyDestroyed        = errors.New("key has been destroyed")
 	ErrNoKeyData           = errors.New("no key data")
 	ErrInvalidFormat       = errors.New("invalid key format")
 	ErrInvalidState        = errors.New("invalid state transition")

--- a/keystore/v2/keystore/api/keyRing.go
+++ b/keystore/v2/keystore/api/keyRing.go
@@ -63,6 +63,9 @@ type MutableKeyRing interface {
 	// SetState changes key State to the given one, if allowed.
 	SetState(seqnum int, newState KeyState) error
 
+	// DestroyKey erases key data (but keeps the key in the ring).
+	DestroyKey(seqnum int) error
+
 	// SetCurrent makes this key current in its key ring.
 	// Does nothing if the key is already current.
 	SetCurrent(seqnum int) error

--- a/keystore/v2/keystore/filesystem/keyRing.go
+++ b/keystore/v2/keystore/filesystem/keyRing.go
@@ -196,6 +196,17 @@ func (r *KeyRing) addKey(newKey *asn1.Key) error {
 	return err
 }
 
+func (r *KeyRing) destroyKey(keySeqnum int, currentState api.KeyState) error {
+	r.pushTX(&txDestroyKeyData{keySeqnum: keySeqnum})
+	r.pushTX(&txChangeKeyState{keySeqnum, currentState, api.KeyDestroyed})
+	err := r.store.syncKeyRing(r)
+	if err != nil {
+		r.popTX()
+		r.popTX()
+	}
+	return err
+}
+
 //
 // Internal utilities
 //

--- a/keystore/v2/keystore/keyRingUtils.go
+++ b/keystore/v2/keystore/keyRingUtils.go
@@ -109,6 +109,18 @@ func (s *ServerKeyStore) addCurrentKeyPair(ring api.MutableKeyRing, pair *keys.K
 	return nil
 }
 
+func (s *ServerKeyStore) destroyCurrentKeyPair(ring api.MutableKeyRing) error {
+	current, err := ring.CurrentKey()
+	if err != nil {
+		return err
+	}
+	err = ring.DestroyKey(current)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func (s *ServerKeyStore) describeNewKeyPair(keypair *keys.Keypair) api.KeyDescription {
 	return api.KeyDescription{
 		ValidSince: time.Now(),

--- a/keystore/v2/keystore/transport_connector.go
+++ b/keystore/v2/keystore/transport_connector.go
@@ -121,3 +121,19 @@ func (s *ServerKeyStore) SaveConnectorKeypair(clientID []byte, keypair *keys.Key
 	}
 	return nil
 }
+
+// DestroyConnectorKeypair destroys currently used AcraConnector transport keypair for given clientID.
+func (s *ServerKeyStore) DestroyConnectorKeypair(clientID []byte) error {
+	log := s.log.WithField("clientID", clientID)
+	ring, err := s.OpenKeyRingRW(s.connectorTransportKeyPairPath(clientID))
+	if err != nil {
+		log.WithError(err).Debug("Failed to open connector transport key ring for client")
+		return err
+	}
+	err = s.destroyCurrentKeyPair(ring)
+	if err != nil {
+		log.WithError(err).Debug("Failed to destroy connector transport key pair for client")
+		return err
+	}
+	return nil
+}

--- a/keystore/v2/keystore/transport_server.go
+++ b/keystore/v2/keystore/transport_server.go
@@ -109,3 +109,19 @@ func (s *ServerKeyStore) SaveServerKeypair(clientID []byte, keypair *keys.Keypai
 	}
 	return nil
 }
+
+// DestroyServerKeypair destroys currently used AcraServer transport keypair for given clientID.
+func (s *ServerKeyStore) DestroyServerKeypair(clientID []byte) error {
+	log := s.log.WithField("clientID", clientID)
+	ring, err := s.OpenKeyRingRW(s.serverTransportKeyPairPath(clientID))
+	if err != nil {
+		log.WithError(err).Debug("Failed to open transport key ring for client")
+		return err
+	}
+	err = s.destroyCurrentKeyPair(ring)
+	if err != nil {
+		log.WithError(err).Debug("Failed to destroy transport key pair for client")
+		return err
+	}
+	return nil
+}

--- a/keystore/v2/keystore/transport_translator.go
+++ b/keystore/v2/keystore/transport_translator.go
@@ -109,3 +109,19 @@ func (s *ServerKeyStore) SaveTranslatorKeypair(clientID []byte, keypair *keys.Ke
 	}
 	return nil
 }
+
+// DestroyTranslatorKeypair destroys currently used AcraTranslator transport keypair for given clientID.
+func (s *ServerKeyStore) DestroyTranslatorKeypair(clientID []byte) error {
+	log := s.log.WithField("clientID", clientID)
+	ring, err := s.OpenKeyRingRW(s.translatorTransportKeyPairPath(clientID))
+	if err != nil {
+		log.WithError(err).Debug("Failed to open translator transport key ring for client")
+		return err
+	}
+	err = s.destroyCurrentKeyPair(ring)
+	if err != nil {
+		log.WithError(err).Debug("Failed to destroy translator transport key pair for client")
+		return err
+	}
+	return nil
+}

--- a/tests/test.py
+++ b/tests/test.py
@@ -1697,9 +1697,6 @@ class TestConnectionClosing(BaseTestCase):
 class TestKeyNonExistence(BaseTestCase):
     def setUp(self):
         self.checkSkip()
-        # FIXME(ilammy, 2020-03-20): implement key removal for v2
-        if KEYSTORE_VERSION == 'v2':
-            self.skipTest('key store v2 does not support key removal')
         try:
             self.init_key_stores()
             if not self.EXTERNAL_ACRA:
@@ -2233,9 +2230,6 @@ class TestCheckLogPoisonRecord(AcraCatchLogsMixin, BasePoisonRecordTest):
 class TestKeyStorageClearing(BaseTestCase):
     def setUp(self):
         self.checkSkip()
-        # FIXME(ilammy, 2020-03-20): implement key removal for v2
-        if KEYSTORE_VERSION == 'v2':
-            self.skipTest('key store v2 does not support key removal')
         try:
             self.init_key_stores()
             self.connector_1 = self.fork_connector(

--- a/tests/test.py
+++ b/tests/test.py
@@ -437,7 +437,7 @@ BINARIES = [
            build_args=DEFAULT_BUILD_ARGS),
     Binary(name='acra-migrate-keys', from_version=DEFAULT_VERSION,
            build_args=DEFAULT_BUILD_ARGS),
-    Binary(name='acra-read-key', from_version=DEFAULT_VERSION,
+    Binary(name='acra-key-tool', from_version=DEFAULT_VERSION,
            build_args=DEFAULT_BUILD_ARGS),
     Binary(name='acra-poisonrecordmaker', from_version=DEFAULT_VERSION,
            build_args=DEFAULT_BUILD_ARGS),
@@ -4617,7 +4617,7 @@ class TestOutdatedServiceConfigs(BaseTestCase, FailedRunProcessMixin):
                 'acra-server': ['-db_host=127.0.0.1'],
                 'acra-connector': ['-user_check_disable', '-acraserver_connection_host=127.0.0.1', '-client_id=keypair1'],
                 'acra-migrate-keys': ['--dry_run', '--src_keys_dir={}'.format(KEYS_FOLDER.name)],
-                'acra-read-key': ['--keys_dir={}'.format(KEYS_FOLDER.name)],
+                'acra-key-tool': ['--keys_dir={}'.format(KEYS_FOLDER.name)],
             }
             for service in services:
                 config_param = '-config_file={}'.format(os.path.join(tmp_dir, '{}.yaml'.format(service)))
@@ -4641,7 +4641,7 @@ class TestOutdatedServiceConfigs(BaseTestCase, FailedRunProcessMixin):
                 'acra-server': ['-db_host=127.0.0.1'],
                 'acra-connector': ['-user_check_disable', '-acraserver_connection_host=127.0.0.1', '-client_id=keypair1'],
                 'acra-migrate-keys': ['--dry_run', '--src_keys_dir={}'.format(KEYS_FOLDER.name)],
-                'acra-read-key': ['--keys_dir={}'.format(KEYS_FOLDER.name)],
+                'acra-key-tool': ['--keys_dir={}'.format(KEYS_FOLDER.name)],
             }
             for service in services:
                 config_param = '-config_file={}'.format(os.path.join(tmp_dir, '{}.yaml'.format(service)))
@@ -4677,7 +4677,7 @@ class TestOutdatedServiceConfigs(BaseTestCase, FailedRunProcessMixin):
                                   '-keys_public_output_dir={}'.format(tmp_dir),
                                   '--keystore={}'.format(KEYSTORE_VERSION)],
                 'acra-migrate-keys': ['--dry_run', '--src_keys_dir={}'.format(KEYS_FOLDER.name)],
-                'acra-read-key': ['--keys_dir={}'.format(KEYS_FOLDER.name)],
+                'acra-key-tool': ['--keys_dir={}'.format(KEYS_FOLDER.name)],
                 'acra-poisonrecordmaker': ['-keys_dir={}'.format(tmp_dir),
                                            '--keystore={}'.format(KEYSTORE_VERSION)],
                 'acra-rollback': {'args': ['-keys_dir={}'.format(tmp_dir),
@@ -4728,7 +4728,7 @@ class TestOutdatedServiceConfigs(BaseTestCase, FailedRunProcessMixin):
                                   '-keys_public_output_dir={}'.format(tmp_dir),
                                   '--keystore={}'.format(KEYSTORE_VERSION)],
                 'acra-migrate-keys': ['--dry_run', '--src_keys_dir={}'.format(KEYS_FOLDER.name)],
-                'acra-read-key': ['--keys_dir={}'.format(KEYS_FOLDER.name)],
+                'acra-key-tool': ['--keys_dir={}'.format(KEYS_FOLDER.name)],
                 'acra-poisonrecordmaker': ['-keys_dir={}'.format(tmp_dir),
                                            '--keystore={}'.format(KEYSTORE_VERSION)],
                 'acra-rollback': {'args': ['-keys_dir={}'.format(tmp_dir),

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -105,8 +105,8 @@ def load_default_config(service_name):
 
 
 def read_key(kind, client_id=None, zone_id=None, keys_dir='.acrakeys'):
-    """Reads key from Key Store with read-key utility."""
-    args = ['./acra-read-key', '--key={}'.format(kind),
+    """Reads key from Key Store with acra-key-tool."""
+    args = ['./acra-key-tool', '--read_key={}'.format(kind),
         '--keys_dir={}'.format(keys_dir)]
     if client_id is not None:
         args.append('--client_id={}'.format(client_id))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -116,14 +116,12 @@ def read_key(kind, client_id=None, zone_id=None, keys_dir='.acrakeys'):
 
 
 def destroy_key(kind, client_id=None, keys_dir='.acrakeys'):
-    if kind == 'transport-connector':
-        os.remove(os.path.join(keys_dir, client_id))
-        os.remove(os.path.join(keys_dir, client_id + '.pub'))
-    elif kind == 'transport-server':
-        os.remove(os.path.join(keys_dir, client_id + '_server'))
-        os.remove(os.path.join(keys_dir, client_id + '_server.pub'))
-    else:
-        raise Exception('unknown key kind: {}'.format(kind))
+    """Destroys key in the Key Store with acra-key-tool."""
+    args = ['./acra-key-tool', '--destroy_key={}'.format(kind),
+        '--keys_dir={}'.format(keys_dir)]
+    if client_id:
+        args.append('--client_id={}'.format(client_id))
+    return subprocess.check_output(args)
 
 
 def read_storage_public_key(client_id, keys_dir='.acrakeys'):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -115,6 +115,17 @@ def read_key(kind, client_id=None, zone_id=None, keys_dir='.acrakeys'):
     return subprocess.check_output(args)
 
 
+def destroy_key(kind, client_id=None, keys_dir='.acrakeys'):
+    if kind == 'transport-connector':
+        os.remove(os.path.join(keys_dir, client_id))
+        os.remove(os.path.join(keys_dir, client_id + '.pub'))
+    elif kind == 'transport-server':
+        os.remove(os.path.join(keys_dir, client_id + '_server'))
+        os.remove(os.path.join(keys_dir, client_id + '_server.pub'))
+    else:
+        raise Exception('unknown key kind: {}'.format(kind))
+
+
 def read_storage_public_key(client_id, keys_dir='.acrakeys'):
     return read_key('storage-public', client_id=client_id, keys_dir=keys_dir)
 


### PR DESCRIPTION
There were a couple of tests left out in #361. Those tests verified that Acra works as expected for unknown keys which was simulated by removing keys from the key store. Key store v1 has it easy as key files can be directly removed from the filesystem. Key store v2 is (way) more complex so you cannot just remove a key ring file. (Well, actually, you *can* right now because the key directory integrity is not verified, but this will not be the case in the future.) However, key store v2 also has a concept of a **destroyed key** – a 'zombie' key with only metadata remaining, but with no actual key material retained. We make use of it.

This patch set starts by updating the tests to decouple them from direct key store access. Instead, new utility function `destroy_key()` should be used to destroy keys. For key store v1 it will remove key files as before, but for key store v2 it will use new API for key removal.

**acra-read-key** tool is renamed into more generic **acra-key-tool** so that it can handle both reading key data and destroying keys, as well as exporting and importing them in the future. We may consider teaching it to generate keys as well.

There's some new key store API that handles key destruction. Note that it's different from _removal_: it is possible to see that a key had existed but has been destroyed, with no way to access its data anymore. However, key store v1 does not differentiate between destruction and removal as many places are unable to properly handle existing but empty key files.

Finally, we compose all of this together to support key removal for both v1 and v2. Then we are able to reenable the removal tests for v2.