### PR TITLE
"acra-keys list" subcommand

### DIFF
--- a/cmd/acra-keys/keys/command-line.go
+++ b/cmd/acra-keys/keys/command-line.go
@@ -43,12 +43,14 @@ var DefaultConfigPath = utils.GetConfigPathByName("acra-keys")
 
 // Sub-command names:
 const (
+	CmdListKeys   = "list"
 	CmdReadKey    = "read"
 	CmdDestroyKey = "destroy"
 )
 
 // SupportedSubCommands lists supported sub-commands or CLI.
 var SupportedSubCommands = []string{
+	CmdListKeys,
 	CmdReadKey,
 	CmdDestroyKey,
 }
@@ -88,6 +90,7 @@ type CommandLineParams struct {
 	ReadKeyKind    string
 	DestroyKeyKind string
 
+	listFlags    *flag.FlagSet
 	readFlags    *flag.FlagSet
 	destroyFlags *flag.FlagSet
 }
@@ -102,6 +105,12 @@ func (params *CommandLineParams) Register() {
 	flag.StringVar(&params.KeyDirPublic, "keys_dir_public", "", "path to key directory for public keys")
 	flag.StringVar(&params.ClientID, "client_id", "", "client ID for which to retrieve key")
 	flag.StringVar(&params.ZoneID, "zone_id", "", "zone ID for which to retrieve key")
+
+	params.listFlags = flag.NewFlagSet(CmdListKeys, flag.ContinueOnError)
+	params.listFlags.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Command \"%s\": list available keys in the key store\n", CmdListKeys)
+		fmt.Fprintf(os.Stderr, "\n\t%s %s [options...]\n", os.Args[0], CmdListKeys)
+	}
 
 	params.readFlags = flag.NewFlagSet(CmdReadKey, flag.ContinueOnError)
 	params.readFlags.Usage = func() {
@@ -125,6 +134,9 @@ func usage() {
 
 	fmt.Fprintf(os.Stderr, "\nGlobal options:\n")
 	cmd.PrintFlags(flag.CommandLine)
+
+	fmt.Fprintf(os.Stderr, "\n")
+	Params.listFlags.Usage()
 
 	fmt.Fprintf(os.Stderr, "\n")
 	Params.readFlags.Usage()
@@ -156,6 +168,9 @@ func (params *CommandLineParams) ParseSubCommand() error {
 	}
 	params.Command = args[0]
 	switch args[0] {
+	case CmdListKeys:
+		return nil
+
 	case CmdReadKey:
 		err := params.readFlags.Parse(args[1:])
 		if err != nil {

--- a/cmd/acra-keys/keys/command-line.go
+++ b/cmd/acra-keys/keys/command-line.go
@@ -90,6 +90,8 @@ type CommandLineParams struct {
 	ReadKeyKind    string
 	DestroyKeyKind string
 
+	UseJSON bool
+
 	listFlags    *flag.FlagSet
 	readFlags    *flag.FlagSet
 	destroyFlags *flag.FlagSet
@@ -105,6 +107,7 @@ func (params *CommandLineParams) Register() {
 	flag.StringVar(&params.KeyDirPublic, "keys_dir_public", "", "path to key directory for public keys")
 	flag.StringVar(&params.ClientID, "client_id", "", "client ID for which to retrieve key")
 	flag.StringVar(&params.ZoneID, "zone_id", "", "zone ID for which to retrieve key")
+	flag.BoolVar(&params.UseJSON, "json", false, "use machine-readable JSON output")
 
 	params.listFlags = flag.NewFlagSet(CmdListKeys, flag.ContinueOnError)
 	params.listFlags.Usage = func() {

--- a/cmd/acra-keys/keys/list-keys.go
+++ b/cmd/acra-keys/keys/list-keys.go
@@ -52,6 +52,7 @@ const (
 func printKeysTable(keys []keystore.KeyDescription, writer io.Writer) error {
 	maxPurposeLen := len(purposeHeader)
 	maxExtraIDLen := len(extraIDHeader)
+	maxKeyIDLen := len(idHeader)
 	for _, key := range keys {
 		if len(key.Purpose) > maxPurposeLen {
 			maxPurposeLen = len(key.Purpose)
@@ -62,12 +63,17 @@ func printKeysTable(keys []keystore.KeyDescription, writer io.Writer) error {
 		if len(key.ZoneID) > maxExtraIDLen {
 			maxExtraIDLen = len(key.ZoneID)
 		}
+		if len(key.ID) > maxKeyIDLen {
+			maxKeyIDLen = len(key.ID)
+		}
 	}
 
-	fmt.Fprintf(writer, "%-*s  %-*s  %s\n", maxPurposeLen, purposeHeader, maxExtraIDLen, extraIDHeader, idHeader)
+	fmt.Fprintf(writer, "%-*s | %-*s | %s\n", maxPurposeLen, purposeHeader, maxExtraIDLen, extraIDHeader, idHeader)
 
-	separator := make([]byte, maxPurposeLen+maxExtraIDLen+len(idHeader)+4)
+	separator := make([]byte, maxPurposeLen+maxExtraIDLen+maxKeyIDLen+6)
 	utils.FillSlice(byte('-'), separator)
+	separator[maxPurposeLen+1] = byte('+')
+	separator[maxPurposeLen+maxExtraIDLen+4] = byte('+')
 	fmt.Fprintln(writer, string(separator))
 
 	for _, key := range keys {
@@ -78,7 +84,7 @@ func printKeysTable(keys []keystore.KeyDescription, writer io.Writer) error {
 		if key.ZoneID != nil {
 			extraID = string(key.ZoneID)
 		}
-		fmt.Fprintf(writer, "%*s  %*s  %s\n", maxPurposeLen, key.Purpose, maxExtraIDLen, extraID, key.ID)
+		fmt.Fprintf(writer, "%-*s | %-*s | %s\n", maxPurposeLen, key.Purpose, maxExtraIDLen, extraID, key.ID)
 	}
 	return nil
 }

--- a/cmd/acra-keys/keys/list-keys.go
+++ b/cmd/acra-keys/keys/list-keys.go
@@ -17,6 +17,7 @@
 package keys
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -26,7 +27,20 @@ import (
 
 // PrintKeys prints key list prettily into the given writer.
 func PrintKeys(keys []keystore.KeyDescription, writer io.Writer, params *CommandLineParams) error {
+	if params.UseJSON {
+		return printKeysJSON(keys, writer)
+	}
 	return printKeysTable(keys, writer)
+}
+
+func printKeysJSON(keys []keystore.KeyDescription, writer io.Writer) error {
+	json, err := json.Marshal(keys)
+	if err != nil {
+		return err
+	}
+	json = append(json, byte('\n'))
+	_, err = writer.Write(json)
+	return err
 }
 
 const (

--- a/cmd/acra-keys/keys/list-keys.go
+++ b/cmd/acra-keys/keys/list-keys.go
@@ -17,12 +17,54 @@
 package keys
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/cossacklabs/acra/keystore"
+	"github.com/cossacklabs/acra/utils"
 )
 
 // PrintKeys prints key list prettily into the given writer.
 func PrintKeys(keys []keystore.KeyDescription, writer io.Writer, params *CommandLineParams) error {
-	panic("not implemented")
+	return printKeysTable(keys, writer)
+}
+
+const (
+	purposeHeader = "Key purpose"
+	extraIDHeader = "Client/Zone ID"
+	idHeader      = "Key ID"
+)
+
+func printKeysTable(keys []keystore.KeyDescription, writer io.Writer) error {
+	maxPurposeLen := len(purposeHeader)
+	maxExtraIDLen := len(extraIDHeader)
+	for _, key := range keys {
+		if len(key.Purpose) > maxPurposeLen {
+			maxPurposeLen = len(key.Purpose)
+		}
+		if len(key.ClientID) > maxExtraIDLen {
+			maxExtraIDLen = len(key.ClientID)
+		}
+		if len(key.ZoneID) > maxExtraIDLen {
+			maxExtraIDLen = len(key.ZoneID)
+		}
+	}
+
+	fmt.Fprintf(writer, "%-*s  %-*s  %s\n", maxPurposeLen, purposeHeader, maxExtraIDLen, extraIDHeader, idHeader)
+
+	separator := make([]byte, maxPurposeLen+maxExtraIDLen+len(idHeader)+4)
+	utils.FillSlice(byte('-'), separator)
+	fmt.Fprintln(writer, string(separator))
+
+	for _, key := range keys {
+		var extraID string
+		if key.ClientID != nil {
+			extraID = string(key.ClientID)
+		}
+		if key.ZoneID != nil {
+			extraID = string(key.ZoneID)
+		}
+		fmt.Fprintf(writer, "%*s  %*s  %s\n", maxPurposeLen, key.Purpose, maxExtraIDLen, extraID, key.ID)
+	}
+	return nil
 }

--- a/cmd/acra-keys/keys/list-keys.go
+++ b/cmd/acra-keys/keys/list-keys.go
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020, Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package keys
+
+import (
+	"io"
+
+	"github.com/cossacklabs/acra/keystore"
+)
+
+// PrintKeys prints key list prettily into the given writer.
+func PrintKeys(keys []keystore.KeyDescription, writer io.Writer, params *CommandLineParams) error {
+	panic("not implemented")
+}

--- a/cmd/acra-keys/keys/list-keys_test.go
+++ b/cmd/acra-keys/keys/list-keys_test.go
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2020, Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package keys
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/cossacklabs/acra/keystore"
+)
+
+func TestPrintKeysDefault(t *testing.T) {
+	keys := []keystore.KeyDescription{
+		keystore.KeyDescription{
+			ID:      "Test ID Please Ignore",
+			Purpose: "no particular",
+			ZoneID:  []byte("Area51"),
+		},
+		keystore.KeyDescription{
+			ID:      "Another ID",
+			Purpose: "testing",
+		},
+	}
+
+	output := strings.Builder{}
+	err := PrintKeys(keys, &output, &CommandLineParams{UseJSON: false})
+	if err != nil {
+		t.Fatalf("Failed to print keys: %v", err)
+	}
+
+	actual := output.String()
+	expected := `Key purpose   | Client/Zone ID | Key ID
+--------------+----------------+----------------------
+no particular | Area51         | Test ID Please Ignore
+testing       |                | Another ID
+`
+	if actual != expected {
+		t.Errorf("Incorrect output.\nActual:\n%s\nExpected:\n%s", actual, expected)
+	}
+}
+
+func TestPrintKeysJSON(t *testing.T) {
+	keys := []keystore.KeyDescription{
+		keystore.KeyDescription{
+			ID:      "Test ID Please Ignore",
+			Purpose: "no particular",
+			ZoneID:  []byte("Area51"),
+		},
+		keystore.KeyDescription{
+			ID:      "Another ID",
+			Purpose: "testing",
+		},
+	}
+
+	output := bytes.Buffer{}
+	err := PrintKeys(keys, &output, &CommandLineParams{UseJSON: true})
+	if err != nil {
+		t.Fatalf("Failed to print keys: %v", err)
+	}
+
+	var actual []keystore.KeyDescription
+	err = json.Unmarshal(output.Bytes(), &actual)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal JSON output: %v", err)
+	}
+
+	if !equalDescriptionLists(actual, keys) {
+		t.Errorf("Incorrect output:\n%s", string(output.Bytes()))
+	}
+}
+
+func equalDescriptionLists(a, b []keystore.KeyDescription) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if !equalDescriptions(a[i], b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func equalDescriptions(a, b keystore.KeyDescription) bool {
+	return a.ID == b.ID && a.Purpose == b.Purpose &&
+		bytes.Equal(a.ClientID, b.ClientID) &&
+		bytes.Equal(a.ZoneID, b.ZoneID)
+}

--- a/keystore/filesystem/server_keystore.go
+++ b/keystore/filesystem/server_keystore.go
@@ -603,6 +603,12 @@ func (store *KeyStore) GenerateDataEncryptionKeys(id []byte) error {
 	return nil
 }
 
+// ListKeys enumerates keys present in the key store.
+func (store *KeyStore) ListKeys() ([]keystore.KeyDescription, error) {
+	// In Acra CE this method is implemented only for key store v2.
+	return nil, keystore.ErrNotImplemented
+}
+
 // Reset clears all cached keys
 func (store *KeyStore) Reset() {
 	store.cache.Clear()

--- a/keystore/keystore.go
+++ b/keystore/keystore.go
@@ -49,6 +49,7 @@ var (
 	ErrInvalidClientID          = errors.New("invalid client ID")
 	ErrEmptyMasterKey           = errors.New("master key is empty")
 	ErrMasterKeyIncorrectLength = fmt.Errorf("master key must have %v length in bytes", SymmetricKeyLength)
+	ErrNotImplemented           = errors.New("not implemented")
 )
 
 // GenerateSymmetricKey return new generated symmetric key that must used in keystore as master key and will comply
@@ -224,7 +225,20 @@ type ServerKeyStore interface {
 	StorageKeyCreation
 	WebConfigKeyStore
 
+	ListKeys() ([]KeyDescription, error)
 	Reset()
+}
+
+// KeyDescription describes a key in the key store.
+//
+// "ID" is unique string that can be used to identify this key set in the key store.
+// "Purpose" is short human-readable description of the key purpose.
+// "ClientID" and "ZoneID" are filled in where relevant.
+type KeyDescription struct {
+	ID       string
+	Purpose  string
+	ClientID []byte
+	ZoneID   []byte
 }
 
 // TranslationKeyStore enables AcraStruct translation. It is used by acra-translator tool.

--- a/keystore/keystore.go
+++ b/keystore/keystore.go
@@ -237,8 +237,8 @@ type ServerKeyStore interface {
 type KeyDescription struct {
 	ID       string
 	Purpose  string
-	ClientID []byte
-	ZoneID   []byte
+	ClientID []byte `json:",omitempty"`
+	ZoneID   []byte `json:",omitempty"`
 }
 
 // TranslationKeyStore enables AcraStruct translation. It is used by acra-translator tool.

--- a/keystore/v2/keystore/api/keyStore.go
+++ b/keystore/v2/keystore/api/keyStore.go
@@ -31,6 +31,9 @@ type KeyStore interface {
 	// This generally renders opened KeyRings unusable.
 	Close() error
 
+	// ListKeyRings enumerates all key rings present in this key store.
+	ListKeyRings() ([]string, error)
+
 	// ExportKeyRings packages specified key rings for export.
 	// Key ring data is encrypted and signed using given cryptosuite.
 	// Resulting container can be imported into existing or different key store with ImportKeyRings().

--- a/keystore/v2/keystore/api/tests/keyStore.go
+++ b/keystore/v2/keystore/api/tests/keyStore.go
@@ -57,6 +57,9 @@ func TestKeyStore(t *testing.T, newKeyStore NewKeyStore) {
 	t.Run("TestKeyStoreDuplicateImportOverwrite", func(t *testing.T) {
 		testKeyStoreDuplicateImportOverwrite(t, newKeyStore)
 	})
+	t.Run("TestKeyStoreListing", func(t *testing.T) {
+		testKeyStoreListing(t, newKeyStore)
+	})
 }
 
 var (
@@ -480,5 +483,32 @@ func testKeyStoreDuplicateImportOverwrite(t *testing.T, newKeyStore NewKeyStore)
 		t.Errorf("cannot open key ring with symmetric key: %v", err)
 	} else {
 		checkDemoKeyRingSymmetric(t, ringSymmetric)
+	}
+}
+
+func testKeyStoreListing(t *testing.T, newKeyStore NewKeyStore) {
+	s := newKeyStore(t)
+
+	keyRingsBefore, err := s.ListKeyRings()
+	if err != nil {
+		t.Fatalf("cannot list key rings: %v", err)
+	}
+
+	setupDemoKeyStore(s, t)
+
+	keyRingsAfter, err := s.ListKeyRings()
+	if err != nil {
+		t.Fatalf("cannot list key rings: %v", err)
+	}
+
+	if len(keyRingsBefore) != 0 {
+		t.Errorf("key store is not empty initially")
+	}
+
+	if len(keyRingsAfter) != 3 {
+		t.Fatalf("incorrect key ring count after setup")
+	}
+	if (keyRingsAfter[0] != exportRingKeyPair) || (keyRingsAfter[1] != exportRingPublic) || (keyRingsAfter[2] != exportRingSymmetric) {
+		t.Errorf("incorrect listing content: %v", keyRingsAfter)
 	}
 }

--- a/keystore/v2/keystore/filesystem/backend/api/backend.go
+++ b/keystore/v2/keystore/filesystem/backend/api/backend.go
@@ -40,6 +40,10 @@ type Backend interface {
 	// Returns ErrExist if path already exists.
 	Put(path string, data []byte) error
 
+	// ListAll enumerates all paths currently stored.
+	// The paths are returned in lexicographical order.
+	ListAll() ([]string, error)
+
 	// Rename oldpath into newpath atomically.
 	// Replaces newpath if it already exists.
 	// Returns ErrNotExist if oldpath does not exist.

--- a/keystore/v2/keystore/filesystem/backend/api/tests/backend.go
+++ b/keystore/v2/keystore/filesystem/backend/api/tests/backend.go
@@ -31,6 +31,9 @@ func TestBackend(t *testing.T, newBackend NewBackend) {
 	t.Run("TestGetPut", func(t *testing.T) {
 		testGetPut(t, newBackend)
 	})
+	t.Run("TestListAll", func(t *testing.T) {
+		testListAll(t, newBackend)
+	})
 	t.Run("TestSeparators", func(t *testing.T) {
 		testSeparators(t, newBackend)
 	})
@@ -101,6 +104,55 @@ func testSeparators(t *testing.T, newBackend NewBackend) {
 	}
 	if string(data) != "bravo" {
 		t.Errorf("Get() with forward slashes returned incorrect data: %v", string(data))
+	}
+}
+
+func testListAll(t *testing.T, newBackend NewBackend) {
+	b := newBackend(t)
+
+	list0, err := b.ListAll()
+	if err != nil {
+		t.Fatalf("failed to list: %v", err)
+	}
+	if len(list0) != 0 {
+		t.Errorf("not empty initially")
+	}
+
+	err = b.Put("alpha", nil)
+	if err != nil {
+		t.Fatalf("Put() failed: %v", err)
+	}
+	err = b.Put("bravo/delta", nil)
+	if err != nil {
+		t.Fatalf("Put() failed: %v", err)
+	}
+
+	list1, err := b.ListAll()
+	if err != nil {
+		t.Fatalf("failed to list: %v", err)
+	}
+	if len(list1) != 2 {
+		t.Fatalf("incorrect count: %d (expected %d)", len(list1), 2)
+	}
+	if list1[0] != "alpha" || list1[1] != "bravo/delta" {
+		t.Errorf("incorrect content: %v", list1)
+	}
+
+	err = b.Put("bravo/charlie", nil)
+	if err != nil {
+		t.Fatalf("Put() failed: %v", err)
+	}
+
+	list2, err := b.ListAll()
+	if err != nil {
+		t.Fatalf("failed to list: %v", err)
+	}
+	if len(list2) != 3 {
+		t.Fatalf("incorrect count: %d (expected %d)", len(list2), 3)
+	}
+	// Output is sorted lexicographically
+	if list2[0] != "alpha" || list2[1] != "bravo/charlie" || list2[2] != "bravo/delta" {
+		t.Errorf("incorrect content: %v", list2)
 	}
 }
 

--- a/keystore/v2/keystore/filesystem/backend/memory.go
+++ b/keystore/v2/keystore/filesystem/backend/memory.go
@@ -17,6 +17,7 @@
 package backend
 
 import (
+	"sort"
 	"sync"
 
 	"github.com/cossacklabs/acra/keystore/v2/keystore/filesystem/backend/api"
@@ -84,6 +85,17 @@ func (m *InMemory) Put(path string, data []byte) error {
 	}
 	m.storage[path] = data
 	return nil
+}
+
+// ListAll enumerates all paths currently stored.
+// The paths are returned in lexicographical order.
+func (m *InMemory) ListAll() ([]string, error) {
+	paths := make([]string, 0, len(m.storage))
+	for path := range m.storage {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	return paths, nil
 }
 
 // Rename oldpath into newpath atomically.

--- a/keystore/v2/keystore/keyStore.go
+++ b/keystore/v2/keystore/keyStore.go
@@ -123,6 +123,15 @@ func (s *ServerKeyStore) describeKeyRing(path string) (*keystore.KeyDescription,
 		}, nil
 	}
 
+	// Paths which are not server-global symmetric keys look like this:
+	//
+	//     client/${client_id}/storage
+	//
+	// And transport paths look like this, with an additional component:
+	//
+	//     client/${client_id}/transport/connector
+	//
+	// Split them into components by slashes and parse the result.
 	components := strings.Split(path, string(filepath.Separator))
 	if len(components) == 3 {
 		if components[0] == clientPrefix && components[2] == storageSuffix {
@@ -132,7 +141,7 @@ func (s *ServerKeyStore) describeKeyRing(path string) (*keystore.KeyDescription,
 				ClientID: []byte(components[1]),
 			}, nil
 		}
-		if components[0] == clientPrefix && components[2] == storageSuffix {
+		if components[0] == zonePrefix && components[2] == storageSuffix {
 			return &keystore.KeyDescription{
 				ID:      path,
 				Purpose: PurposeStorageZone,

--- a/keystore/v2/keystore/keyStore.go
+++ b/keystore/v2/keystore/keyStore.go
@@ -19,6 +19,7 @@ package keystore
 
 import (
 	connector_mode "github.com/cossacklabs/acra/cmd/acra-connector/connector-mode"
+	"github.com/cossacklabs/acra/keystore"
 	"github.com/cossacklabs/acra/keystore/v2/keystore/api"
 	log "github.com/sirupsen/logrus"
 )
@@ -69,6 +70,11 @@ func NewTranslatorKeyStore(keyStore api.MutableKeyStore) *TranslatorKeyStore {
 	return &TranslatorKeyStore{
 		ServerKeyStore{keyStore, log.WithField("service", serviceName)},
 	}
+}
+
+// ListKeys enumerates keys present in the key store.
+func (s *ServerKeyStore) ListKeys() ([]keystore.KeyDescription, error) {
+	panic("not implemented")
 }
 
 // Reset is a compatibility method that does nothing.

--- a/keystore/v2/keystore/keyStore.go
+++ b/keystore/v2/keystore/keyStore.go
@@ -18,6 +18,10 @@
 package keystore
 
 import (
+	"errors"
+	"path/filepath"
+	"strings"
+
 	connector_mode "github.com/cossacklabs/acra/cmd/acra-connector/connector-mode"
 	"github.com/cossacklabs/acra/keystore"
 	"github.com/cossacklabs/acra/keystore/v2/keystore/api"
@@ -25,6 +29,22 @@ import (
 )
 
 const serviceName = "keystore"
+
+// Errors in key store listing and export.
+var (
+	ErrUnrecognizedKeyPurpose = errors.New("key purpose not recognized")
+)
+
+// Key purpose constants.
+const (
+	PurposePoisonRecord        = "poison record key"
+	PurposeAuthentication      = "authentication key"
+	PurposeStorageClient       = "client storage key"
+	PurposeStorageZone         = "zone storage key"
+	PurposeTransportServer     = "AcraServer transport key"
+	PurposeTransportConnector  = "AcraConnector transport key"
+	PurposeTransportTranslator = "AcraTranslator transport key"
+)
 
 // ServerKeyStore provides full access to Acra Key Store.
 //
@@ -74,7 +94,77 @@ func NewTranslatorKeyStore(keyStore api.MutableKeyStore) *TranslatorKeyStore {
 
 // ListKeys enumerates keys present in the key store.
 func (s *ServerKeyStore) ListKeys() ([]keystore.KeyDescription, error) {
-	panic("not implemented")
+	keyRings, err := s.ListKeyRings()
+	if err != nil {
+		return nil, err
+	}
+	keys := make([]keystore.KeyDescription, len(keyRings))
+	for i := range keys {
+		description, err := s.describeKeyRing(keyRings[i])
+		if err != nil {
+			return nil, err
+		}
+		keys[i] = *description
+	}
+	return keys, nil
+}
+
+func (s *ServerKeyStore) describeKeyRing(path string) (*keystore.KeyDescription, error) {
+	if path == poisonKeyPath {
+		return &keystore.KeyDescription{
+			ID:      path,
+			Purpose: PurposePoisonRecord,
+		}, nil
+	}
+	if path == authKeyPath {
+		return &keystore.KeyDescription{
+			ID:      path,
+			Purpose: PurposeAuthentication,
+		}, nil
+	}
+
+	components := strings.Split(path, string(filepath.Separator))
+	if len(components) == 3 {
+		if components[0] == clientPrefix && components[2] == storageSuffix {
+			return &keystore.KeyDescription{
+				ID:       path,
+				Purpose:  PurposeStorageClient,
+				ClientID: []byte(components[1]),
+			}, nil
+		}
+		if components[0] == clientPrefix && components[2] == storageSuffix {
+			return &keystore.KeyDescription{
+				ID:      path,
+				Purpose: PurposeStorageZone,
+				ZoneID:  []byte(components[1]),
+			}, nil
+		}
+	}
+	if len(components) == 4 {
+		if components[0] == clientPrefix && components[2] == transportSuffix && components[3] == serverSuffix {
+			return &keystore.KeyDescription{
+				ID:       path,
+				Purpose:  PurposeTransportServer,
+				ClientID: []byte(components[1]),
+			}, nil
+		}
+		if components[0] == clientPrefix && components[2] == transportSuffix && components[3] == connectorSuffix {
+			return &keystore.KeyDescription{
+				ID:       path,
+				Purpose:  PurposeTransportConnector,
+				ClientID: []byte(components[1]),
+			}, nil
+		}
+		if components[0] == clientPrefix && components[2] == transportSuffix && components[3] == translatorSuffix {
+			return &keystore.KeyDescription{
+				ID:       path,
+				Purpose:  PurposeTransportTranslator,
+				ClientID: []byte(components[1]),
+			}, nil
+		}
+	}
+
+	return nil, ErrUnrecognizedKeyPurpose
 }
 
 // Reset is a compatibility method that does nothing.

--- a/keystore/v2/keystore/storage_client.go
+++ b/keystore/v2/keystore/storage_client.go
@@ -17,7 +17,7 @@
 package keystore
 
 import (
-	"fmt"
+	"path/filepath"
 
 	"github.com/cossacklabs/themis/gothemis/keys"
 )
@@ -83,8 +83,11 @@ func (s *ServerKeyStore) GetServerDecryptionPrivateKeys(clientID []byte) ([]*key
 // StorageKeyCreation interface (clients)
 //
 
+const clientPrefix = "client"
+const storageSuffix = "storage"
+
 func (s *ServerKeyStore) clientStorageKeyPairPath(clientID []byte) string {
-	return fmt.Sprintf("client/%s/storage", string(clientID))
+	return filepath.Join(clientPrefix, string(clientID), storageSuffix)
 }
 
 // GenerateDataEncryptionKeys generates new storage keypair used by given client.

--- a/keystore/v2/keystore/storage_zone.go
+++ b/keystore/v2/keystore/storage_zone.go
@@ -17,7 +17,7 @@
 package keystore
 
 import (
-	"fmt"
+	"path/filepath"
 
 	"github.com/cossacklabs/acra/utils"
 	"github.com/cossacklabs/acra/zone"
@@ -95,8 +95,10 @@ func (s *ServerKeyStore) HasZonePrivateKey(zoneID []byte) bool {
 // StorageKeyCreation interface (zones)
 //
 
+const zonePrefix = "client"
+
 func (s *ServerKeyStore) zoneStorageKeyPairPath(zoneID []byte) string {
-	return fmt.Sprintf("zone/%s/storage", string(zoneID))
+	return filepath.Join(zonePrefix, string(zoneID), storageSuffix)
 }
 
 // GenerateZoneKey generates new zone and a storage key for it.

--- a/keystore/v2/keystore/transport_connector.go
+++ b/keystore/v2/keystore/transport_connector.go
@@ -18,6 +18,7 @@ package keystore
 
 import (
 	"fmt"
+	"path/filepath"
 
 	connectorMode "github.com/cossacklabs/acra/cmd/acra-connector/connector-mode"
 	"github.com/cossacklabs/themis/gothemis/keys"
@@ -86,8 +87,10 @@ func (c *ConnectorKeyStore) CheckIfPrivateKeyExists(clientID []byte) (bool, erro
 // TransportKeyCreation interface (AcraConnector)
 //
 
+const connectorSuffix = "connector"
+
 func (s *ServerKeyStore) connectorTransportKeyPairPath(clientID []byte) string {
-	return fmt.Sprintf("client/%s/transport/connector", string(clientID))
+	return filepath.Join(clientPrefix, string(clientID), transportSuffix, connectorSuffix)
 }
 
 // GenerateConnectorKeys generates new AcraConnector transport keypair for given clientID.

--- a/keystore/v2/keystore/transport_server.go
+++ b/keystore/v2/keystore/transport_server.go
@@ -17,7 +17,7 @@
 package keystore
 
 import (
-	"fmt"
+	"path/filepath"
 
 	"github.com/cossacklabs/themis/gothemis/keys"
 )
@@ -74,8 +74,11 @@ func (s *ServerKeyStore) CheckIfPrivateKeyExists(clientID []byte) (bool, error) 
 // TransportKeyCreation interface (AcraServer)
 //
 
+const transportSuffix = "transport"
+const serverSuffix = "server"
+
 func (s *ServerKeyStore) serverTransportKeyPairPath(clientID []byte) string {
-	return fmt.Sprintf("client/%s/transport/server", string(clientID))
+	return filepath.Join(clientPrefix, string(clientID), transportSuffix, serverSuffix)
 }
 
 // GenerateServerKeys generates new AcraServer transport keypair for given clientID.

--- a/keystore/v2/keystore/transport_translator.go
+++ b/keystore/v2/keystore/transport_translator.go
@@ -17,7 +17,7 @@
 package keystore
 
 import (
-	"fmt"
+	"path/filepath"
 
 	"github.com/cossacklabs/themis/gothemis/keys"
 )
@@ -74,8 +74,10 @@ func (t *TranslatorKeyStore) CheckIfPrivateKeyExists(clientID []byte) (bool, err
 // TransportKeyCreation interface (AcraTranslator)
 //
 
+const translatorSuffix = "translator"
+
 func (s *ServerKeyStore) translatorTransportKeyPairPath(clientID []byte) string {
-	return fmt.Sprintf("client/%s/transport/translator", string(clientID))
+	return filepath.Join(clientPrefix, string(clientID), transportSuffix, translatorSuffix)
 }
 
 // GenerateTranslatorKeys generates new AcraTranslator transport keypair for given clientID.


### PR DESCRIPTION
Introduce a new subcommand `list` which could be used to enumerate all keys stored in the key store. This will be useful during key export to specify which keys need to be exported.

The basic usage looks like this:

```
$ acra-keys list
Key purpose                  | Client/Zone ID | Key ID
-----------------------------+----------------+-----------------------------------
client storage key           | ilammy         | client/ilammy/storage
AcraConnector transport key  | ilammy         | client/ilammy/transport/connector
AcraServer transport key     | ilammy         | client/ilammy/transport/server
AcraTranslator transport key | ilammy         | client/ilammy/transport/translator
```

Fully machine-readable output is also support with new `--json` option:

```
$ acra-keys --json list | jq
[
  {
    "ID": "client/ilammy/storage",
    "Purpose": "client storage key",
    "ClientID": "aWxhbW15"
  },
  {
    "ID": "client/ilammy/transport/connector",
    "Purpose": "AcraConnector transport key",
    "ClientID": "aWxhbW15"
  },
  {
    "ID": "client/ilammy/transport/server",
    "Purpose": "AcraServer transport key",
    "ClientID": "aWxhbW15"
  },
  {
    "ID": "client/ilammy/transport/translator",
    "Purpose": "AcraTranslator transport key",
    "ClientID": "aWxhbW15"
  }
]
```

(Note that client and zone IDs are actually binary so in JSON they are encoded in base64.)

The new command is supported only for key store v2. For older key stores acra-keys will print an error and exit:

```
ERRO[0000] "list" is not implemented for key store v1 in Acra Community Edition 
INFO[0000] You can convert key store v1 into v2 with "acra-migrate-keys" 
INFO[0000] Read more: https://docs.cossacklabs.com/pages/documentation-acra/#key-management 
FATA[0000] Failed to read key list                       error="not implemented"
```