### PR TITLE
Improve build scripts

### DIFF
--- a/CHANGELOG_DEV.md
+++ b/CHANGELOG_DEV.md
@@ -1,0 +1,20 @@
+## 0.85.0 - 2020-04-02
+### Added
+- Support of RHEL >= 7
+- Configurable build and install parameters in Makefile (see `make help`)
+- Self-documented Makefile
+- `go_install.sh` script
+- Makefile `pkg` target with automatic detection of OS (use it instead of `rpm` and `deb`)
+### Changed
+- Build image use Debian 10 instead of Debian 9
+- Application names in Docker image description got `CE` suffix
+- Refined logic of automatic image tagging
+### Removed
+- Makefile targets `dist`, `temp_copy`
+- `docker_push` target replaced with `docker-push`
+- default argument `--db_host=postgres` from `acra-server` docker image, specifying it explicitly is more secure
+- default argument `--acraserver_connection_host=acra-server` from `acra-connector` image
+### Deprecated
+- `docker` target in Makefile (will be removed in 0.87.0), use `docker-build` instead
+- docker images `acra-authmanager` and `acra-keymaker` (will be removed in 0.87.0); all tools are now packaged into the `acra-tools` image
+- Makefile targets `rpm` and `deb` are aliases for `pkg` and will be removed in future

--- a/Makefile
+++ b/Makefile
@@ -296,9 +296,8 @@ endif
 		--package '$(BUILD_DIR_ABS)/$(PKG_TYPE)/$(PKG_NAME)' \
 		--version '$(PKG_VERSION)' \
 		--category security \
-		--depends openssl \
 		--depends libthemis \
-		--conflicts acra \
+		--conflicts acra-ee \
 		$(PKG_TYPE_SPECIFIC_ARGS) \
 		'$(BUILD_DIR_ABS)/$(PKG_TYPE).struct/bin=$(PKG_INSTALL_PREFIX)'
 	@find '$(BUILD_DIR_ABS)' -name \*.$(PKG_TYPE)

--- a/Makefile
+++ b/Makefile
@@ -1,190 +1,310 @@
-ifneq ($(BUILD_PATH),)
-    BIN_PATH = $(BUILD_PATH)
-else
-    BIN_PATH = build
-endif
+#===== Variables ===============================================================
 
-ifeq ($(PREFIX),)
-    PREFIX = /usr
-endif
+#----- Application -------------------------------------------------------------
 
-TEMP_GOPATH = temp_gopath
-ABS_TEMP_GOPATH := $(shell pwd)/$(TEMP_GOPATH)
+APP_NAME := acra
+APP_LICENSE_NAME = Apache License Version 2.0
 
-ifneq ($(GIT_BRANCH),)
-    BRANCH = $(GIT_BRANCH)
-else
-    BRANCH = master
-endif
+VCS_URL := https://github.com/cossacklabs/acra
 
-GIT_VERSION := $(shell if [ -d ".git" ]; then git version; fi 2>/dev/null)
-ifdef GIT_VERSION
-    VERSION = $(shell git describe --tags HEAD | cut -b 1-)
-    GIT_HASH = $(shell git rev-parse --verify HEAD)
-else
-    VERSION = $(shell date -I)
-endif
-
-.PHONY: get_version dist temp_copy install clean test_go test_python test \
-        test_all unpack_dist deb rpm docker docker_push
-
-get_version:
-	@echo $(VERSION)
-
-DIST_FILENAME = $(VERSION).tar.gz
-
-RSYNC_EXCLUDE = --exclude=$(TEMP_GOPATH) --exclude=$(BIN_PATH) --exclude=.acrakeys --exclude=.git --exclude=$(VERSION)
-RSYNC_COPY = acra-writer cmd docker examples io LICENSE poison tests utils zone benchmarks circle.yml configs decryptor fuzz keystore Makefile README.md wrappers
-
-dist:
-	@mkdir -p $(VERSION)
-	@rsync -az $(RSYNC_EXCLUDE) $(RSYNC_COPY) $(VERSION)
-	@tar -zcf $(DIST_FILENAME) $(VERSION)
-	@rm -rf $(VERSION)
-
-temp_copy:
-	@mkdir -p $(ABS_TEMP_GOPATH)/src/github.com/cossacklabs/acra
-	@rsync -az $(RSYNC_EXCLUDE) ./* $(TEMP_GOPATH)/src/github.com/cossacklabs/acra
-	@GOPATH=$(ABS_TEMP_GOPATH) go get github.com/cossacklabs/acra/cmd/...
-
-install: temp_copy
-	@mkdir -p $(BIN_PATH)
-	@cp $(TEMP_GOPATH)/bin/* $(BIN_PATH)
-
-clean:
-	@rm -rf $(BIN_PATH)
-	@rm -rf $(TEMP_GOPATH)
-
-test_go:
-	@GOPATH=$(ABS_TEMP_GOPATH) go test github.com/cossacklabs/acra/...
-
-# should work postgresql on postgres:postgres@127.0.0.1:5432/postgres or override default connection params via TEST_DB_[HOST|PORT|USERNAME|USER_PASSWORD|NAME]
-# and installed libpq-dev for python psycopg2
-test_python:
-	@virtualenv --python=python3 $(BIN_PATH)/test_env && \
-		$(BIN_PATH)/test_env/bin/pip install -r tests/requirements.txt && \
-		GOPATH=$(ABS_TEMP_GOPATH) $(BIN_PATH)/test_env/bin/python $(ABS_TEMP_GOPATH)/src/github.com/cossacklabs/acra/tests/test.py
-
-test: temp_copy test_go
-
-# alias for unification with other products
-test_all: test
-
-PACKAGE_NAME = acra
-COSSACKLABS_URL = https://www.cossacklabs.com
-MAINTAINER = "Cossack Labs Limited <dev@cossacklabs.com>"
-
-# tag version from VCS
-LICENSE_NAME = "Apache License Version 2.0"
-
-DEBIAN_CODENAME := $(shell lsb_release -cs 2> /dev/null)
-DEBIAN_ARCHITECTURE = `dpkg --print-architecture 2>/dev/null`
-DEBIAN_DEPENDENCIES = --depends openssl --depends libthemis
-RPM_DEPENDENCIES = --depends openssl --depends libthemis
-
-ifeq ($(shell lsb_release -is 2> /dev/null),Debian)
-    NAME_SUFFIX = $(VERSION)+$(DEBIAN_CODENAME)_$(DEBIAN_ARCHITECTURE).deb
-    OS_CODENAME = $(shell lsb_release -cs)
-else ifeq ($(shell lsb_release -is 2> /dev/null),Ubuntu)
-    NAME_SUFFIX = $(VERSION)+$(DEBIAN_CODENAME)_$(DEBIAN_ARCHITECTURE).deb
-    OS_CODENAME = $(shell lsb_release -cs)
-else
-    OS_NAME = $(shell cat /etc/os-release | grep -e "^ID=\".*\"" | cut -d'"' -f2)
-    OS_VERSION = $(shell cat /etc/os-release | grep -i version_id|cut -d'"' -f2)
-    ARCHITECTURE = $(shell arch)
-    RPM_VERSION = $(shell echo -n "$(VERSION)"|sed s/-/_/g)
-    NAME_SUFFIX = $(RPM_VERSION).$(OS_NAME)$(OS_VERSION).$(ARCHITECTURE).rpm
-endif
-
-SHORT_DESCRIPTION = "Acra helps you easily secure your databases in distributed, microservice-rich environments"
-RPM_SUMMARY = "Acra helps you easily secure your databases in distributed, microservice-rich environments. \
+APP_SHORT_DESCRIPTION := "Acra helps you easily secure your databases in distributed, microservice-rich environments"
+APP_LONG_DESCRIPTION := "Acra helps you easily secure your databases in distributed, microservice-rich environments. \
     It allows you to selectively encrypt sensitive records with strong multi-layer cryptography, detect potential \
     intrusions and SQL injections and cryptographically compartmentalize data stored in large sharded schemes. \
     Acra's security model guarantees that if your database or your application become compromised, they will not \
     leak sensitive data, or keys to decrypt them."
 
-BUILD_DATE = $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
+APP_VENDOR_URL := https://www.cossacklabs.com
+APP_VENDOR_NAME := Cossack Labs Limited
+APP_VENDOR_EMAIL := dev@cossacklabs.com
 
-unpack_dist:
-	@tar -xf $(DIST_FILENAME)
+#----- Build -------------------------------------------------------------------
 
-deb: install
-	@mkdir -p '$(BIN_PATH)/deb'
-	@fpm --input-type dir \
-		 --output-type deb \
-		 --name $(PACKAGE_NAME) \
-		 --license $(LICENSE_NAME) \
-		 --url '$(COSSACKLABS_URL)' \
-		 --description $(SHORT_DESCRIPTION) \
-		 --maintainer $(MAINTAINER) \
-		 --package $(BIN_PATH)/deb/$(PACKAGE_NAME)_$(NAME_SUFFIX) \
-		 --architecture $(DEBIAN_ARCHITECTURE) \
-		 --version $(VERSION)+$(OS_CODENAME) \
-		 $(DEBIAN_DEPENDENCIES) \
-		 --deb-priority optional \
-		 --category security \
-		 $(TEMP_GOPATH)/bin/=$(PREFIX)/bin
-# it's just for printing .deb files
-	@find $(BIN_PATH) -name \*.deb
+BUILD_DATE := $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
+## Absolute or relative GOPATH for the 'build' target
+BUILD_DIR ?= build
+BUILD_DIR_ABS := $(abspath $(BUILD_DIR))
 
-rpm: install
-	@mkdir -p $(BIN_PATH)/rpm
-	@fpm --input-type dir \
-		--output-type rpm \
-		--name $(PACKAGE_NAME) \
-		--license $(LICENSE_NAME) \
-		--url '$(COSSACKLABS_URL)' \
-		--description $(SHORT_DESCRIPTION) \
-		--rpm-summary $(RPM_SUMMARY) \
-		--maintainer $(MAINTAINER) \
-		$(RPM_DEPENDENCIES) \
-		--package $(BIN_PATH)/rpm/$(PACKAGE_NAME)-$(NAME_SUFFIX) \
-		--version $(RPM_VERSION) \
-		--category security \
-		$(TEMP_GOPATH)/bin/=$(PREFIX)/bin
-# it's just for printing .rpm files
-	@find $(BIN_PATH) -name \*.rpm
+#----- Git ---------------------------------------------------------------------
 
-define docker_build
-	@docker image build \
-		--no-cache=true \
-		--build-arg VERSION=$(VERSION)\
-		--build-arg VCS_URL="https://github.com/cossacklabs/acra" \
-		--build-arg VCS_REF=$(GIT_HASH) \
-		--build-arg VCS_BRANCH=$(BRANCH) \
-		--build-arg BUILD_DATE=$(BUILD_DATE) \
-		--tag cossacklabs/$(1):$(GIT_HASH) \
-		-f ./docker/$(1).dockerfile \
-		.
-	for tag in $(2); do \
-		docker tag cossacklabs/$(1):$(GIT_HASH) cossacklabs/$(1):$$tag; \
-	done
-endef
-
-ifeq ($(BRANCH),stable)
-    CONTAINER_TAGS = stable latest $(VERSION)
-else ifeq ($(BRANCH),master)
-    CONTAINER_TAGS = master current $(VERSION)
+GIT_VERSION := $(shell if [ -d ".git" ]; then git version; fi 2>/dev/null)
+ifdef GIT_VERSION
+    APP_VERSION := $(shell git describe --tags HEAD 2>/dev/null || printf '0.0.0' | cut -b 1-)
+    VCS_HASH := $(shell git rev-parse --verify HEAD)
+    VCS_BRANCH := $(shell git branch | grep \* | cut -d ' ' -f2)
+else
+    APP_VERSION := $(shell date +%s)
+    VCS_HASH := 00000000
+    VCS_BRANCH := master
 endif
 
-docker:
-	$(call docker_build,acra-build,)
-	$(call docker_build,acra-server,$(CONTAINER_TAGS))
-	$(call docker_build,acra-connector,$(CONTAINER_TAGS))
-	$(call docker_build,acra-translator,$(CONTAINER_TAGS))
-	$(call docker_build,acra-keymaker,$(CONTAINER_TAGS))
-	$(call docker_build,acra-webconfig,$(CONTAINER_TAGS))
-	$(call docker_build,acra-authmanager,$(CONTAINER_TAGS))
-	@docker image rm cossacklabs/acra-build:$(GIT_HASH)
+#----- Packages ----------------------------------------------------------------
 
-docker_push: docker
-	@docker push cossacklabs/acra-server
-	@docker push cossacklabs/acra-connector
-	@docker push cossacklabs/acra-translator
-	@docker push cossacklabs/acra-keymaker
-	@docker push cossacklabs/acra-webconfig
-	@docker push cossacklabs/acra-authmanager
+## Application components to include
+PKG_COMPONENTS ?= addzone authmanager connector keymaker poisonrecordmaker rollback rotate server translator webconfig
 
+## Installation path prefix for packages
+PKG_INSTALL_PREFIX ?= /usr
+
+#----- Docker ------------------------------------------------------------------
+
+DOCKER_BIN := $(shell command -v docker 2> /dev/null)
+
+## Registry host
+DOCKER_REGISTRY_HOST ?= localhost
+## Registry path, usually - company name
+DOCKER_REGISTRY_PATH ?= cossacklabs
+
+## List of extra tags for building, delimiter - single space
+DOCKER_EXTRA_BUILD_TAGS ?=
+## List of extra tags for pushing into remote registry, delimiter - single space
+DOCKER_EXTRA_PUSH_TAGS ?=
+
+# Adapt the branch name to the tag naming convention. For a typical custom branch
+# name it looks like replacing 'username/T000_branch_name' to 'username.T000-branch-name'.
+# If, despite the naming conventions, the resulting branch name begins with
+# a minus symbol, add the word 'branch' to the beginning.
+DOCKER_BRANCH_TAGS := $(shell printf "$(VCS_BRANCH)" | \
+	tr '/' '.' | tr -c '[:alnum:].-' '-' | \
+	awk '/^-/ {printf "branch"$$0; next} {printf $$0}')
+ifeq ($(VCS_BRANCH),stable)
+    DOCKER_BRANCH_TAGS := $(DOCKER_BRANCH_TAGS) latest
+else ifeq ($(VCS_BRANCH),master)
+    DOCKER_BRANCH_TAGS := $(DOCKER_BRANCH_TAGS) current
+endif
+
+# $(VCS_HASH) is the only tag that must be present to exactly identify the image
+DOCKER_BUILD_TAGS := $(VCS_HASH) $(APP_VERSION) $(DOCKER_BRANCH_TAGS) $(DOCKER_EXTRA_BUILD_TAGS)
+DOCKER_PUSH_TAGS := $(VCS_HASH) $(APP_VERSION) $(DOCKER_BRANCH_TAGS) $(DOCKER_EXTRA_PUSH_TAGS)
+
+#----- Makefile ----------------------------------------------------------------
+
+COLOR_DEFAULT := \033[0m
+COLOR_MENU := \033[1m
+COLOR_TARGET := \033[93m
+COLOR_ENVVAR := \033[32m
+COLOR_COMMENT := \033[90m
+
+#----- Detect OS ---------------------------------------------------------------
+
+# As far as this block is used only for the 'pkg' target, we recognize here
+# only the OSs used in it. For the same reason error processing also placed into
+# the 'pkg' target.
+
+UNAME := $(shell uname)
+
+ifeq ($(UNAME),Linux)
+	OS_NAME := $(shell lsb_release -is 2>/dev/null || printf 'unknown')
+	OS_SHORTNAME := $(shell printf "$(OS_NAME)" | tr '[:upper:]' '[:lower:]')
+	OS_CODENAME := $(shell lsb_release -cs 2>/dev/null || printf 'unknown')
+	OS_VERSION_MAJOR := $(shell (lsb_release -rs 2>/dev/null || printf 'unknown') | cut -d'.' -f1)
+	ifeq ($(OS_NAME),$(filter $(OS_NAME),Debian Ubuntu))
+		OS_ARCH_DEBIAN := $(shell dpkg --print-architecture 2>/dev/null || printf 'unknown')
+	else ifeq ($(OS_NAME),$(filter $(OS_NAME),RedHatEnterpriseServer CentOS))
+		ifeq ($(OS_NAME),RedHatEnterpriseServer)
+			OS_SHORTNAME := rhel
+		endif
+		OS_ARCH_RHEL := $(shell arch || printf 'unknown')
+	endif
+endif
+
+
+#===== Functions ===============================================================
+
+define docker_build
+	@$(DOCKER_BIN) image build \
+		--no-cache=true \
+		--build-arg APP_NAME=$(APP_NAME) \
+		--build-arg VERSION='$(APP_VERSION)' \
+		--build-arg VCS_URL='$(VCS_URL)' \
+		--build-arg VCS_REF='$(VCS_HASH)' \
+		--build-arg VCS_BRANCH='$(VCS_BRANCH)' \
+		--build-arg BUILD_DATE='$(BUILD_DATE)' \
+		--build-arg DOCKER_REGISTRY_PATH='$(DOCKER_REGISTRY_PATH)' \
+		$(foreach tag_name,$(DOCKER_BUILD_TAGS), \
+			--tag '$(DOCKER_REGISTRY_PATH)/$(1):$(tag_name)') \
+		-f ./docker/$(1).dockerfile \
+		.
+endef
+
+define docker_push
+	@$(foreach tag_name,$(DOCKER_PUSH_TAGS), \
+		$(DOCKER_BIN) tag \
+			'$(DOCKER_REGISTRY_PATH)/$(1):$(VCS_HASH)' \
+			'$(DOCKER_REGISTRY_HOST)/$(DOCKER_REGISTRY_PATH)/$(1):$(tag_name)'; \
+		$(DOCKER_BIN) push \
+			'$(DOCKER_REGISTRY_HOST)/$(DOCKER_REGISTRY_PATH)/$(1):$(tag_name)'; \
+	)
+endef
+
+
+#===== Targets =================================================================
+
+.DEFAULT_GOAL := build
+
+.PHONY: help \
+    build install test_go test_python test test_all clean \
+    docker-build docker-push docker-clean docker \
+    pkg deb rpm
+
+#----- Help --------------------------------------------------------------------
+
+## Show this help
+help:
+	@echo "$(COLOR_MENU)Targets:$(COLOR_DEFAULT)"
+	@awk 'BEGIN { FS = ":.*?" }\
+		/^## *--/ { print "" }\
+		/^## / { split($$0,a,/## /); comment = a[2] }\
+		/^[a-zA-Z-][a-zA-Z_-]*:.*?/ {\
+			if (length(comment) == 0) { next };\
+			printf "  $(COLOR_TARGET)%-15s$(COLOR_DEFAULT) %s\n", $$1, comment;\
+			comment = "" }'\
+		$(MAKEFILE_LIST)
+	@echo "\n$(COLOR_MENU)Properties allowed for overriding:$(COLOR_DEFAULT)"
+	@awk 'BEGIN { FS = "[[:space:]]*\\?=[[:space:]]*" }\
+		/^## / { split($$0,a,/## /); comment = a[2] }\
+		/^[a-zA-Z-][a-zA-Z_-]+[[:space:]]*\?=.*/ {\
+			if (length(comment) == 0) { next };\
+			printf "  $(COLOR_ENVVAR)%-23s$(COLOR_DEFAULT) - %s\n", $$1, comment;\
+			printf "%28s$(COLOR_COMMENT)'\''%s'\'' by default$(COLOR_DEFAULT)\n", "", $$2;\
+			comment = "" }'\
+		$(MAKEFILE_LIST)
+	@echo "$(COLOR_MENU)Usage example:$(COLOR_DEFAULT)\n\
+	  make DOCKER_EXTRA_BUILD_TAGS='staging' DOCKER_REGISTRY_HOST=registry.example.com docker-build"
+
+##---- Application -------------------------------------------------------------
+
+## Build the application in the subdirectory (default)
+build:
+	@GOPATH=$(BUILD_DIR_ABS) go install ./cmd/...
+
+## Build the application and install to the system GOPATH
+install:
+	go install ./cmd/...
+
+test_go:
+	@GOPATH=$(BUILD_DIR_ABS) go test ./cmd/...
+
+## Test the application
+test: test_go
+
+# DEPRECATED
+test_all: test
+
+# PostgreSQL should be accessible via postgres:postgres@127.0.0.1:5432/postgres
+# Alternatively override default connection params via TEST_DB_[HOST|PORT|USERNAME|USER_PASSWORD|NAME]
+# Package libpq-dev must be installed for python psycopg2
+## Run extra python test
+test_python:
+	@virtualenv --python=python3 $(BUILD_DIR_ABS)/test_env && \
+		$(BUILD_DIR_ABS)/test_env/bin/pip install -r tests/requirements.txt && \
+		GOPATH=$(BUILD_DIR_ABS) $(BUILD_DIR_ABS)/test_env/bin/python \
+			$(BUILD_DIR_ABS)/src/github.com/cossacklabs/acra/tests/test.py
+
+## Remove build artifacts
+clean:
+	@test -d $(BUILD_DIR_ABS) && chmod -R u+w $(BUILD_DIR_ABS) || true
+	@rm -rf $(BUILD_DIR_ABS)
+
+## Generate keys
 keys: install
 	@chmod +x scripts/generate-keys.sh
 	@scripts/generate-keys.sh
+
+##---- Docker ------------------------------------------------------------------
+
+## Docker : build the image locally
+docker-build:
+	$(call docker_build,acra-build)
+	$(call docker_build,acra-server)
+	$(call docker_build,acra-connector)
+	$(call docker_build,acra-translator)
+	$(call docker_build,acra-keymaker)
+	$(call docker_build,acra-tools)
+	$(call docker_build,acra-webconfig)
+	$(call docker_build,acra-authmanager)
+	$(DOCKER_BIN) image prune --force -a \
+		--filter label=com.cossacklabs.product.name="$(APP_NAME)" \
+		--filter label=com.cossacklabs.docker.container.type="build"
+
+## Docker : tag and push image to remote registry
+docker-push:
+	$(call docker_push,acra-server)
+	$(call docker_push,acra-connector)
+	$(call docker_push,acra-translator)
+	$(call docker_push,acra-keymaker)
+	$(call docker_push,acra-tools)
+	$(call docker_push,acra-webconfig)
+	$(call docker_push,acra-authmanager)
+
+## Docker : remove stopped containers and dangling images
+docker-clean:
+	$(DOCKER_BIN) container prune --force \
+		--filter label=com.cossacklabs.product.name="$(APP_NAME)"
+	$(DOCKER_BIN) image prune --force -a \
+		--filter label=com.cossacklabs.product.name="$(APP_NAME)"
+
+## Docker : alias for 'docker-build' target (DEPRECATED)
+docker: docker-build
+
+##---- Packages ----------------------------------------------------------------
+
+## Package : build deb/rpm depending on the current OS
+pkg: build
+ifeq ($(OS_NAME),unknown)
+	$(error OS is not detected)
+endif
+ifeq ($(OS_CODENAME),unknown)
+	$(error OS codename is not detected)
+endif
+ifeq ($(OS_VERSION_MAJOR),unknown)
+	$(error OS version is not detected)
+endif
+ifeq ($(OS_NAME),$(filter $(OS_NAME),Debian Ubuntu))
+# acra_0.85.0+stretch_amd64.deb
+# acra_0.84.0-53-gd90b699+stretch_amd64.deb
+	$(eval PKG_TYPE := deb)
+	$(eval PKG_VERSION := $(APP_VERSION)+$(OS_CODENAME))
+	$(eval PKG_NAME := $(APP_NAME)_$(PKG_VERSION)_$(OS_ARCH_DEBIAN).deb)
+	$(eval PKG_TYPE_SPECIFIC_ARGS := --deb-priority optional \
+		--architecture $(OS_ARCH_DEBIAN))
+else ifeq ($(OS_NAME),$(filter $(OS_NAME),RedHatEnterpriseServer CentOS))
+# acra-0.85.0.centos7.x86_64.rpm
+# acra-0.84.0_54_g41001c5.centos7.x86_64.rpm
+	$(eval PKG_TYPE := rpm)
+	$(eval PKG_VERSION := $(shell printf "$(APP_VERSION)"|sed s/-/_/g))
+	$(eval PKG_NAME := $(APP_NAME)-$(PKG_VERSION).$(OS_SHORTNAME)$(OS_VERSION_MAJOR).$(OS_ARCH_RHEL).rpm)
+	$(eval PKG_TYPE_SPECIFIC_ARGS := --rpm-summary $(APP_LONG_DESCRIPTION) \
+		--architecture $(OS_ARCH_RHEL))
+else
+	$(error packaging for OS $(OS_NAME) is not supported yet)
+endif
+	@mkdir -p '$(BUILD_DIR_ABS)/$(PKG_TYPE)'
+	@mkdir -p '$(BUILD_DIR_ABS)/$(PKG_TYPE).struct/bin'
+	@for p in $(PKG_COMPONENTS); do \
+		cp "$(BUILD_DIR_ABS)/bin/acra-$$p" '$(BUILD_DIR_ABS)/$(PKG_TYPE).struct/bin/'; \
+	done
+	@fpm \
+		--input-type dir \
+		--output-type $(PKG_TYPE) \
+		--name $(APP_NAME) \
+		--license '$(APP_LICENSE_NAME)' \
+		--url '$(APP_VENDOR_URL)' \
+		--description $(APP_SHORT_DESCRIPTION) \
+		--vendor '$(APP_VENDOR_NAME)' \
+		--maintainer '$(shell printf "$(APP_VENDOR_NAME) <$(APP_VENDOR_EMAIL)>")' \
+		--package '$(BUILD_DIR_ABS)/$(PKG_TYPE)/$(PKG_NAME)' \
+		--version '$(PKG_VERSION)' \
+		--category security \
+		--depends openssl \
+		--depends libthemis \
+		--conflicts acra \
+		$(PKG_TYPE_SPECIFIC_ARGS) \
+		'$(BUILD_DIR_ABS)/$(PKG_TYPE).struct/bin=$(PKG_INSTALL_PREFIX)'
+	@find '$(BUILD_DIR_ABS)' -name \*.$(PKG_TYPE)
+
+## Package : alias for the 'pkg' target (DEPRECATED)
+rpm: pkg
+
+## Package : alias for the 'pkg' target (DEPRECATED)
+deb: pkg

--- a/docker/_scripts/acra-build/add_component.sh
+++ b/docker/_scripts/acra-build/add_component.sh
@@ -8,5 +8,5 @@ CONTAINER="$2"
 COMPONENT_BIN="${GOPATH}/bin/acra-${COMPONENT}"
 DESTINATION_DIR="container.acra-${CONTAINER}"
 
-./collect_dependencies.sh "$COMPONENT_BIN" "/${DESTINATION_DIR}"
+/image.scripts/collect_dependencies.sh "$COMPONENT_BIN" "/${DESTINATION_DIR}"
 cp "$COMPONENT_BIN" "/${DESTINATION_DIR}/"

--- a/docker/_scripts/acra-build/install_go.sh
+++ b/docker/_scripts/acra-build/install_go.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Install latest Golang version on Linux
+# See https://golang.org/dl/
+#
+# This script accepts next environment variables:
+#     - GO_VERSION : go version "1.12.4"
+#     - GO_TARBALL_DIGEST : sha256 hash
+#     - GO_PREFIX_DIR : directory prefix to install go
+#     - GO_TARBALL_CLEAN : 1 - clean up after install
+
+set -euo pipefail
+
+GO_PREFIX_DIR="${GO_PREFIX_DIR:-$HOME}"
+GO_VERSION="${GO_VERSION:-1.13.9}"
+GO_TARBALL_DIGEST="${GO_TARBALL_DIGEST:-f4ad8180dd0aaf7d7cda7e2b0a2bf27e84131320896d376549a7d849ecf237d7}"
+GO_TARBALL="go${GO_VERSION}.linux-amd64.tar.gz"
+GO_URL="https://dl.google.com/go/$GO_TARBALL"
+GO_TARBALL_TMP_PATH="/tmp/$GO_TARBALL"
+GO_TARBALL_CLEAN="${GO_TARBALL_CLEAN:-0}"
+
+if [ ! -f "$GO_TARBALL_TMP_PATH" ]; then
+    curl "$GO_URL" > "$GO_TARBALL_TMP_PATH"
+fi
+if [ "$(sha256sum "$GO_TARBALL_TMP_PATH" | awk '{print $1}')" != "$GO_TARBALL_DIGEST" ]; then
+    echo 2>&1 "ERROR : checksum does not match"
+    exit 1
+fi
+
+tar -C "$GO_PREFIX_DIR" -xzf "$GO_TARBALL_TMP_PATH"
+if [[ $GO_TARBALL_CLEAN == '1' ]]; then
+    rm -f "$GO_TARBALL_TMP_PATH"
+fi
+
+export PATH="$PATH:${GO_PREFIX_DIR}/go/bin"
+go version

--- a/docker/acra-connector.dockerfile
+++ b/docker/acra-connector.dockerfile
@@ -1,9 +1,12 @@
 # Create internal synonym for previuosly built image
+ARG DOCKER_REGISTRY_PATH
 ARG VCS_REF
-FROM cossacklabs/acra-build:${VCS_REF} as acra-build
+FROM ${DOCKER_REGISTRY_PATH}/acra-build:${VCS_REF} as acra-build
 
 # Build resulting image from scratch
 FROM scratch
+# Application name
+ARG APP_NAME
 # Product version
 ARG VERSION
 # Link to the product repository
@@ -14,28 +17,35 @@ ARG VCS_REF
 ARG VCS_BRANCH
 # Date of the build
 ARG BUILD_DATE
+
 # Include metadata, additionally use label-schema namespace
 LABEL org.label-schema.schema-version="1.0" \
     org.label-schema.vendor="Cossack Labs" \
     org.label-schema.url="https://cossacklabs.com" \
-    org.label-schema.name="AcraConnector" \
+    org.label-schema.name="AcraConnector CE" \
     org.label-schema.description="Acra helps you easily secure your databases in distributed, microservice-rich environments" \
-    org.label-schema.version=$VERSION \
-    org.label-schema.vcs-url=$VCS_URL \
-    org.label-schema.vcs-ref=$VCS_REF \
-    org.label-schema.build-date=$BUILD_DATE \
-    com.cossacklabs.product.name="acra" \
-    com.cossacklabs.product.version=$VERSION \
-    com.cossacklabs.product.vcs-ref=$VCS_REF \
-    com.cossacklabs.product.vcs-branch=$VCS_BRANCH \
+    org.label-schema.version="$VERSION" \
+    org.label-schema.vcs-url="$VCS_URL" \
+    org.label-schema.vcs-ref="$VCS_REF" \
+    org.label-schema.build-date="$BUILD_DATE" \
+    com.cossacklabs.vendor.name="Cossack Labs Limited" \
+    com.cossacklabs.vendor.url="https://www.cossacklabs.com" \
+    com.cossacklabs.vendor.email="dev@cossacklabs.com" \
+    com.cossacklabs.product.name="$APP_NAME" \
+    com.cossacklabs.product.version="$VERSION" \
+    com.cossacklabs.product.vcs-ref="$VCS_REF" \
+    com.cossacklabs.product.vcs-branch="$VCS_BRANCH" \
     com.cossacklabs.product.component="acra-connector" \
-    com.cossacklabs.docker.container.build-date=$BUILD_DATE \
+    com.cossacklabs.docker.container.build-date="$BUILD_DATE" \
     com.cossacklabs.docker.container.type="product"
+
 # Copy prepared component's folder from acra-build image
 COPY --from=acra-build /container.acra-connector/ /
+
 VOLUME ["/keys"]
 EXPOSE 9191 9494
+
 # Base command
 ENTRYPOINT ["/acra-connector"]
 # Optional arguments
-CMD ["--acraserver_connection_host=acra-server", "-v", "--keys_dir=/keys"]
+CMD ["-v", "--keys_dir=/keys"]

--- a/docker/acra-keymaker.dockerfile
+++ b/docker/acra-keymaker.dockerfile
@@ -1,9 +1,12 @@
 # Create internal synonym for previuosly built image
+ARG DOCKER_REGISTRY_PATH
 ARG VCS_REF
-FROM cossacklabs/acra-build:${VCS_REF} as acra-build
+FROM ${DOCKER_REGISTRY_PATH}/acra-build:${VCS_REF} as acra-build
 
 # Build resulting image from scratch
 FROM scratch
+# Application name
+ARG APP_NAME
 # Product version
 ARG VERSION
 # Link to the product repository
@@ -14,26 +17,33 @@ ARG VCS_REF
 ARG VCS_BRANCH
 # Date of the build
 ARG BUILD_DATE
+
 # Include metadata, additionally use label-schema namespace
 LABEL org.label-schema.schema-version="1.0" \
     org.label-schema.vendor="Cossack Labs" \
     org.label-schema.url="https://cossacklabs.com" \
-    org.label-schema.name="AcraKeymaker - key generator" \
+    org.label-schema.name="AcraKeymaker CE" \
     org.label-schema.description="Acra helps you easily secure your databases in distributed, microservice-rich environments" \
-    org.label-schema.version=$VERSION \
-    org.label-schema.vcs-url=$VCS_URL \
-    org.label-schema.vcs-ref=$VCS_REF \
-    org.label-schema.build-date=$BUILD_DATE \
-    com.cossacklabs.product.name="acra" \
-    com.cossacklabs.product.version=$VERSION \
-    com.cossacklabs.product.vcs-ref=$VCS_REF \
-    com.cossacklabs.product.vcs-branch=$VCS_BRANCH \
+    org.label-schema.version="$VERSION" \
+    org.label-schema.vcs-url="$VCS_URL" \
+    org.label-schema.vcs-ref="$VCS_REF" \
+    org.label-schema.build-date="$BUILD_DATE" \
+    com.cossacklabs.vendor.name="Cossack Labs Limited" \
+    com.cossacklabs.vendor.url="https://www.cossacklabs.com" \
+    com.cossacklabs.vendor.email="dev@cossacklabs.com" \
+    com.cossacklabs.product.name="$APP_NAME" \
+    com.cossacklabs.product.version="$VERSION" \
+    com.cossacklabs.product.vcs-ref="$VCS_REF" \
+    com.cossacklabs.product.vcs-branch="$VCS_BRANCH" \
     com.cossacklabs.product.component="acra-keymaker" \
-    com.cossacklabs.docker.container.build-date=$BUILD_DATE \
+    com.cossacklabs.docker.container.build-date="$BUILD_DATE" \
     com.cossacklabs.docker.container.type="product"
+
 # Copy prepared component's folder from acra-build image
 COPY --from=acra-build /container.acra-keymaker/ /
+
 VOLUME ["/keys"]
+
 # Base command
 ENTRYPOINT ["/acra-keymaker"]
 # Optional arguments

--- a/docker/acra-server.dockerfile
+++ b/docker/acra-server.dockerfile
@@ -1,9 +1,12 @@
 # Create internal synonym for previuosly built image
+ARG DOCKER_REGISTRY_PATH
 ARG VCS_REF
-FROM cossacklabs/acra-build:${VCS_REF} as acra-build
+FROM ${DOCKER_REGISTRY_PATH}/acra-build:${VCS_REF} as acra-build
 
 # Build resulting image from scratch
 FROM scratch
+# Application name
+ARG APP_NAME
 # Product version
 ARG VERSION
 # Link to the product repository
@@ -14,28 +17,35 @@ ARG VCS_REF
 ARG VCS_BRANCH
 # Date of the build
 ARG BUILD_DATE
+
 # Include metadata, additionally use label-schema namespace
 LABEL org.label-schema.schema-version="1.0" \
     org.label-schema.vendor="Cossack Labs" \
     org.label-schema.url="https://cossacklabs.com" \
-    org.label-schema.name="AcraServer" \
+    org.label-schema.name="AcraServer CE" \
     org.label-schema.description="Acra helps you easily secure your databases in distributed, microservice-rich environments" \
-    org.label-schema.version=$VERSION \
-    org.label-schema.vcs-url=$VCS_URL \
-    org.label-schema.vcs-ref=$VCS_REF \
-    org.label-schema.build-date=$BUILD_DATE \
-    com.cossacklabs.product.name="acra" \
-    com.cossacklabs.product.version=$VERSION \
-    com.cossacklabs.product.vcs-ref=$VCS_REF \
-    com.cossacklabs.product.vcs-branch=$VCS_BRANCH \
+    org.label-schema.version="$VERSION" \
+    org.label-schema.vcs-url="$VCS_URL" \
+    org.label-schema.vcs-ref="$VCS_REF" \
+    org.label-schema.build-date="$BUILD_DATE" \
+    com.cossacklabs.vendor.name="Cossack Labs Limited" \
+    com.cossacklabs.vendor.url="https://www.cossacklabs.com" \
+    com.cossacklabs.vendor.email="dev@cossacklabs.com" \
+    com.cossacklabs.product.name="$APP_NAME" \
+    com.cossacklabs.product.version="$VERSION" \
+    com.cossacklabs.product.vcs-ref="$VCS_REF" \
+    com.cossacklabs.product.vcs-branch="$VCS_BRANCH" \
     com.cossacklabs.product.component="acra-server" \
-    com.cossacklabs.docker.container.build-date=$BUILD_DATE \
+    com.cossacklabs.docker.container.build-date="$BUILD_DATE" \
     com.cossacklabs.docker.container.type="product"
+
 # Copy prepared component's folder from acra-build image
 COPY --from=acra-build /container.acra-server/ /
+
 VOLUME ["/keys"]
 EXPOSE 9090 9393
+
 # Base command
 ENTRYPOINT ["/acra-server"]
 # Optional arguments
-CMD ["--db_host=postgres", "-v", "--keys_dir=/keys"]
+CMD ["-v", "--keys_dir=/keys"]

--- a/docker/acra-tools.dockerfile
+++ b/docker/acra-tools.dockerfile
@@ -22,7 +22,7 @@ ARG BUILD_DATE
 LABEL org.label-schema.schema-version="1.0" \
     org.label-schema.vendor="Cossack Labs" \
     org.label-schema.url="https://cossacklabs.com" \
-    org.label-schema.name="AcraAuthmanager CE" \
+    org.label-schema.name="AcraTools CE" \
     org.label-schema.description="Acra helps you easily secure your databases in distributed, microservice-rich environments" \
     org.label-schema.version="$VERSION" \
     org.label-schema.vcs-url="$VCS_URL" \
@@ -35,16 +35,16 @@ LABEL org.label-schema.schema-version="1.0" \
     com.cossacklabs.product.version="$VERSION" \
     com.cossacklabs.product.vcs-ref="$VCS_REF" \
     com.cossacklabs.product.vcs-branch="$VCS_BRANCH" \
-    com.cossacklabs.product.component="acra-authmanager" \
+    com.cossacklabs.product.component="acra-tools" \
     com.cossacklabs.docker.container.build-date="$BUILD_DATE" \
     com.cossacklabs.docker.container.type="product"
 
 # Copy prepared component's folder from acra-build image
-COPY --from=acra-build /container.acra-authmanager/ /
+COPY --from=acra-build /container.acra-tools/ /
 
-VOLUME ["/auth"]
-
+VOLUME ["/keys"]
 # Base command
-ENTRYPOINT ["/acra-authmanager"]
+
+ENTRYPOINT ["/acra-keymaker"]
 # Optional arguments
-CMD ["--keys_dir=/auth", "--file=/auth/auth.keys"]
+CMD ["-v", "--keys_dir=/keys"]

--- a/docker/acra-translator.dockerfile
+++ b/docker/acra-translator.dockerfile
@@ -1,9 +1,12 @@
 # Create internal synonym for previuosly built image
+ARG DOCKER_REGISTRY_PATH
 ARG VCS_REF
-FROM cossacklabs/acra-build:${VCS_REF} as acra-build
+FROM ${DOCKER_REGISTRY_PATH}/acra-build:${VCS_REF} as acra-build
 
 # Build resulting image from scratch
 FROM scratch
+# Application name
+ARG APP_NAME
 # Product version
 ARG VERSION
 # Link to the product repository
@@ -14,27 +17,34 @@ ARG VCS_REF
 ARG VCS_BRANCH
 # Date of the build
 ARG BUILD_DATE
+
 # Include metadata, additionally use label-schema namespace
 LABEL org.label-schema.schema-version="1.0" \
     org.label-schema.vendor="Cossack Labs" \
     org.label-schema.url="https://cossacklabs.com" \
-    org.label-schema.name="AcraTranslator" \
+    org.label-schema.name="AcraTranslator CE" \
     org.label-schema.description="Acra helps you easily secure your databases in distributed, microservice-rich environments" \
-    org.label-schema.version=$VERSION \
-    org.label-schema.vcs-url=$VCS_URL \
-    org.label-schema.vcs-ref=$VCS_REF \
-    org.label-schema.build-date=$BUILD_DATE \
-    com.cossacklabs.product.name="acra" \
-    com.cossacklabs.product.version=$VERSION \
-    com.cossacklabs.product.vcs-ref=$VCS_REF \
-    com.cossacklabs.product.vcs-branch=$VCS_BRANCH \
+    org.label-schema.version="$VERSION" \
+    org.label-schema.vcs-url="$VCS_URL" \
+    org.label-schema.vcs-ref="$VCS_REF" \
+    org.label-schema.build-date="$BUILD_DATE" \
+    com.cossacklabs.vendor.name="Cossack Labs Limited" \
+    com.cossacklabs.vendor.url="https://www.cossacklabs.com" \
+    com.cossacklabs.vendor.email="dev@cossacklabs.com" \
+    com.cossacklabs.product.name="$APP_NAME" \
+    com.cossacklabs.product.version="$VERSION" \
+    com.cossacklabs.product.vcs-ref="$VCS_REF" \
+    com.cossacklabs.product.vcs-branch="$VCS_BRANCH" \
     com.cossacklabs.product.component="acra-translator" \
-    com.cossacklabs.docker.container.build-date=$BUILD_DATE \
+    com.cossacklabs.docker.container.build-date="$BUILD_DATE" \
     com.cossacklabs.docker.container.type="product"
+
 # Copy prepared component's folder from acra-build image
 COPY --from=acra-build /container.acra-translator/ /
+
 VOLUME ["/keys"]
 EXPOSE 9595 9696
+
 # Base command
 ENTRYPOINT ["/acra-translator"]
 # Optional arguments

--- a/docker/acra-webconfig.dockerfile
+++ b/docker/acra-webconfig.dockerfile
@@ -1,9 +1,12 @@
 # Create internal synonym for previuosly built image
+ARG DOCKER_REGISTRY_PATH
 ARG VCS_REF
-FROM cossacklabs/acra-build:${VCS_REF} as acra-build
+FROM ${DOCKER_REGISTRY_PATH}/acra-build:${VCS_REF} as acra-build
 
 # Build resulting image from scratch
 FROM scratch
+# Application name
+ARG APP_NAME
 # Product version
 ARG VERSION
 # Link to the product repository
@@ -14,24 +17,30 @@ ARG VCS_REF
 ARG VCS_BRANCH
 # Date of the build
 ARG BUILD_DATE
+
 # Include metadata, additionally use label-schema namespace
 LABEL org.label-schema.schema-version="1.0" \
     org.label-schema.vendor="Cossack Labs" \
     org.label-schema.url="https://cossacklabs.com" \
-    org.label-schema.name="AcraWebconfig" \
+    org.label-schema.name="AcraWebconfig CE" \
     org.label-schema.description="Acra helps you easily secure your databases in distributed, microservice-rich environments" \
-    org.label-schema.version=$VERSION \
-    org.label-schema.vcs-url=$VCS_URL \
-    org.label-schema.vcs-ref=$VCS_REF \
-    org.label-schema.build-date=$BUILD_DATE \
-    com.cossacklabs.product.name="acra" \
-    com.cossacklabs.product.version=$VERSION \
-    com.cossacklabs.product.vcs-ref=$VCS_REF \
-    com.cossacklabs.product.vcs-branch=$VCS_BRANCH \
+    org.label-schema.version="$VERSION" \
+    org.label-schema.vcs-url="$VCS_URL" \
+    org.label-schema.vcs-ref="$VCS_REF" \
+    org.label-schema.build-date="$BUILD_DATE" \
+    com.cossacklabs.vendor.name="Cossack Labs Limited" \
+    com.cossacklabs.vendor.url="https://www.cossacklabs.com" \
+    com.cossacklabs.vendor.email="dev@cossacklabs.com" \
+    com.cossacklabs.product.name="$APP_NAME" \
+    com.cossacklabs.product.version="$VERSION" \
+    com.cossacklabs.product.vcs-ref="$VCS_REF" \
+    com.cossacklabs.product.vcs-branch="$VCS_BRANCH" \
     com.cossacklabs.product.component="acra-webconfig" \
-    com.cossacklabs.docker.container.build-date=$BUILD_DATE \
+    com.cossacklabs.docker.container.build-date="$BUILD_DATE" \
     com.cossacklabs.docker.container.type="product"
+
 # Copy prepared component's folder from acra-build image
 COPY --from=acra-build /container.acra-webconfig/ /
+
 # Base command
 ENTRYPOINT ["/acra-webconfig", "-static_path=/static"]


### PR DESCRIPTION
* Makefile now has:
  - clean, readable and maintainable structure (I hope)
  - strict division by sections and namespaces
  - OS detection
  - correct error handling for most cases
* implemented build/install:
  - build target builds the binaries in the ./build subdirectory
  - install target builds and installs binaries into system/user $GOPATH directory
  - test/test_all run tests
  - clean removes all created artifacts
* refined packaging:
  - single target pkg
  - auto detection of package type
  - deb and rpm targets are temporarily left for backward compatibility
  - supported Debian >= 9, Ubuntu >= 16.04, RHEL >= 7, CentOS >= 7
* refined docker build flow:
  - useful scripts added for easy automation
  - dockerfiles refined
  - labels refined
* implemented help system:
  - try this: make help
  - auto generated description for targets
  - auto generated description for properties/variables

Rules for adding docker tags:
* VCS hash — always
* VCS version — always
* VCS branch¹ — always
* + `latest` — when VCS branch is `stable`
* + `current` — when VCS branch is `master`
* + specified in `DOCKER_EXTRA_(BUILD|PUSH)_TAGS`

¹ — VCS branch is preliminarily adapted to comply with naming conventions. For a typical custom branch name it looks like replacing 'username/T000_branch_name' to 'username.T000-branch-name'. If, despite the naming conventions, the resulting branch name begins with a minus symbol, the word 'branch' will be added to the beginning.