### PR TITLE
Use modern GoThemis 0.12 API

### DIFF
--- a/acra-writer/acra-writer.go
+++ b/acra-writer/acra-writer.go
@@ -25,6 +25,7 @@ import (
 	"crypto/rand"
 	"encoding/binary"
 	"errors"
+
 	"github.com/cossacklabs/acra/decryptor/base"
 	"github.com/cossacklabs/acra/utils"
 	"github.com/cossacklabs/themis/gothemis/cell"
@@ -35,7 +36,7 @@ import (
 // CreateAcrastruct encrypt your data using acra_public key and context (optional)
 // and pack into correct Acrastruct format
 func CreateAcrastruct(data []byte, acraPublic *keys.PublicKey, context []byte) ([]byte, error) {
-	randomKeyPair, err := keys.New(keys.KEYTYPE_EC)
+	randomKeyPair, err := keys.New(keys.TypeEC)
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +59,7 @@ func CreateAcrastruct(data []byte, acraPublic *keys.PublicKey, context []byte) (
 	utils.FillSlice('0', randomKeyPair.Private.Value)
 
 	// create scell for encrypting data
-	scell := cell.New(randomKey, cell.CELL_MODE_SEAL)
+	scell := cell.New(randomKey, cell.ModeSeal)
 	encryptedData, _, err := scell.Protect(data, context)
 	if err != nil {
 		return nil, err

--- a/acra-writer/acra-writer_test.go
+++ b/acra-writer/acra-writer_test.go
@@ -19,16 +19,17 @@ import (
 	"bytes"
 	"crypto/rand"
 	"encoding/binary"
-	"github.com/cossacklabs/acra/acra-writer"
+	"testing"
+
+	acrawriter "github.com/cossacklabs/acra/acra-writer"
 	"github.com/cossacklabs/acra/decryptor/base"
 	"github.com/cossacklabs/themis/gothemis/cell"
 	"github.com/cossacklabs/themis/gothemis/keys"
 	"github.com/cossacklabs/themis/gothemis/message"
-	"testing"
 )
 
 func TestCreateAcrastruct(t *testing.T) {
-	acra_kp, err := keys.New(keys.KEYTYPE_EC)
+	acra_kp, err := keys.New(keys.TypeEC)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -55,7 +56,7 @@ func TestCreateAcrastruct(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	scell := cell.New(unwrapped_key, cell.CELL_MODE_SEAL)
+	scell := cell.New(unwrapped_key, cell.ModeSeal)
 	data_length_buf := acra_struct[len(base.TagBegin)+base.KeyBlockLength : len(base.TagBegin)+base.KeyBlockLength+base.DataLengthSize]
 	data_length := int(binary.LittleEndian.Uint64(data_length_buf))
 	data := acra_struct[len(base.TagBegin)+base.KeyBlockLength+base.DataLengthSize:]

--- a/cmd/acra-authmanager/acra_authmanager.go
+++ b/cmd/acra-authmanager/acra_authmanager.go
@@ -24,6 +24,10 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+
 	"github.com/cossacklabs/acra/cmd"
 	"github.com/cossacklabs/acra/keystore"
 	"github.com/cossacklabs/acra/keystore/filesystem"
@@ -31,9 +35,6 @@ import (
 	"github.com/cossacklabs/acra/utils"
 	"github.com/cossacklabs/themis/gothemis/cell"
 	log "github.com/sirupsen/logrus"
-	"io/ioutil"
-	"os"
-	"strings"
 )
 
 // HashedPasswords stores username:hashed_password map
@@ -70,7 +71,7 @@ func (hp HashedPasswords) WriteToFile(file string, keystore *filesystem.KeyStore
 	if err != nil {
 		return err
 	}
-	SecureCell := cell.New(key, cell.CELL_MODE_SEAL)
+	SecureCell := cell.New(key, cell.ModeSeal)
 	crypted, _, err := SecureCell.Protect(hp.Bytes(), nil)
 	if err != nil {
 		return err
@@ -106,7 +107,7 @@ func parseHtpasswdFile(file string, keystore *filesystem.KeyStore) (passwords Ha
 	if err != nil {
 		return
 	}
-	SecureCell := cell.New(key, cell.CELL_MODE_SEAL)
+	SecureCell := cell.New(key, cell.ModeSeal)
 	authData, err := SecureCell.Unprotect(htpasswdBytes, nil, nil)
 	if err != nil {
 		return

--- a/cmd/acra-server/client_commands_session.go
+++ b/cmd/acra-server/client_commands_session.go
@@ -131,7 +131,7 @@ func (clientSession *ClientCommandsSession) HandleSession() {
 			response = Response500Error
 			break
 		}
-		SecureCell := cell.New(key, cell.CELL_MODE_SEAL)
+		SecureCell := cell.New(key, cell.ModeSeal)
 		authData, err := SecureCell.Unprotect(authDataCrypted, nil, nil)
 		if err != nil {
 			logger.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorHTTPAPICantDecryptAuthData).WithError(err).Error("loadAuthData: SecureCell.Unprotect")

--- a/decryptor/base/utils.go
+++ b/decryptor/base/utils.go
@@ -21,6 +21,7 @@ import (
 	"encoding/binary"
 
 	"errors"
+
 	"github.com/cossacklabs/acra/keystore"
 	"github.com/cossacklabs/acra/utils"
 	"github.com/cossacklabs/themis/gothemis/cell"
@@ -85,7 +86,7 @@ func DecryptAcrastruct(data []byte, privateKey *keys.PrivateKey, zone []byte) ([
 	if err != nil {
 		return []byte{}, err
 	}
-	scell := cell.New(symmetricKey, cell.CELL_MODE_SEAL)
+	scell := cell.New(symmetricKey, cell.ModeSeal)
 	decrypted, err := scell.Unprotect(innerData[KeyBlockLength+DataLengthSize:], nil, zone)
 	// fill zero symmetric_key
 	utils.FillSlice(byte(0), symmetricKey)

--- a/decryptor/base/utils_test.go
+++ b/decryptor/base/utils_test.go
@@ -18,12 +18,13 @@ package base_test
 import (
 	"bytes"
 	"crypto/rand"
-	"github.com/cossacklabs/acra/acra-writer"
+	"testing"
+
+	acrawriter "github.com/cossacklabs/acra/acra-writer"
 	// use another package name and explicit import to avoid cyclic import
 	"github.com/cossacklabs/acra/decryptor/base"
 	"github.com/cossacklabs/acra/zone"
 	"github.com/cossacklabs/themis/gothemis/keys"
-	"testing"
 )
 
 func TestDecryptAcrastruct(t *testing.T) {
@@ -32,7 +33,7 @@ func TestDecryptAcrastruct(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	keypair, err := keys.New(keys.KEYTYPE_EC)
+	keypair, err := keys.New(keys.TypeEC)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -89,7 +90,7 @@ func TestValidateAcraStructLength(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	keypair, err := keys.New(keys.KEYTYPE_EC)
+	keypair, err := keys.New(keys.TypeEC)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/decryptor/binary/binary_decryptor.go
+++ b/decryptor/binary/binary_decryptor.go
@@ -20,6 +20,8 @@ package binary
 import (
 	"bytes"
 	"encoding/binary"
+	"io"
+
 	"github.com/cossacklabs/acra/decryptor/base"
 	"github.com/cossacklabs/acra/logging"
 	"github.com/cossacklabs/acra/utils"
@@ -27,7 +29,6 @@ import (
 	"github.com/cossacklabs/themis/gothemis/keys"
 	"github.com/cossacklabs/themis/gothemis/message"
 	log "github.com/sirupsen/logrus"
-	"io"
 )
 
 // Decryptor stores settings for finding and decrypting AcraStruct from binary data
@@ -145,7 +146,7 @@ func (decryptor *Decryptor) ReadData(symmetricKey, zoneID []byte, reader io.Read
 		return append(rawLengthData, rawData...), err
 	}
 
-	scell := cell.New(symmetricKey, cell.CELL_MODE_SEAL)
+	scell := cell.New(symmetricKey, cell.ModeSeal)
 	decrypted, err := scell.Unprotect(data, nil, zoneID)
 	data = nil
 	// fill zero symmetric_key

--- a/decryptor/mysql/decryptor_test.go
+++ b/decryptor/mysql/decryptor_test.go
@@ -1,11 +1,9 @@
 package mysql
 
 import (
-	"encoding/base64"
-	"github.com/sirupsen/logrus"
-	"testing"
-
 	"crypto/rand"
+	"encoding/base64"
+	"testing"
 
 	"github.com/cossacklabs/acra/decryptor/base"
 	"github.com/cossacklabs/acra/decryptor/binary"
@@ -13,6 +11,7 @@ import (
 	"github.com/cossacklabs/acra/keystore"
 	"github.com/cossacklabs/acra/poison"
 	"github.com/cossacklabs/themis/gothemis/keys"
+	"github.com/sirupsen/logrus"
 )
 
 type testKeystore struct {
@@ -88,7 +87,7 @@ func getDecryptor(keystore keystore.KeyStore) *Decryptor {
 }
 
 func TestMySQLDecryptor_CheckPoisonRecord_Inline(t *testing.T) {
-	poisonKeypair, err := keys.New(keys.KEYTYPE_EC)
+	poisonKeypair, err := keys.New(keys.TypeEC)
 	if err != nil {
 		panic(err)
 	}
@@ -119,7 +118,7 @@ func TestMySQLDecryptor_CheckPoisonRecord_Inline(t *testing.T) {
 }
 
 func TestMySQLDecryptor_CheckPoisonRecord_Block(t *testing.T) {
-	poisonKeypair, err := keys.New(keys.KEYTYPE_EC)
+	poisonKeypair, err := keys.New(keys.TypeEC)
 	if err != nil {
 		panic(err)
 	}

--- a/decryptor/postgresql/pg_escape_decryptor.go
+++ b/decryptor/postgresql/pg_escape_decryptor.go
@@ -19,17 +19,17 @@ package postgresql
 import (
 	"bytes"
 	"encoding/binary"
-	"github.com/cossacklabs/acra/logging"
-	"github.com/cossacklabs/acra/utils"
-	log "github.com/sirupsen/logrus"
 	"io"
 	"strconv"
 
 	"github.com/cossacklabs/acra/decryptor/base"
+	"github.com/cossacklabs/acra/logging"
+	"github.com/cossacklabs/acra/utils"
 	"github.com/cossacklabs/acra/zone"
 	"github.com/cossacklabs/themis/gothemis/cell"
 	"github.com/cossacklabs/themis/gothemis/keys"
 	"github.com/cossacklabs/themis/gothemis/message"
+	log "github.com/sirupsen/logrus"
 )
 
 // ZoneID begin tags, lengths, etc
@@ -227,7 +227,7 @@ func (decryptor *PgEscapeDecryptor) ReadData(symmetricKey, zoneID []byte, reader
 		return append(hexLengthBuf, octData...), err
 	}
 
-	scell := cell.New(symmetricKey, cell.CELL_MODE_SEAL)
+	scell := cell.New(symmetricKey, cell.ModeSeal)
 	decrypted, err := scell.Unprotect(data, nil, zoneID)
 	// fill zero symmetric_key
 	utils.FillSlice(byte(0), symmetricKey[:])

--- a/decryptor/postgresql/pg_hex_decryptor.go
+++ b/decryptor/postgresql/pg_hex_decryptor.go
@@ -20,17 +20,17 @@ import (
 	"bytes"
 	"encoding/binary"
 	"encoding/hex"
-	"github.com/cossacklabs/acra/logging"
-	"github.com/cossacklabs/acra/utils"
-	log "github.com/sirupsen/logrus"
 	"io"
 
 	"github.com/cossacklabs/acra/decryptor/base"
 	"github.com/cossacklabs/acra/keystore"
+	"github.com/cossacklabs/acra/logging"
+	"github.com/cossacklabs/acra/utils"
 	"github.com/cossacklabs/acra/zone"
 	"github.com/cossacklabs/themis/gothemis/cell"
 	"github.com/cossacklabs/themis/gothemis/keys"
 	"github.com/cossacklabs/themis/gothemis/message"
+	log "github.com/sirupsen/logrus"
 )
 
 // ZoneID begin tags, lengths, etc
@@ -218,7 +218,7 @@ func (decryptor *PgHexDecryptor) ReadData(symmetricKey, zoneID []byte, reader io
 		return append(hexLengthBuf, hexData...), err
 	}
 
-	scell := cell.New(symmetricKey, cell.CELL_MODE_SEAL)
+	scell := cell.New(symmetricKey, cell.ModeSeal)
 
 	decrypted, err := scell.Unprotect(data, nil, zoneID)
 	data = nil

--- a/encryptor/queryDataEncryptor_test.go
+++ b/encryptor/queryDataEncryptor_test.go
@@ -20,7 +20,9 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
-	"github.com/cossacklabs/acra/acra-writer"
+	"testing"
+
+	acrawriter "github.com/cossacklabs/acra/acra-writer"
 	"github.com/cossacklabs/acra/decryptor/base"
 	"github.com/cossacklabs/acra/encryptor/config"
 	"github.com/cossacklabs/acra/sqlparser"
@@ -29,7 +31,6 @@ import (
 	"github.com/cossacklabs/acra/sqlparser/dialect/postgresql"
 	"github.com/cossacklabs/acra/zone"
 	"github.com/cossacklabs/themis/gothemis/keys"
-	"testing"
 )
 
 type testEncryptor struct {
@@ -73,7 +74,7 @@ func TestGeneralQueryParser_Parse(t *testing.T) {
 	defaultClientIDStr := "default_client_id"
 	defaultClientID := []byte(defaultClientIDStr)
 
-	keypair, err := keys.New(keys.KEYTYPE_EC)
+	keypair, err := keys.New(keys.TypeEC)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/cossacklabs/acra
 
 require (
-	github.com/cossacklabs/themis v0.0.0-20190313112615-419d5a3c2ca8
+	github.com/cossacklabs/themis/gothemis v0.12.0
 	github.com/go-sql-driver/mysql v1.4.1
 	github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef
 	github.com/golang/protobuf v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cossacklabs/themis v0.0.0-20190313112615-419d5a3c2ca8 h1:6aC23IdI5R4gdBXsgqiTFPmkxEmcYwP7kiDl5f7xH2k=
 github.com/cossacklabs/themis v0.0.0-20190313112615-419d5a3c2ca8/go.mod h1:qMChJuHrlKgEbrzJqAiVncL2Put5W55nQUx38mrUfM0=
+github.com/cossacklabs/themis/gothemis v0.12.0 h1:XgfWhIc6FHCCqnYFnJ9JfCum04z8nHY2MdcZfaaJ5xU=
+github.com/cossacklabs/themis/gothemis v0.12.0/go.mod h1:6fvSguI8fMmChlgdG0cZywirhtTsRmp+/PsCWLDUID8=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/keystore/filesystem/server_keystore.go
+++ b/keystore/filesystem/server_keystore.go
@@ -177,7 +177,7 @@ func newFilesystemKeyStore(privateKeyFolder, publicKeyFolder string, storage Sto
 }
 
 func (store *KeyStore) generateKeyPair(filename string, clientID []byte) (*keys.Keypair, error) {
-	keypair, err := keys.New(keys.KEYTYPE_EC)
+	keypair, err := keys.New(keys.TypeEC)
 	if err != nil {
 		return nil, err
 	}

--- a/keystore/filesystem/server_keystore_test.go
+++ b/keystore/filesystem/server_keystore_test.go
@@ -403,11 +403,11 @@ func testFilesystemKeyStoreRotateZoneKey(storage Storage, t *testing.T) {
 func testSaveKeypairs(store *KeyStore, t *testing.T) {
 	store.Reset()
 	testID := []byte("testid")
-	startKeypair, err := keys.New(keys.KEYTYPE_EC)
+	startKeypair, err := keys.New(keys.TypeEC)
 	if err != nil {
 		t.Fatal(err)
 	}
-	overwritedKeypair, err := keys.New(keys.KEYTYPE_EC)
+	overwritedKeypair, err := keys.New(keys.TypeEC)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/keystore/keystore.go
+++ b/keystore/keystore.go
@@ -117,7 +117,7 @@ type SCellKeyEncryptor struct {
 
 // NewSCellKeyEncryptor creates new SCellKeyEncryptor object with masterKey using Themis Secure Cell in Seal mode.
 func NewSCellKeyEncryptor(masterKey []byte) (*SCellKeyEncryptor, error) {
-	return &SCellKeyEncryptor{scell: cell.New(masterKey, cell.CELL_MODE_SEAL)}, nil
+	return &SCellKeyEncryptor{scell: cell.New(masterKey, cell.ModeSeal)}, nil
 }
 
 // Encrypt return encrypted key using masterKey and context.

--- a/network/connection_wrapper_test.go
+++ b/network/connection_wrapper_test.go
@@ -21,11 +21,11 @@ import (
 	"crypto/tls"
 	"net"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/cossacklabs/themis/gothemis/keys"
-	"strings"
 )
 
 var TestClientID = []byte("client")
@@ -158,11 +158,11 @@ func (keystore *SimpleKeyStore) GetPeerPublicKey(id []byte) (*keys.PublicKey, er
 }
 
 func TestSessionWrapper(t *testing.T) {
-	clientPair, err := keys.New(keys.KEYTYPE_EC)
+	clientPair, err := keys.New(keys.TypeEC)
 	if err != nil {
 		t.Fatal(err)
 	}
-	serverPair, err := keys.New(keys.KEYTYPE_EC)
+	serverPair, err := keys.New(keys.TypeEC)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/network/deadline_listener.go
+++ b/network/deadline_listener.go
@@ -17,7 +17,7 @@ limitations under the License.
 package network
 
 import (
-	"github.com/cossacklabs/themis/gothemis/errors"
+	"errors"
 	"net"
 	"time"
 )


### PR DESCRIPTION
GoThemis 0.12 has deprecated some API names which broke Go conventions (https://github.com/cossacklabs/themis/pull/424). Update the code to use new names.

Note that Secure Cell API is scheduled for an overhaul in the next version of GoThemis 0.13.

Also, since GoThemis 0.12 it is possible to use properly versioned modules. Update go.mod accordingly.

While I've been auditing uses of `gothemis` package I have noticed that in one place we have been erroneously using it's `errors` subpackage instead of the standard one.