### PR TITLE
Key store v2 export/import API

### DIFF
--- a/keystore/v2/keystore/api/key.go
+++ b/keystore/v2/keystore/api/key.go
@@ -40,7 +40,6 @@ type KeyFormat int
 
 // Supported key material formats:
 const (
-	ThemisPublicKeyFormat    = KeyFormat(asn1.ThemisPublicKeyFormat)
 	ThemisKeyPairFormat      = KeyFormat(asn1.ThemisKeyPairFormat)
 	ThemisSymmetricKeyFormat = KeyFormat(asn1.ThemisSymmetricKeyFormat)
 )

--- a/keystore/v2/keystore/api/keyStore.go
+++ b/keystore/v2/keystore/api/keyStore.go
@@ -17,6 +17,11 @@
 // Package api describes API of Acra Key Store version 2.
 package api
 
+import (
+	"github.com/cossacklabs/acra/keystore/v2/keystore/asn1"
+	"github.com/cossacklabs/acra/keystore/v2/keystore/crypto"
+)
+
 // KeyStore securely keeps all of the client key data.
 type KeyStore interface {
 	// OpenKeyRing opens an existing key ring with given purpose.
@@ -25,6 +30,11 @@ type KeyStore interface {
 	// Close this keystore, releasing associated resources.
 	// This generally renders opened KeyRings unusable.
 	Close() error
+
+	// ExportKeyRings packages specified key rings for export.
+	// Key ring data is encrypted and signed using given cryptosuite.
+	// Resulting container can be imported into existing or different key store with ImportKeyRings().
+	ExportKeyRings(paths []string, cryptosuite *crypto.KeyStoreSuite) ([]byte, error)
 }
 
 // MutableKeyStore interface to KeyStore allowing write access.
@@ -34,4 +44,31 @@ type MutableKeyStore interface {
 	// OpenKeyRingRW opens a modifiable key ring with given purpose.
 	// A new key ring will be created if it does not exist yet.
 	OpenKeyRingRW(purpose string) (MutableKeyRing, error)
+
+	// ImportKeyRings unpacks key rings packaged by ExportKeyRings.
+	// The provided cryptosuite is used to verify the signature on the container and decrypt key ring data.
+	// Optional delegate can be used to control various aspects of the import process, such as conflict resolution.
+	ImportKeyRings(exportData []byte, cryptosuite *crypto.KeyStoreSuite, delegate *KeyRingImportDelegate) error
+}
+
+// ImportDecision constants describe how to proceed with import conflict resolution.
+type ImportDecision int
+
+// ImportDecision options.
+const (
+	// Do not modify existing key ring, abort with given error.
+	ImportAbort ImportDecision = iota
+	// Do not modify existing key ring, proceed with importing others.
+	ImportSkip
+	// Overwrite existing key ring with new data.
+	ImportOverwrite
+)
+
+// KeyRingImportDelegate controls details of key ring import process.
+type KeyRingImportDelegate struct {
+	// This callback is executed when an imported key ring already exists.
+	// If not set, import process will be aborted.
+	// Current key ring content is encrypted, new key ring content is in plain.
+	// Don't look at the key material, decide based on validity ranges and sequence numbers.
+	DecideKeyRingOverwrite func(currentData, newData *asn1.KeyRing) (ImportDecision, error)
 }

--- a/keystore/v2/keystore/api/keyStore.go
+++ b/keystore/v2/keystore/api/keyStore.go
@@ -48,7 +48,7 @@ type MutableKeyStore interface {
 	// ImportKeyRings unpacks key rings packaged by ExportKeyRings.
 	// The provided cryptosuite is used to verify the signature on the container and decrypt key ring data.
 	// Optional delegate can be used to control various aspects of the import process, such as conflict resolution.
-	ImportKeyRings(exportData []byte, cryptosuite *crypto.KeyStoreSuite, delegate *KeyRingImportDelegate) error
+	ImportKeyRings(exportData []byte, cryptosuite *crypto.KeyStoreSuite, delegate KeyRingImportDelegate) error
 }
 
 // ImportDecision constants describe how to proceed with import conflict resolution.
@@ -65,10 +65,9 @@ const (
 )
 
 // KeyRingImportDelegate controls details of key ring import process.
-type KeyRingImportDelegate struct {
-	// This callback is executed when an imported key ring already exists.
-	// If not set, import process will be aborted.
+type KeyRingImportDelegate interface {
+	// This method is executed when an imported key ring already exists.
 	// Current key ring content is encrypted, new key ring content is in plain.
 	// Don't look at the key material, decide based on validity ranges and sequence numbers.
-	DecideKeyRingOverwrite func(currentData, newData *asn1.KeyRing) (ImportDecision, error)
+	DecideKeyRingOverwrite(currentData, newData *asn1.KeyRing) (ImportDecision, error)
 }

--- a/keystore/v2/keystore/api/tests/keyStore.go
+++ b/keystore/v2/keystore/api/tests/keyStore.go
@@ -18,10 +18,13 @@
 package tests
 
 import (
+	"crypto/subtle"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/cossacklabs/acra/keystore/v2/keystore/api"
+	"github.com/cossacklabs/acra/keystore/v2/keystore/asn1"
 	"github.com/cossacklabs/acra/keystore/v2/keystore/crypto"
 )
 
@@ -42,8 +45,17 @@ var exportRingAll = []string{
 
 // TestKeyStore runs KeyStore test suite.
 func TestKeyStore(t *testing.T, newKeyStore NewKeyStore) {
-	t.Run("TestKeyStoreExport", func(t *testing.T) {
-		testKeyStoreExport(t, newKeyStore)
+	t.Run("TestKeyStoreCleanImport", func(t *testing.T) {
+		testKeyStoreCleanImport(t, newKeyStore)
+	})
+	t.Run("TestKeyStoreDuplicateImport", func(t *testing.T) {
+		testKeyStoreDuplicateImport(t, newKeyStore)
+	})
+	t.Run("TestKeyStoreDuplicateImportSkip", func(t *testing.T) {
+		testKeyStoreDuplicateImportSkip(t, newKeyStore)
+	})
+	t.Run("TestKeyStoreDuplicateImportOverwrite", func(t *testing.T) {
+		testKeyStoreDuplicateImportOverwrite(t, newKeyStore)
 	})
 }
 
@@ -60,6 +72,12 @@ func newExportStoreSuite(t *testing.T) *crypto.KeyStoreSuite {
 	return encryptor
 }
 
+var (
+	demoPublicKeyData    = []byte("public key")
+	demoPrivateKeyData   = []byte("private key")
+	demoSymmetricKeyData = []byte("symmetric key")
+)
+
 func setupDemoKeyStore(s api.MutableKeyStore, t *testing.T) {
 	ringKeyPair, err := s.OpenKeyRingRW(exportRingKeyPair)
 	if err != nil {
@@ -71,8 +89,8 @@ func setupDemoKeyStore(s api.MutableKeyStore, t *testing.T) {
 		Data: []api.KeyData{
 			api.KeyData{
 				Format:     api.ThemisKeyPairFormat,
-				PublicKey:  []byte("public key"),
-				PrivateKey: []byte("private key"),
+				PublicKey:  demoPublicKeyData,
+				PrivateKey: demoPrivateKeyData,
 			},
 		},
 	})
@@ -90,7 +108,7 @@ func setupDemoKeyStore(s api.MutableKeyStore, t *testing.T) {
 		Data: []api.KeyData{
 			api.KeyData{
 				Format:    api.ThemisKeyPairFormat,
-				PublicKey: []byte("only public key"),
+				PublicKey: demoPublicKeyData,
 			},
 		},
 	})
@@ -108,7 +126,7 @@ func setupDemoKeyStore(s api.MutableKeyStore, t *testing.T) {
 		Data: []api.KeyData{
 			api.KeyData{
 				Format:       api.ThemisSymmetricKeyFormat,
-				SymmetricKey: []byte("symmetric key"),
+				SymmetricKey: demoSymmetricKeyData,
 			},
 		},
 	})
@@ -117,12 +135,350 @@ func setupDemoKeyStore(s api.MutableKeyStore, t *testing.T) {
 	}
 }
 
-func testKeyStoreExport(t *testing.T, newKeyStore NewKeyStore) {
+func checkDemoKeyRingKeyPair(t *testing.T, ring api.KeyRing) {
+	seqnums, err := ring.AllKeys()
+	if err != nil {
+		t.Errorf("cannot get seqnums: %v", err)
+		return
+	}
+	if len(seqnums) != 1 {
+		t.Errorf("invalid seqnum count: %d", len(seqnums))
+		return
+	}
+	publicKey, err := ring.PublicKey(seqnums[0], api.ThemisKeyPairFormat)
+	if err != nil {
+		t.Errorf("cannot get public key data: %v", err)
+	}
+	privateKey, err := ring.PrivateKey(seqnums[0], api.ThemisKeyPairFormat)
+	if err != nil {
+		t.Errorf("cannot get private key data: %v", err)
+	}
+	if subtle.ConstantTimeCompare(publicKey, demoPublicKeyData) != 1 {
+		t.Errorf("incorrect public key data")
+	}
+	if subtle.ConstantTimeCompare(privateKey, demoPrivateKeyData) != 1 {
+		t.Errorf("incorrect private key data")
+	}
+}
+
+func checkDemoKeyRingPublic(t *testing.T, ring api.KeyRing) {
+	seqnums, err := ring.AllKeys()
+	if err != nil {
+		t.Errorf("cannot get seqnums: %v", err)
+		return
+	}
+	if len(seqnums) != 1 {
+		t.Errorf("invalid seqnum count: %d", len(seqnums))
+		return
+	}
+	publicKey, err := ring.PublicKey(seqnums[0], api.ThemisKeyPairFormat)
+	if err != nil {
+		t.Errorf("cannot get public key data: %v", err)
+	}
+	_, err = ring.PrivateKey(seqnums[0], api.ThemisKeyPairFormat)
+	if err != api.ErrNoKeyData {
+		t.Errorf("unexpected error for private key data: %v", err)
+	}
+	if subtle.ConstantTimeCompare(publicKey, demoPublicKeyData) != 1 {
+		t.Errorf("incorrect public key data")
+	}
+}
+
+func checkDemoKeyRingSymmetric(t *testing.T, ring api.KeyRing) {
+	seqnums, err := ring.AllKeys()
+	if err != nil {
+		t.Errorf("cannot get seqnums of public key ring: %v", err)
+		return
+	}
+	if len(seqnums) != 1 {
+		t.Errorf("invalid seqnum count: %d", len(seqnums))
+		return
+	}
+	symmetricKey, err := ring.SymmetricKey(seqnums[0], api.ThemisSymmetricKeyFormat)
+	if err != nil {
+		t.Errorf("cannot get symmetric key data: %v", err)
+	}
+	if subtle.ConstantTimeCompare(symmetricKey, demoSymmetricKeyData) != 1 {
+		t.Errorf("incorrect symmetric key data")
+	}
+}
+
+type stubImportDelegate struct {
+	decision api.ImportDecision
+	err      error
+}
+
+func (s *stubImportDelegate) DecideKeyRingOverwrite(currentData, newData *asn1.KeyRing) (api.ImportDecision, error) {
+	return s.decision, s.err
+}
+
+func testKeyStoreCleanImport(t *testing.T, newKeyStore NewKeyStore) {
 	s := newKeyStore(t)
 	setupDemoKeyStore(s, t)
+	cryptosuite := newExportStoreSuite(t)
 
-	_, err := s.ExportKeyRings(exportRingAll, newExportStoreSuite(t))
+	exported, err := s.ExportKeyRings(exportRingAll, cryptosuite)
 	if err != nil {
-		t.Errorf("failed to export key rings: %v", err)
+		t.Fatalf("failed to export key rings: %v", err)
+	}
+
+	s2 := newKeyStore(t)
+
+	err = s2.ImportKeyRings(exported, cryptosuite, nil)
+	if err != nil {
+		t.Fatalf("failed to import key rings: %v", err)
+	}
+
+	ringKeyPair, err := s2.OpenKeyRing(exportRingKeyPair)
+	if err != nil {
+		t.Errorf("cannot open key ring with key pair: %v", err)
+	} else {
+		checkDemoKeyRingKeyPair(t, ringKeyPair)
+	}
+
+	ringPublic, err := s2.OpenKeyRing(exportRingPublic)
+	if err != nil {
+		t.Errorf("cannot open key ring with public key: %v", err)
+	} else {
+		checkDemoKeyRingPublic(t, ringPublic)
+	}
+
+	ringSymmetric, err := s2.OpenKeyRing(exportRingSymmetric)
+	if err != nil {
+		t.Errorf("cannot open key ring with symmetric key: %v", err)
+	} else {
+		checkDemoKeyRingSymmetric(t, ringSymmetric)
+	}
+}
+
+func testKeyStoreDuplicateImport(t *testing.T, newKeyStore NewKeyStore) {
+	s := newKeyStore(t)
+	s2 := newKeyStore(t)
+	setupDemoKeyStore(s, t)
+	cryptosuite := newExportStoreSuite(t)
+
+	exported1, err := s.ExportKeyRings([]string{exportRingPublic}, cryptosuite)
+	if err != nil {
+		t.Fatalf("failed to export public key ring: %v", err)
+	}
+
+	err = s2.ImportKeyRings(exported1, cryptosuite, nil)
+	if err != nil {
+		t.Fatalf("failed to import public key ring: %v", err)
+	}
+
+	exported2, err := s.ExportKeyRings([]string{exportRingKeyPair, exportRingPublic, exportRingSymmetric}, cryptosuite)
+	if err != nil {
+		t.Fatalf("failed to export key rings: %v", err)
+	}
+
+	duplicateError := errors.New("duplicate detected")
+	delegate := &stubImportDelegate{
+		decision: api.ImportAbort,
+		err:      duplicateError,
+	}
+	err = s2.ImportKeyRings(exported2, cryptosuite, delegate)
+	if err != duplicateError {
+		t.Fatalf("duplicate import should be aborted: %v", err)
+	}
+
+	// Note that key exported key pair has been imported successfully, the process aborted at public key
+	ringKeyPair, err := s2.OpenKeyRing(exportRingKeyPair)
+	if err != nil {
+		t.Errorf("cannot open key ring with key pair: %v", err)
+	} else {
+		checkDemoKeyRingKeyPair(t, ringKeyPair)
+	}
+
+	ringPublic, err := s2.OpenKeyRing(exportRingPublic)
+	if err != nil {
+		t.Errorf("cannot open key ring with public key: %v", err)
+	} else {
+		checkDemoKeyRingPublic(t, ringPublic)
+	}
+
+	_, err = s2.OpenKeyRing(exportRingSymmetric)
+	if err == nil {
+		t.Errorf("symmetric key should not be imported: %v", err)
+	}
+}
+
+func testKeyStoreDuplicateImportSkip(t *testing.T, newKeyStore NewKeyStore) {
+	s := newKeyStore(t)
+	s2 := newKeyStore(t)
+	setupDemoKeyStore(s, t)
+	cryptosuite := newExportStoreSuite(t)
+
+	exported1, err := s.ExportKeyRings([]string{exportRingPublic}, cryptosuite)
+	if err != nil {
+		t.Fatalf("failed to export public key ring: %v", err)
+	}
+
+	err = s2.ImportKeyRings(exported1, cryptosuite, nil)
+	if err != nil {
+		t.Fatalf("failed to import public key ring: %v", err)
+	}
+
+	exported2, err := s.ExportKeyRings([]string{exportRingKeyPair, exportRingPublic, exportRingSymmetric}, cryptosuite)
+	if err != nil {
+		t.Fatalf("failed to export key rings: %v", err)
+	}
+
+	delegate := &stubImportDelegate{
+		decision: api.ImportSkip,
+	}
+	err = s2.ImportKeyRings(exported2, cryptosuite, delegate)
+	if err != nil {
+		t.Fatalf("duplicate import should be skipped: %v", err)
+	}
+
+	// Now all three key rings are imported without issue. Already present public key
+	// is simply skipped.
+	ringKeyPair, err := s2.OpenKeyRing(exportRingKeyPair)
+	if err != nil {
+		t.Errorf("cannot open key ring with key pair: %v", err)
+	} else {
+		checkDemoKeyRingKeyPair(t, ringKeyPair)
+	}
+
+	ringPublic, err := s2.OpenKeyRing(exportRingPublic)
+	if err != nil {
+		t.Errorf("cannot open key ring with public key: %v", err)
+	} else {
+		checkDemoKeyRingPublic(t, ringPublic)
+	}
+
+	ringSymmetric, err := s2.OpenKeyRing(exportRingSymmetric)
+	if err != nil {
+		t.Errorf("cannot open key ring with symmetric key: %v", err)
+	} else {
+		checkDemoKeyRingSymmetric(t, ringSymmetric)
+	}
+}
+
+func checkDemoKeyRingKeyPublicNew(t *testing.T, ring api.KeyRing, newSeqnum int) {
+	seqnums, err := ring.AllKeys()
+	if err != nil {
+		t.Errorf("cannot get seqnums: %v", err)
+		return
+	}
+	if len(seqnums) != 2 {
+		t.Errorf("invalid seqnum count: %d", len(seqnums))
+		return
+	}
+	if seqnums[0] != newSeqnum {
+		t.Errorf("invalid seqnum[0]: %d", seqnums[1])
+		return
+	}
+
+	current, err := ring.CurrentKey()
+	if err != nil {
+		t.Errorf("falied to get current: %v", err)
+		return
+	}
+	if current != seqnums[0] {
+		t.Errorf("invalid current: %d", current)
+		return
+	}
+
+	publicKey, err := ring.PublicKey(seqnums[1], api.ThemisKeyPairFormat)
+	if err != nil {
+		t.Errorf("cannot get public key data: %v", err)
+	}
+	_, err = ring.PrivateKey(seqnums[1], api.ThemisKeyPairFormat)
+	if err != api.ErrNoKeyData {
+		t.Errorf("unexpected error for private key data: %v", err)
+	}
+	if subtle.ConstantTimeCompare(publicKey, demoPublicKeyData) != 1 {
+		t.Errorf("incorrect public key data")
+	}
+
+	publicKey2, err := ring.PublicKey(seqnums[0], api.ThemisKeyPairFormat)
+	if err != nil {
+		t.Errorf("cannot get public key data: %v", err)
+	}
+	_, err = ring.PrivateKey(seqnums[0], api.ThemisKeyPairFormat)
+	if err != api.ErrNoKeyData {
+		t.Errorf("unexpected error for private key data: %v", err)
+	}
+	if subtle.ConstantTimeCompare(publicKey2, []byte("another public key")) != 1 {
+		t.Errorf("incorrect public key data")
+	}
+
+}
+
+func testKeyStoreDuplicateImportOverwrite(t *testing.T, newKeyStore NewKeyStore) {
+	s := newKeyStore(t)
+	s2 := newKeyStore(t)
+	setupDemoKeyStore(s, t)
+	cryptosuite := newExportStoreSuite(t)
+
+	exported1, err := s.ExportKeyRings([]string{exportRingPublic}, cryptosuite)
+	if err != nil {
+		t.Fatalf("failed to export public key ring: %v", err)
+	}
+
+	err = s2.ImportKeyRings(exported1, cryptosuite, nil)
+	if err != nil {
+		t.Fatalf("failed to import public key ring: %v", err)
+	}
+
+	ringPublic1, err := s.OpenKeyRingRW(exportRingPublic)
+	if err != nil {
+		t.Fatalf("failed to open public key ring: %v", err)
+	}
+
+	newSeqnum, err := ringPublic1.AddKey(api.KeyDescription{
+		ValidSince: time.Now(),
+		ValidUntil: time.Now().Add(time.Hour),
+		Data: []api.KeyData{
+			api.KeyData{
+				Format:    api.ThemisKeyPairFormat,
+				PublicKey: []byte("another public key"),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to add new public key: %v", err)
+	}
+	err = ringPublic1.SetCurrent(newSeqnum)
+	if err != nil {
+		t.Fatalf("failed to set new public key current: %v", err)
+	}
+
+	exported2, err := s.ExportKeyRings([]string{exportRingKeyPair, exportRingPublic, exportRingSymmetric}, cryptosuite)
+	if err != nil {
+		t.Fatalf("failed to export key rings: %v", err)
+	}
+
+	delegate := &stubImportDelegate{
+		decision: api.ImportOverwrite,
+	}
+	err = s2.ImportKeyRings(exported2, cryptosuite, delegate)
+	if err != nil {
+		t.Fatalf("duplicate import should be overwritten: %v", err)
+	}
+
+	// Now all three key rings are imported without issue. Already present public key
+	// is overwritten with new data.
+	ringKeyPair, err := s2.OpenKeyRing(exportRingKeyPair)
+	if err != nil {
+		t.Errorf("cannot open key ring with key pair: %v", err)
+	} else {
+		checkDemoKeyRingKeyPair(t, ringKeyPair)
+	}
+
+	ringPublic, err := s2.OpenKeyRing(exportRingPublic)
+	if err != nil {
+		t.Errorf("cannot open key ring with public key: %v", err)
+	} else {
+		checkDemoKeyRingKeyPublicNew(t, ringPublic, newSeqnum)
+	}
+
+	ringSymmetric, err := s2.OpenKeyRing(exportRingSymmetric)
+	if err != nil {
+		t.Errorf("cannot open key ring with symmetric key: %v", err)
+	} else {
+		checkDemoKeyRingSymmetric(t, ringSymmetric)
 	}
 }

--- a/keystore/v2/keystore/api/tests/keyStore.go
+++ b/keystore/v2/keystore/api/tests/keyStore.go
@@ -19,9 +19,110 @@ package tests
 
 import (
 	"testing"
+	"time"
 
 	"github.com/cossacklabs/acra/keystore/v2/keystore/api"
+	"github.com/cossacklabs/acra/keystore/v2/keystore/crypto"
 )
 
 // NewKeyStore is a factory of KeyStore under testing.
 type NewKeyStore func(t *testing.T) api.MutableKeyStore
+
+const (
+	exportRingKeyPair   = "keyring/keypair"
+	exportRingPublic    = "keyring/public"
+	exportRingSymmetric = "keyring/symmetric"
+)
+
+var exportRingAll = []string{
+	exportRingKeyPair,
+	exportRingPublic,
+	exportRingSymmetric,
+}
+
+// TestKeyStore runs KeyStore test suite.
+func TestKeyStore(t *testing.T, newKeyStore NewKeyStore) {
+	t.Run("TestKeyStoreExport", func(t *testing.T) {
+		testKeyStoreExport(t, newKeyStore)
+	})
+}
+
+var (
+	testExportMasterKey    = []byte("test export master key")
+	testExportSignatureKey = []byte("test export signature key")
+)
+
+func newExportStoreSuite(t *testing.T) *crypto.KeyStoreSuite {
+	encryptor, err := crypto.NewSCellSuite(testExportMasterKey, testExportSignatureKey)
+	if err != nil {
+		t.Fatalf("cannot create encryptor: %v", err)
+	}
+	return encryptor
+}
+
+func setupDemoKeyStore(s api.MutableKeyStore, t *testing.T) {
+	ringKeyPair, err := s.OpenKeyRingRW(exportRingKeyPair)
+	if err != nil {
+		t.Errorf("failed to create key ring: %v", err)
+	}
+	_, err = ringKeyPair.AddKey(api.KeyDescription{
+		ValidSince: time.Now(),
+		ValidUntil: time.Now().Add(time.Hour),
+		Data: []api.KeyData{
+			api.KeyData{
+				Format:     api.ThemisKeyPairFormat,
+				PublicKey:  []byte("public key"),
+				PrivateKey: []byte("private key"),
+			},
+		},
+	})
+	if err != nil {
+		t.Errorf("failed to add key pair: %v", err)
+	}
+
+	ringPublic, err := s.OpenKeyRingRW(exportRingPublic)
+	if err != nil {
+		t.Errorf("failed to create key ring: %v", err)
+	}
+	_, err = ringPublic.AddKey(api.KeyDescription{
+		ValidSince: time.Now(),
+		ValidUntil: time.Now().Add(time.Hour),
+		Data: []api.KeyData{
+			api.KeyData{
+				Format:    api.ThemisKeyPairFormat,
+				PublicKey: []byte("only public key"),
+			},
+		},
+	})
+	if err != nil {
+		t.Errorf("failed to add public key: %v", err)
+	}
+
+	ringSymmetric, err := s.OpenKeyRingRW(exportRingSymmetric)
+	if err != nil {
+		t.Errorf("failed to create key ring: %v", err)
+	}
+	_, err = ringSymmetric.AddKey(api.KeyDescription{
+		ValidSince: time.Now(),
+		ValidUntil: time.Now().Add(time.Hour),
+		Data: []api.KeyData{
+			api.KeyData{
+				Format:       api.ThemisSymmetricKeyFormat,
+				SymmetricKey: []byte("symmetric key"),
+			},
+		},
+	})
+	if err != nil {
+		t.Errorf("failed to add public key: %v", err)
+	}
+}
+
+func testKeyStoreExport(t *testing.T, newKeyStore NewKeyStore) {
+	s := newKeyStore(t)
+	setupDemoKeyStore(s, t)
+
+	_, err := s.ExportKeyRings(exportRingAll, newExportStoreSuite(t))
+	if err != nil {
+		t.Errorf("failed to export key rings: %v", err)
+	}
+}

--- a/keystore/v2/keystore/asn1/asn1.go
+++ b/keystore/v2/keystore/asn1/asn1.go
@@ -242,7 +242,7 @@ type KeyFormat asn1.Enumerated
 // Supported key formats:
 const (
 	ThemisKeyPairFormat KeyFormat = iota + 1
-	ThemisPublicKeyFormat
+	_                             // reserved
 	ThemisSymmetricKeyFormat
 )
 

--- a/keystore/v2/keystore/asn1/asn1.go
+++ b/keystore/v2/keystore/asn1/asn1.go
@@ -102,6 +102,7 @@ const (
 	TypeKeyRing ContentType = iota + 1
 	TypeKeyDirectory
 	TypeDirectKeyDirectory
+	TypeEncryptedKeys
 )
 
 // Common Version constants:
@@ -147,6 +148,32 @@ func UnmarshalKeyDirectory(data []byte) (*KeyDirectory, error) {
 		return nil, ErrExtraData
 	}
 	return container, nil
+}
+
+// EncryptedKeys is a set of key rings.
+// It is typically used for backup purposes or to transfer keys between machines.
+// SignedContainer actually contains an OCTET STRING with DER serialization of this object
+// encrypted with Themis Secure Cell.
+type EncryptedKeys struct {
+	KeyRings []KeyRing `asn1:"set"`
+}
+
+// Marshal into bytes.
+func (keys *EncryptedKeys) Marshal() ([]byte, error) {
+	return asn1.Marshal(*keys)
+}
+
+// UnmarshalEncryptedKeys constructs EncryptedKeys from serialized representation.
+func UnmarshalEncryptedKeys(data []byte) (*EncryptedKeys, error) {
+	keys := new(EncryptedKeys)
+	rest, err := asn1.Unmarshal(data, keys)
+	if err != nil {
+		return nil, err
+	}
+	if len(rest) != 0 {
+		return nil, ErrExtraData
+	}
+	return keys, nil
 }
 
 // KeyRingReference to a child key ring, not included into KeyDirectory object directly.

--- a/keystore/v2/keystore/asn1/keyStoreFormat.asn1
+++ b/keystore/v2/keystore/asn1/keyStoreFormat.asn1
@@ -40,8 +40,9 @@ SignedContainer ::= SEQUENCE {
 -- Common content identifiers for the "data" field of SignedContainer objects.
 ContentType ::= ENUMERATED {
     typeKeyRing             (1),
-    typeKeyDirectory        (2)
-    typeDirectKeyDirectory  (3)
+    typeKeyDirectory        (2),
+    typeDirectKeyDirectory  (3),
+    typeEncryptedKeys       (4)
 --  ...
 }
 
@@ -71,6 +72,13 @@ KeyDirectory ::= SEQUENCE {
     name            LikelyUTF8String,   -- human-readable name of the directory
     keyRings    [1] SET OF KeyRingReference OPTIONAL,       -- attached key rings
     children    [2] SET OF KeyDirectoryReference OPTIONAL   -- child directories
+}
+
+-- Encrypted set of key rings, typically used for backup purposes or to transfer
+-- keys between machines. SignedContainer actually contains an OCTET STRING with
+-- DER serialization of this object encrypted with Themis Secure Cell.
+EncryptedKeys := SEQUENCE {
+    keyRings    SET OF KeyRing     -- exported key ring data
 }
 
 -- Reference to a child key ring, not included into KeyDirectory object directly.

--- a/keystore/v2/keystore/asn1/keyStoreFormat.asn1
+++ b/keystore/v2/keystore/asn1/keyStoreFormat.asn1
@@ -131,8 +131,8 @@ KeyData ::= SEQUENCE {
 }
 
 KeyFormat ::= ENUMERATED {
-    themisKeyPair       (1),    -- asymmetric key pair (public + private key)
-    themisPublicKey     (2),    -- standalone public key
+    themisKeyPair       (1),    -- asymmetric key pair (public and private key, or public key alone)
+--  reserved            (2),    -- (was intended for standalone public keys, now reserved)
     themisSymmetricKey  (3)     -- symmetric key
 --  ...
 }

--- a/keystore/v2/keystore/filesystem/export.go
+++ b/keystore/v2/keystore/filesystem/export.go
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2020, Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package filesystem
+
+import (
+	"errors"
+	"time"
+
+	"github.com/cossacklabs/acra/keystore/v2/keystore/api"
+	"github.com/cossacklabs/acra/keystore/v2/keystore/asn1"
+	"github.com/cossacklabs/acra/keystore/v2/keystore/crypto"
+	backendAPI "github.com/cossacklabs/acra/keystore/v2/keystore/filesystem/backend/api"
+	"github.com/cossacklabs/acra/keystore/v2/keystore/signature"
+	"github.com/cossacklabs/acra/utils"
+)
+
+// Errors returned by export/import routines.
+var (
+	ErrKeyRingExists = errors.New("imported key ring already exists")
+)
+
+func (s *KeyStore) exportKeyRings(paths []string) (rings []asn1.KeyRing, err error) {
+	rings = make([]asn1.KeyRing, len(paths))
+	defer func() {
+		if err != nil {
+			zeroizeKeyRings(rings)
+		}
+	}()
+	for i, path := range paths {
+		err := s.exportKeyRing(path, &rings[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return rings, nil
+}
+
+func (s *KeyStore) exportKeyRing(path string, ringData *asn1.KeyRing) error {
+	ring := newKeyRing(s, path)
+	err := s.readKeyRing(ring)
+	if err != nil {
+		return err
+	}
+	*ringData, err = ring.exportASN1()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *KeyStore) importKeyRing(newRingData *asn1.KeyRing, delegate *api.KeyRingImportDelegate) error {
+	keyRing := newKeyRing(s, string(newRingData.Purpose))
+	err := s.readKeyRing(keyRing)
+	switch err {
+	case nil:
+		// If the key store successfuly returned an existing key ring with the same name,
+		// we have to resolve this conflict somehow. Present both current and new versions
+		// to the delegate and let it decide how to proceed.
+		decision := api.ImportAbort
+		err := ErrKeyRingExists
+		if delegate != nil && delegate.DecideKeyRingOverwrite != nil {
+			decision, err = delegate.DecideKeyRingOverwrite(keyRing.data, newRingData)
+		}
+		switch decision {
+		case api.ImportOverwrite:
+			// Forget whatever we just read and import into a clean key ring.
+			keyRing = newKeyRing(s, string(newRingData.Purpose))
+			err := keyRing.importASN1(newRingData)
+			if err != nil {
+				return err
+			}
+		case api.ImportSkip:
+			return nil
+		default:
+			return err
+		}
+
+	case backendAPI.ErrNotExist:
+		// If the key ring does not seem to exist right now, go ahead with clean-slate import.
+		err := keyRing.importASN1(newRingData)
+		if err != nil {
+			return err
+		}
+
+	default:
+		// Otherwise, this is some unexpected error from the key store. Abort import and get out.
+		return err
+	}
+	return s.writeKeyRing(keyRing)
+}
+
+var exportKeyContext = []byte("AKSv2 keystore: exported key rings")
+
+func (s *KeyStore) encryptAndSignKeyRings(rings []asn1.KeyRing, cryptosuite *crypto.KeyStoreSuite) ([]byte, error) {
+	keysData := &asn1.EncryptedKeys{KeyRings: rings}
+	keysBytes, err := keysData.Marshal()
+	if err != nil {
+		return nil, err
+	}
+	defer utils.FillSlice(0, keysBytes)
+
+	encryptedKeyBytes, err := cryptosuite.KeyEncryptor.Encrypt(keysBytes, exportKeyContext)
+	if err != nil {
+		return nil, err
+	}
+	container := asn1.SignedContainer{Payload: asn1.SignedPayload{
+		ContentType:  asn1.TypeEncryptedKeys,
+		Version:      asn1.KeyRingVersion2,
+		LastModified: time.Now(),
+		Data:         encryptedKeyBytes,
+	}}
+
+	notary, err := signature.NewNotary(cryptosuite.SignatureAlgorithms)
+	if err != nil {
+		return nil, err
+	}
+	signedKeyContainer, err := notary.Sign(&container, exportKeyContext)
+	if err != nil {
+		return nil, err
+	}
+	return signedKeyContainer, nil
+}
+
+func (s *KeyStore) decryptAndVerifyKeyRings(ringData []byte, cryptosuite *crypto.KeyStoreSuite) ([]asn1.KeyRing, error) {
+	panic("not implemented")
+}
+
+func (r *KeyRing) exportASN1() (exported asn1.KeyRing, err error) {
+	exported = asn1.KeyRing{
+		Purpose: r.data.Purpose,
+		Current: r.data.Current,
+		Keys:    make([]asn1.Key, len(r.data.Keys)),
+	}
+	copy(exported.Keys, r.data.Keys)
+	defer func() {
+		if err != nil {
+			zeroizeKeyRing(&exported)
+		}
+	}()
+	for i := range exported.Keys {
+		decrypted, err := r.decryptAllKeyData(exported.Keys[i].Data, exported.Keys[i].Seqnum)
+		if err != nil {
+			return exported, err
+		}
+		exported.Keys[i].Data = decrypted
+	}
+	return exported, nil
+}
+
+func (r *KeyRing) importASN1(*asn1.KeyRing) error {
+	panic("not implemented")
+}
+
+func (r *KeyRing) decryptAllKeyData(encrypted []asn1.KeyData, seqnum int) (decrypted []asn1.KeyData, err error) {
+	decrypted = make([]asn1.KeyData, len(encrypted))
+	copy(decrypted, encrypted)
+	defer func() {
+		if err != nil {
+			zeroizeKeyData(decrypted)
+		}
+	}()
+	for i := range decrypted {
+		err = r.decryptKeyData(&decrypted[i], seqnum)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return decrypted, nil
+}
+
+func (r *KeyRing) decryptKeyData(data *asn1.KeyData, seqnum int) error {
+	if len(data.PrivateKey) != 0 {
+		privateKey, err := r.decryptPrivateKey(seqnum, data.PrivateKey)
+		if err != nil {
+			return err
+		}
+		data.PrivateKey = privateKey
+	}
+	if len(data.SymmetricKey) != 0 {
+		symmetricKey, err := r.decryptSymmetricKey(seqnum, data.SymmetricKey)
+		if err != nil {
+			return err
+		}
+		data.SymmetricKey = symmetricKey
+	}
+	return nil
+}
+
+func zeroizeKeyRings(rings []asn1.KeyRing) {
+	for i := range rings {
+		zeroizeKeyRing(&rings[i])
+	}
+}
+
+func zeroizeKeyRing(ring *asn1.KeyRing) {
+	for i := range ring.Keys {
+		zeroizeKeyData(ring.Keys[i].Data)
+	}
+}
+
+func zeroizeKeyData(data []asn1.KeyData) {
+	for i := range data {
+		utils.FillSlice(0, data[i].PrivateKey)
+		utils.FillSlice(0, data[i].PublicKey)
+		utils.FillSlice(0, data[i].SymmetricKey)
+	}
+}

--- a/keystore/v2/keystore/filesystem/keyStore_test.go
+++ b/keystore/v2/keystore/filesystem/keyStore_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/cossacklabs/acra/keystore/v2/keystore/api"
+	"github.com/cossacklabs/acra/keystore/v2/keystore/api/tests"
 	"github.com/cossacklabs/acra/keystore/v2/keystore/crypto"
 	backend "github.com/cossacklabs/acra/keystore/v2/keystore/filesystem/backend"
 	backendAPI "github.com/cossacklabs/acra/keystore/v2/keystore/filesystem/backend/api"
@@ -190,4 +191,14 @@ func TestKeyStorePersistence(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to open key ring: %v", err)
 	}
+}
+
+func TestKeyStoreInMemory(t *testing.T) {
+	tests.TestKeyStore(t, newInMemoryKeyStore)
+}
+
+func TestKeyStoreFilesystem(t *testing.T) {
+	newFilesystemKeyStore, cleanup := testFilesystemKeyStore(t)
+	defer cleanup()
+	tests.TestKeyStore(t, newFilesystemKeyStore)
 }


### PR DESCRIPTION
This PR is work-in-progress on key export and import. Here we add low-level API for exporting and importing keys, and implement the export code path which is easier. Importing will come later as it's a bit harder. Meanwhile I'd like to get feedback on whatever is ready at the moment.

First of all we get rid of an unused key type for public keys only. I intended it to be used when a service needs to store only public keys of its peers. However, it's not convenient to use when programming, and it's not really a new "type" – it's just the same Themis key pair, just without the private part. So, instead of inventing a new type, just reuse the existing key pair and store only the public key. Update the code to allow skipping private keys and return a more appropriate error when a private key is requested for a key pair that does not have one.

The next commit adds the data structure used for exported keys. It's a simple list of key ring data which is going to be encrypted and signed for export. Resulting binary blob is what's going to be stored for backup and transferred between machines. Its structure is the following:

- `SignedContainer` signed with an exporting key (different from the key used by the key store)
  - binary blob, result of Themis Secure Cell encryption with another exporting key for encryption 
    - `EncryptedKeys` structure containing `KeyRing` data
      Individual key rings and keys inside them are not encrypted. Instead, the entire list is encrypted to conceal its contents.

Finally, we add some API that's going to be used for exporting and importing key rings. For export you give a list of key rings you need and get an encrypted blob in return. Then this blob can be used to import the key rings inside it. In both cases you need to explicitly pass a "crypto suite" which will be used for the transfer, it is different from the suite used by the key store to access the key data. 

Also, importing operation is more involved. We have to decide what to do if the key ring already exists. I currently have no concrete vision of what situations we might run into. For example, the same backup may be imported twice, or an outdated backup applied, or an incremental one, or there is an overlap in data. Whatever it is, I want the interface to be extensible enough to be able to handle that situations when we identify them.

This PR implements only the exporting path, and it's more like a backend support. `acra-keys` tool still has to be taught to use this API, and for that we'll need to first provide an API to retrieve all available key rings.