### PR TITLE
Support storage key rotation

### DIFF
--- a/cmd/acra-rollback/acra-rollback.go
+++ b/cmd/acra-rollback/acra-rollback.go
@@ -282,15 +282,9 @@ func main() {
 		defer executor.Close()
 	}
 
-	var data, zone []byte
-	var privateKeys []*keys.PrivateKey
-	defer func() {
-		for _, key := range privateKeys {
-			utils.ZeroizePrivateKey(key)
-		}
-	}()
-
 	for i := 0; rows.Next(); i++ {
+		var data, zone []byte
+		var privateKeys []*keys.PrivateKey
 		if *withZone {
 			err = rows.Scan(&zone, &data)
 			if err != nil {
@@ -312,6 +306,7 @@ func main() {
 				continue
 			}
 		}
+		defer utils.ZeroizePrivateKeys(privateKeys)
 		decrypted, err := base.DecryptRotatedAcrastruct(data, privateKeys, zone)
 		if err != nil {
 			log.WithError(err).Errorf("Can't decrypt acrastruct in row with number %v", i)

--- a/cmd/acra-rotate/rotator.go
+++ b/cmd/acra-rotate/rotator.go
@@ -59,11 +59,7 @@ func (rotator *keyRotator) rotateAcrastructWithZone(zoneID, acrastruct []byte) (
 		logger.WithField("acrastruct", hex.EncodeToString(acrastruct)).WithError(err).Errorln("Can't get private key")
 		return nil, err
 	}
-	defer func() {
-		for _, key := range privateKeys {
-			utils.ZeroizePrivateKey(key)
-		}
-	}()
+	defer utils.ZeroizePrivateKeys(privateKeys)
 	decrypted, err := base.DecryptRotatedAcrastruct(acrastruct, privateKeys, zoneID)
 	if err != nil {
 		logger.WithField("acrastruct", hex.EncodeToString(acrastruct)).WithError(err).Errorln("Can't decrypt AcraStruct")
@@ -99,11 +95,7 @@ func (rotator *keyRotator) rotateAcrastructWithClientID(clientID, acrastruct []b
 		logger.WithField("acrastruct", hex.EncodeToString(acrastruct)).WithError(err).Errorln("Can't get private key")
 		return nil, err
 	}
-	defer func() {
-		for _, key := range privateKeys {
-			utils.ZeroizePrivateKey(key)
-		}
-	}()
+	defer utils.ZeroizePrivateKeys(privateKeys)
 	decrypted, err := base.DecryptRotatedAcrastruct(acrastruct, privateKeys, nil)
 	if err != nil {
 		logger.WithField("acrastruct", hex.EncodeToString(acrastruct)).WithError(err).Errorln("Can't decrypt AcraStruct")

--- a/cmd/acra-rotate/rotator.go
+++ b/cmd/acra-rotate/rotator.go
@@ -101,7 +101,7 @@ func (rotator *keyRotator) rotateAcrastructWithClientID(clientID, acrastruct []b
 	}
 	defer func() {
 		for _, key := range privateKeys {
-			utils.FillSlice(0, key.Value)
+			utils.ZeroizePrivateKey(key)
 		}
 	}()
 	decrypted, err := base.DecryptRotatedAcrastruct(acrastruct, privateKeys, nil)

--- a/cmd/acra-translator/grpc_api/decryptor.go
+++ b/cmd/acra-translator/grpc_api/decryptor.go
@@ -114,10 +114,8 @@ func (service *DecryptGRPCService) Decrypt(ctx context.Context, request *Decrypt
 		logger.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantReadKeys).WithError(err).Errorln("Can't load private key for decryption")
 		return nil, ErrCantDecrypt
 	}
+	defer utils.ZeroizePrivateKeys(privateKeys)
 	data, decryptErr := base.DecryptRotatedAcrastruct(request.Acrastruct, privateKeys, decryptionContext)
-	for _, privateKey := range privateKeys {
-		utils.FillSlice(byte(0), privateKey.Value)
-	}
 	if decryptErr != nil {
 		base.AcrastructDecryptionCounter.WithLabelValues(base.DecryptionTypeFail).Inc()
 		logger.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorTranslatorCantDecryptAcraStruct).WithError(decryptErr).Errorln("Can't decrypt AcraStruct")

--- a/cmd/acra-translator/http_api/decryptor.go
+++ b/cmd/acra-translator/http_api/decryptor.go
@@ -244,18 +244,14 @@ func (decryptor *HTTPConnectionsDecryptor) decryptAcraStruct(logger *log.Entry, 
 	} else {
 		privateKeys, err = decryptor.TranslatorData.Keystorage.GetServerDecryptionPrivateKeys(clientID)
 	}
+	defer utils.ZeroizePrivateKeys(privateKeys)
 
 	if err != nil {
 		logger.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantReadKeys).Errorln("Can't load private key to decrypt AcraStruct")
 		return nil, err
 	}
 
-	// decrypt
 	decryptedStruct, err := base.DecryptRotatedAcrastruct(acraStruct, privateKeys, decryptionContext)
-	// zeroing private keys
-	for _, privateKey := range privateKeys {
-		utils.FillSlice(byte(0), privateKey.Value)
-	}
 
 	if err != nil {
 		return nil, err

--- a/decryptor/base/dataProcessor.go
+++ b/decryptor/base/dataProcessor.go
@@ -51,16 +51,12 @@ type DecryptProcessor struct{}
 func (DecryptProcessor) Process(data []byte, context *DataProcessorContext) ([]byte, error) {
 	var privateKeys []*keys.PrivateKey
 	var err error
-	defer func() {
-		for _, key := range privateKeys {
-			utils.ZeroizePrivateKey(key)
-		}
-	}()
 	if context.WithZone {
 		privateKeys, err = context.Keystore.GetZonePrivateKeys(context.ZoneID)
 	} else {
 		privateKeys, err = context.Keystore.GetServerDecryptionPrivateKeys(context.ClientID)
 	}
+	defer utils.ZeroizePrivateKeys(privateKeys)
 	if err != nil {
 		logging.GetLoggerFromContext(context.Context).WithError(err).WithFields(
 			logrus.Fields{"client_id": string(context.ClientID), "zone_id": context.ZoneID}).Warningln("Can't read private key for matched client_id/zone_id")

--- a/decryptor/base/decryptor.go
+++ b/decryptor/base/decryptor.go
@@ -97,7 +97,7 @@ type DataDecryptor interface {
 	// acrastruct using secure message
 	// return decrypted data or data as is if fail
 	// db specific
-	ReadSymmetricKey(*keys.PrivateKey, io.Reader) ([]byte, []byte, error)
+	ReadSymmetricKey([]*keys.PrivateKey, io.Reader) ([]byte, []byte, error)
 	// read and decrypt data or return as is if fail
 	// db specific
 	ReadData([]byte, []byte, io.Reader) ([]byte, error)
@@ -110,9 +110,9 @@ type Decryptor interface {
 	DecryptionSubscriber
 	// register key store that will be used for retrieving private keys
 	SetKeyStore(keystore.DecryptionKeyStore)
-	// return private key for current connected client for decrypting symmetric
-	// key with secure message
-	GetPrivateKey() (*keys.PrivateKey, error)
+	// Return private keys for current connected client used to decrypt
+	// symmetric keys embedded in AcraStructs
+	GetPrivateKeys() ([]*keys.PrivateKey, error)
 	TurnOnPoisonRecordCheck(bool)
 	IsPoisonRecordCheckOn() bool
 	// register storage of callbacks for detected poison records

--- a/decryptor/base/decryptor.go
+++ b/decryptor/base/decryptor.go
@@ -97,7 +97,8 @@ type DataDecryptor interface {
 	// acrastruct using secure message
 	// return decrypted data or data as is if fail
 	// db specific
-	ReadSymmetricKey([]*keys.PrivateKey, io.Reader) ([]byte, []byte, error)
+	ReadSymmetricKey(*keys.PrivateKey, io.Reader) ([]byte, []byte, error)
+	ReadSymmetricKeyRotated([]*keys.PrivateKey, io.Reader) ([]byte, []byte, error)
 	// read and decrypt data or return as is if fail
 	// db specific
 	ReadData([]byte, []byte, io.Reader) ([]byte, error)
@@ -112,6 +113,7 @@ type Decryptor interface {
 	SetKeyStore(keystore.DecryptionKeyStore)
 	// Return private keys for current connected client used to decrypt
 	// symmetric keys embedded in AcraStructs
+	GetPrivateKey() (*keys.PrivateKey, error)
 	GetPrivateKeys() ([]*keys.PrivateKey, error)
 	TurnOnPoisonRecordCheck(bool)
 	IsPoisonRecordCheckOn() bool

--- a/decryptor/postgresql/pg_decryptor.go
+++ b/decryptor/postgresql/pg_decryptor.go
@@ -502,7 +502,7 @@ func (proxy *PgProxy) processInlineBlockDecryption(ctx context.Context, packet *
 			continue
 		}
 		blockReader := bytes.NewReader(column.GetData()[currentIndex+tagLength:])
-		symKey, _, err := decryptor.ReadSymmetricKey(keys, blockReader)
+		symKey, _, err := decryptor.ReadSymmetricKeyRotated(keys, blockReader)
 		if err != nil {
 			span.AddAttributes(trace.BoolAttribute("failed_decryption", true))
 			base.AcrastructDecryptionCounter.WithLabelValues(base.DecryptionTypeFail).Inc()

--- a/decryptor/postgresql/pg_decryptor.go
+++ b/decryptor/postgresql/pg_decryptor.go
@@ -487,7 +487,7 @@ func (proxy *PgProxy) processInlineBlockDecryption(ctx context.Context, packet *
 		outputBlock.Write(column.GetData()[currentIndex:beginTagIndex])
 		currentIndex = beginTagIndex
 
-		key, err := decryptor.GetPrivateKey()
+		keys, err := decryptor.GetPrivateKeys()
 		if err != nil {
 			logger.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantReadKeys).WithError(err).Warningln("Can't read private key for matched client_id/zone_id")
 			if decryptor.IsPoisonRecordCheckOn() {
@@ -502,7 +502,7 @@ func (proxy *PgProxy) processInlineBlockDecryption(ctx context.Context, packet *
 			continue
 		}
 		blockReader := bytes.NewReader(column.GetData()[currentIndex+tagLength:])
-		symKey, _, err := decryptor.ReadSymmetricKey(key, blockReader)
+		symKey, _, err := decryptor.ReadSymmetricKey(keys, blockReader)
 		if err != nil {
 			span.AddAttributes(trace.BoolAttribute("failed_decryption", true))
 			base.AcrastructDecryptionCounter.WithLabelValues(base.DecryptionTypeFail).Inc()

--- a/decryptor/postgresql/pg_general_decryptor.go
+++ b/decryptor/postgresql/pg_general_decryptor.go
@@ -157,8 +157,19 @@ func (decryptor *PgDecryptor) GetMatched() []byte {
 // ReadSymmetricKey reads, decodes from database format block of data, decrypts symmetric key from
 // AcraStruct using Secure message
 // returns decrypted symmetric key or ErrFakeAcraStruct error if can't decrypt
-func (decryptor *PgDecryptor) ReadSymmetricKey(privateKeys []*keys.PrivateKey, reader io.Reader) ([]byte, []byte, error) {
-	symmetricKey, rawData, err := decryptor.binaryDecryptor.ReadSymmetricKey(privateKeys, reader)
+func (decryptor *PgDecryptor) ReadSymmetricKey(privateKey *keys.PrivateKey, reader io.Reader) ([]byte, []byte, error) {
+	symmetricKey, rawData, err := decryptor.binaryDecryptor.ReadSymmetricKey(privateKey, reader)
+	if err != nil {
+		return symmetricKey, rawData, err
+	}
+	return symmetricKey, rawData, nil
+}
+
+// ReadSymmetricKeyRotated reads, decodes from database format block of data, decrypts symmetric key from
+// AcraStruct using Secure message
+// returns decrypted symmetric key or ErrFakeAcraStruct error if can't decrypt
+func (decryptor *PgDecryptor) ReadSymmetricKeyRotated(privateKeys []*keys.PrivateKey, reader io.Reader) ([]byte, []byte, error) {
+	symmetricKey, rawData, err := decryptor.binaryDecryptor.ReadSymmetricKeyRotated(privateKeys, reader)
 	if err != nil {
 		return symmetricKey, rawData, err
 	}
@@ -215,6 +226,16 @@ func (decryptor *PgDecryptor) ReadData(symmetricKey, zoneID []byte, reader io.Re
 // SetKeyStore sets keystore
 func (decryptor *PgDecryptor) SetKeyStore(store keystore.DecryptionKeyStore) {
 	decryptor.keyStore = store
+}
+
+// GetPrivateKey returns private key for decrypting AcraStructs.
+// This is either ZonePrivate key (if Zone mode enabled)
+// or Server Decryption private key otherwise.
+func (decryptor *PgDecryptor) GetPrivateKey() (*keys.PrivateKey, error) {
+	if decryptor.IsWithZone() {
+		return decryptor.keyStore.GetZonePrivateKey(decryptor.GetMatchedZoneID())
+	}
+	return decryptor.keyStore.GetServerDecryptionPrivateKey(decryptor.clientID)
 }
 
 // GetPrivateKeys returns private keys for decrypting AcraStructs.

--- a/decryptor/postgresql/pg_general_decryptor.go
+++ b/decryptor/postgresql/pg_general_decryptor.go
@@ -157,8 +157,8 @@ func (decryptor *PgDecryptor) GetMatched() []byte {
 // ReadSymmetricKey reads, decodes from database format block of data, decrypts symmetric key from
 // AcraStruct using Secure message
 // returns decrypted symmetric key or ErrFakeAcraStruct error if can't decrypt
-func (decryptor *PgDecryptor) ReadSymmetricKey(privateKey *keys.PrivateKey, reader io.Reader) ([]byte, []byte, error) {
-	symmetricKey, rawData, err := decryptor.binaryDecryptor.ReadSymmetricKey(privateKey, reader)
+func (decryptor *PgDecryptor) ReadSymmetricKey(privateKeys []*keys.PrivateKey, reader io.Reader) ([]byte, []byte, error) {
+	symmetricKey, rawData, err := decryptor.binaryDecryptor.ReadSymmetricKey(privateKeys, reader)
 	if err != nil {
 		return symmetricKey, rawData, err
 	}
@@ -217,13 +217,14 @@ func (decryptor *PgDecryptor) SetKeyStore(store keystore.DecryptionKeyStore) {
 	decryptor.keyStore = store
 }
 
-// GetPrivateKey returns either ZonePrivate key (if Zone mode enabled) or
-// Server Decryption private key otherwise
-func (decryptor *PgDecryptor) GetPrivateKey() (*keys.PrivateKey, error) {
+// GetPrivateKeys returns private keys for decrypting AcraStructs.
+// These are either ZonePrivate keys (if Zone mode enabled)
+// or Server Decryption private key otherwise.
+func (decryptor *PgDecryptor) GetPrivateKeys() ([]*keys.PrivateKey, error) {
 	if decryptor.IsWithZone() {
-		return decryptor.keyStore.GetZonePrivateKey(decryptor.GetMatchedZoneID())
+		return decryptor.keyStore.GetZonePrivateKeys(decryptor.GetMatchedZoneID())
 	}
-	return decryptor.keyStore.GetServerDecryptionPrivateKey(decryptor.clientID)
+	return decryptor.keyStore.GetServerDecryptionPrivateKeys(decryptor.clientID)
 }
 
 // TurnOnPoisonRecordCheck turns on or off poison recods check

--- a/decryptor/postgresql/proxy_test.go
+++ b/decryptor/postgresql/proxy_test.go
@@ -34,7 +34,7 @@ func (t testDecryptor) GetMatched() []byte {
 	panic("implement me")
 }
 
-func (t testDecryptor) ReadSymmetricKey(*keys.PrivateKey, io.Reader) ([]byte, []byte, error) {
+func (t testDecryptor) ReadSymmetricKey([]*keys.PrivateKey, io.Reader) ([]byte, []byte, error) {
 	panic("implement me")
 }
 
@@ -54,7 +54,7 @@ func (t testDecryptor) SetKeyStore(keystore.DecryptionKeyStore) {
 	panic("implement me")
 }
 
-func (t testDecryptor) GetPrivateKey() (*keys.PrivateKey, error) {
+func (t testDecryptor) GetPrivateKeys() ([]*keys.PrivateKey, error) {
 	panic("implement me")
 }
 

--- a/decryptor/postgresql/proxy_test.go
+++ b/decryptor/postgresql/proxy_test.go
@@ -34,7 +34,11 @@ func (t testDecryptor) GetMatched() []byte {
 	panic("implement me")
 }
 
-func (t testDecryptor) ReadSymmetricKey([]*keys.PrivateKey, io.Reader) ([]byte, []byte, error) {
+func (t testDecryptor) ReadSymmetricKey(*keys.PrivateKey, io.Reader) ([]byte, []byte, error) {
+	panic("implement me")
+}
+
+func (t testDecryptor) ReadSymmetricKeyRotated([]*keys.PrivateKey, io.Reader) ([]byte, []byte, error) {
 	panic("implement me")
 }
 
@@ -51,6 +55,10 @@ func (t testDecryptor) OnColumn(context.Context, []byte) (context.Context, []byt
 }
 
 func (t testDecryptor) SetKeyStore(keystore.DecryptionKeyStore) {
+	panic("implement me")
+}
+
+func (t testDecryptor) GetPrivateKey() (*keys.PrivateKey, error) {
 	panic("implement me")
 }
 

--- a/keystore/filesystem/server_keystore.go
+++ b/keystore/filesystem/server_keystore.go
@@ -417,9 +417,7 @@ func (store *KeyStore) getPrivateKeysByFilenames(id []byte, filenames []string) 
 	for i, name := range filenames {
 		key, err := store.getPrivateKeyByFilename(id, name)
 		if err != nil {
-			for _, key := range privateKeys[:i] {
-				utils.FillSlice(0, key.Value)
-			}
+			utils.ZeroizePrivateKeys(privateKeys)
 			return nil, err
 		}
 		privateKeys[i] = key

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,6 +3,7 @@ psycopg2==2.8.3
 asyncpg==0.18.3
 SQLAlchemy==1.3.9
 PyMySQL==0.8.0
+ddt==1.3.1
 semver==2.7.9
 requests==2.22.0
 # driver with binary prepared statements support

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -149,6 +149,13 @@ func ZeroizePrivateKey(privateKey *keys.PrivateKey) {
 	}
 }
 
+// ZeroizePrivateKeys wipes a slice of private keys from memory, filling them with zero bytes.
+func ZeroizePrivateKeys(privateKeys []*keys.PrivateKey) {
+	for _, privateKey := range privateKeys {
+		ZeroizePrivateKey(privateKey)
+	}
+}
+
 // ZeroizeKeyPair wipes a private key of a key pair from memory, filling it with zero bytes.
 func ZeroizeKeyPair(keypair *keys.Keypair) {
 	if keypair != nil {


### PR DESCRIPTION
Teach remaining services working with AcraStructs – **acra-server, acra-rollback, acra-rotate** – to use historical keys for decryption. Previously only acra-translator supported that. Now it should be truly possible to rotate keys without reencrypting the data.

While we're here, clean up key wiping as well. Now we wipe keys on acra-server as soon as we don't need them.

Tests for acra-rotate are quite involved so I do not want to copy-paste them with key rotation added. I have pulled a library for data-driven testing ([`ddt`](https://ddt.readthedocs.io/en/latest/index.html)) to cover cases with and without key rotation. It's not pretty because of some inheritance issues, but it works. @Lagovas, if you have any ideas how to make it better (ideally, without a massive refactoring), I'm all ears.

Unfortunately, right now it's not possible to rotate zone storage keys alone, without creating a new zone, so it's impossible to test that. The code is updated to support zones, but there are TODOs instead of tests.

I don't want to waste time on merge conflict resolution and would like to test this with key store v2 as well, so these changes target the **keystore-v2** branch, not master. It is possible to apply them onto master, but with some conflicts around the `KeyStore` methods for multiple keys.

This PR also does not cover _poison records_. They use rotatable keys, but currently do not really support rotation (including the case via AcraTranslator). This will be added later since it's more involved and requires updates in the key store to be able to retrieve historical poison keys.