### PR TITLE
acra-keys export & import subcommands

### DIFF
--- a/cmd/acra-keys/acra-keys.go
+++ b/cmd/acra-keys/acra-keys.go
@@ -39,11 +39,20 @@ func main() {
 	switch keys.Params.Command {
 	case keys.CmdListKeys:
 		listKeys(keys.Params)
+	case keys.CmdExportKeys:
+		exportKeys(keys.Params)
 	case keys.CmdReadKey:
 		printKey(keys.Params)
 	case keys.CmdDestroyKey:
 		destroyKey(keys.Params)
 	}
+}
+
+func warnKeystoreV2Only(command string) {
+	log.Error(fmt.Sprintf("\"%s\" is not implemented for key store v1 in Acra Community Edition", command))
+	log.Info("You can convert key store v1 into v2 with \"acra-migrate-keys\"")
+	// TODO(ilammy, 2020-05-19): production documentation does not describe migration yet
+	log.Info("Read more: https://docs.cossacklabs.com/pages/documentation-acra/#key-management")
 }
 
 func listKeys(params *keys.CommandLineParams) {
@@ -55,10 +64,7 @@ func listKeys(params *keys.CommandLineParams) {
 	keyDescriptions, err := keyStore.ListKeys()
 	if err != nil {
 		if err == keystore.ErrNotImplemented {
-			log.Error(fmt.Sprintf("\"%s\" is not implemented for key store v1 in Acra Community Edition", keys.CmdListKeys))
-			log.Info("You can convert key store v1 into v2 with \"acra-migrate-keys\"")
-			// TODO(ilammy, 2020-05-19): production documentation does not describe migration yet
-			log.Info("Read more: https://docs.cossacklabs.com/pages/documentation-acra/#key-management")
+			warnKeystoreV2Only(keys.CmdListKeys)
 		}
 		log.WithError(err).Fatal("Failed to read key list")
 	}
@@ -67,6 +73,36 @@ func listKeys(params *keys.CommandLineParams) {
 	if err != nil {
 		log.WithError(err).Fatal("Failed to print key list")
 	}
+}
+
+func exportKeys(params *keys.CommandLineParams) {
+	keyStore, err := keys.OpenKeyStoreForExportImport(params)
+	if err != nil {
+		if err == keystore.ErrNotImplemented {
+			warnKeystoreV2Only(keys.CmdExportKeys)
+		}
+		log.WithError(err).Fatal("Failed to open key store")
+	}
+
+	encryptionKeyData, cryptosuite, err := keys.PrepareExportEncryptionKeys()
+	if err != nil {
+		log.WithError(err).Fatal("Failed to prepare encryption keys")
+	}
+	defer utils.ZeroizeSymmetricKey(encryptionKeyData)
+
+	exportedData, err := keys.ExportKeys(keyStore, cryptosuite, params)
+	if err != nil {
+		log.WithError(err).Fatal("Failed to export keys")
+	}
+
+	err = keys.WriteExportedData(exportedData, encryptionKeyData, params)
+	if err != nil {
+		log.WithError(err).Fatal("Failed to write exported data")
+	}
+
+	log.Infof("Exported key data is encrypted and saved here: %s", params.ExportDataFile)
+	log.Infof("New encryption keys for import generated here: %s", params.ExportKeysFile)
+	log.Infof("DO NOT transport or store these files together")
 }
 
 func printKey(params *keys.CommandLineParams) {

--- a/cmd/acra-keys/acra-keys.go
+++ b/cmd/acra-keys/acra-keys.go
@@ -105,7 +105,7 @@ func exportKeys(params *keys.CommandLineParams) {
 	log.Infof("Exported key data is encrypted and saved here: %s", params.ExportDataFile)
 	log.Infof("New encryption keys for import generated here: %s", params.ExportKeysFile)
 	log.Infof("DO NOT transport or store these files together")
-	log.Infof("Import the keys into another key store like this:\n\tacra-keys import --data \"%s\" --keys \"%s\"", params.ExportDataFile, params.ExportKeysFile)
+	log.Infof("Import the keys into another key store like this:\n\tacra-keys import --key_bundle_file \"%s\" --key_bundle_secret \"%s\"", params.ExportDataFile, params.ExportKeysFile)
 }
 
 func importKeys(params *keys.CommandLineParams) {

--- a/cmd/acra-keys/acra-keys.go
+++ b/cmd/acra-keys/acra-keys.go
@@ -127,9 +127,16 @@ func importKeys(params *keys.CommandLineParams) {
 		log.WithError(err).Fatal("Failed to prepare encryption keys")
 	}
 
-	err = keys.ImportKeys(exportedData, keyStore, cryptosuite, params)
+	descriptions, err := keys.ImportKeys(exportedData, keyStore, cryptosuite, params)
 	if err != nil {
 		log.WithError(err).Fatal("Failed to import keys")
+	}
+
+	log.Infof("successfully imported %d keys", len(descriptions))
+
+	err = keys.PrintKeys(descriptions, os.Stdout, params)
+	if err != nil {
+		log.WithError(err).Fatal("Failed to print imported key list")
 	}
 }
 

--- a/cmd/acra-keys/keys/command-line.go
+++ b/cmd/acra-keys/keys/command-line.go
@@ -131,21 +131,21 @@ func (params *CommandLineParams) Register() {
 
 	params.exportFlags = flag.NewFlagSet(CmdListKeys, flag.ContinueOnError)
 	params.exportFlags.BoolVar(&params.ExportAll, "all", false, "export all keys")
-	params.exportFlags.StringVar(&params.ExportDataFile, "data", "", "path to output file for exported key data")
-	params.exportFlags.StringVar(&params.ExportKeysFile, "keys", "", "path to output file for encryption keys")
+	params.exportFlags.StringVar(&params.ExportDataFile, "key_bundle_file", "", "path to output file for exported key bundle")
+	params.exportFlags.StringVar(&params.ExportKeysFile, "key_bundle_secret", "", "path to output file for key encryption keys")
 	params.exportFlags.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Command \"%s\": export keys from the key store\n", CmdExportKeys)
-		fmt.Fprintf(os.Stderr, "\n\t%s %s [options...] --data <file> --keys <file> <key-ID...>\n", os.Args[0], CmdExportKeys)
+		fmt.Fprintf(os.Stderr, "\n\t%s %s [options...] --key_bundle_file <file> --key_bundle_secret <file> <key-ID...>\n", os.Args[0], CmdExportKeys)
 		fmt.Fprintf(os.Stderr, "\nOptions:\n")
 		cmd.PrintFlags(params.exportFlags)
 	}
 
 	params.importFlags = flag.NewFlagSet(CmdListKeys, flag.ContinueOnError)
-	params.importFlags.StringVar(&params.ExportDataFile, "data", "", "path to input file with exported key data")
-	params.importFlags.StringVar(&params.ExportKeysFile, "keys", "", "path to input file with encryption keys")
+	params.importFlags.StringVar(&params.ExportDataFile, "key_bundle_file", "", "path to input file with exported key bundle")
+	params.importFlags.StringVar(&params.ExportKeysFile, "key_bundle_secret", "", "path to input file with key encryption keys")
 	params.importFlags.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Command \"%s\": import keys into the key store\n", CmdImportKeys)
-		fmt.Fprintf(os.Stderr, "\n\t%s %s [options...] --data <file> --keys <file>\n", os.Args[0], CmdImportKeys)
+		fmt.Fprintf(os.Stderr, "\n\t%s %s [options...] --key_bundle_file <file> --key_bundle_secret <file>\n", os.Args[0], CmdImportKeys)
 		fmt.Fprintf(os.Stderr, "\nOptions:\n")
 		cmd.PrintFlags(params.importFlags)
 	}
@@ -222,12 +222,12 @@ func (params *CommandLineParams) ParseSubCommand() error {
 		}
 
 		if params.ExportDataFile == "" || params.ExportKeysFile == "" {
-			log.Errorf("\"%s\" command requires output files specified with \"--data\" and \"--keys\"", CmdExportKeys)
+			log.Errorf("\"%s\" command requires output files specified with \"--key_bundle_file\" and \"--key_bundle_secret\"", CmdExportKeys)
 			return ErrMissingOutputFile
 		}
 		// We do not account for people getting creative with ".." and links.
 		if params.ExportDataFile == params.ExportKeysFile {
-			log.Errorf("\"--data\" and \"--keys\" must not be the same file")
+			log.Errorf("\"--key_bundle_file\" and \"--key_bundle_secret\" must not be the same file")
 			return ErrOutputSame
 		}
 
@@ -246,7 +246,7 @@ func (params *CommandLineParams) ParseSubCommand() error {
 			return err
 		}
 		if params.ExportDataFile == "" || params.ExportKeysFile == "" {
-			log.Errorf("\"%s\" command requires input files specified with \"--data\" and \"--keys\"", CmdImportKeys)
+			log.Errorf("\"%s\" command requires input files specified with \"--key_bundle_file\" and \"--key_bundle_secret\"", CmdImportKeys)
 			return ErrMissingOutputFile
 		}
 		return nil

--- a/cmd/acra-keys/keys/export.go
+++ b/cmd/acra-keys/keys/export.go
@@ -118,8 +118,18 @@ func ExportKeys(keyStore *keystoreV2.ServerKeyStore, cryptosuite *crypto.KeyStor
 }
 
 // ImportKeys imports available key rings.
-func ImportKeys(exportedData []byte, keyStore *keystoreV2.ServerKeyStore, cryptosuite *crypto.KeyStoreSuite, params *CommandLineParams) error {
-	return keyStore.ImportKeyRings(exportedData, cryptosuite, nil)
+func ImportKeys(exportedData []byte, keyStore *keystoreV2.ServerKeyStore, cryptosuite *crypto.KeyStoreSuite, params *CommandLineParams) ([]keystore.KeyDescription, error) {
+	keyIDs, err := keyStore.ImportKeyRings(exportedData, cryptosuite, nil)
+	if err != nil {
+		log.WithError(err).Debug("Failed to import key rings")
+		return nil, err
+	}
+	descriptions, err := keyStore.DescribeKeys(keyIDs)
+	if err != nil {
+		log.WithError(err).Debug("Failed to describe imported key rings")
+		return nil, err
+	}
+	return descriptions, nil
 }
 
 // WriteExportedData saves exported key data and ephemeral keys into designated files.

--- a/cmd/acra-keys/keys/export.go
+++ b/cmd/acra-keys/keys/export.go
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2020, Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package keys
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+
+	"github.com/cossacklabs/acra/keystore"
+	keystoreV2 "github.com/cossacklabs/acra/keystore/v2/keystore"
+	"github.com/cossacklabs/acra/keystore/v2/keystore/crypto"
+	"github.com/cossacklabs/acra/utils"
+	log "github.com/sirupsen/logrus"
+)
+
+// ExportKeyPerm is file permissions required for exported key data.
+const ExportKeyPerm = os.FileMode(0600)
+
+// Key export errors:
+var (
+	ErrIncorrectPerm = errors.New("incorrect output file permissions")
+)
+
+type serializedKeys struct {
+	Encryption []byte `json:"encryption"`
+	Signature  []byte `json:"signature"`
+}
+
+// PrepareExportEncryptionKeys generates new ephemeral keys for key export operation.
+func PrepareExportEncryptionKeys() ([]byte, *crypto.KeyStoreSuite, error) {
+	encryptionKey, err := keystore.GenerateSymmetricKey()
+	if err != nil {
+		log.WithError(err).Debug("Failed to generate symmetric key")
+		return nil, nil, err
+	}
+
+	signatureKey, err := keystore.GenerateSymmetricKey()
+	if err != nil {
+		log.WithError(err).Debug("Failed to generate symmetric key")
+		return nil, nil, err
+	}
+
+	serializedKeys, err := json.Marshal(&serializedKeys{Encryption: encryptionKey, Signature: signatureKey})
+	if err != nil {
+		log.WithError(err).Debug("Failed to serialize keys in JSON")
+		return nil, nil, err
+	}
+
+	// We do not zeroize the keys since a) they are stored by reference in the cryptosuite,
+	// b) they have not been used to encrypt anything yet.
+	cryptosuite, err := crypto.NewSCellSuite(encryptionKey, signatureKey)
+	if err != nil {
+		log.WithError(err).Debug("Failed to setup cryptosuite")
+		return nil, nil, err
+	}
+
+	return serializedKeys, cryptosuite, nil
+}
+
+// ExportKeys exports requested key rings.
+func ExportKeys(keyStore *keystoreV2.ServerKeyStore, cryptosuite *crypto.KeyStoreSuite, params *CommandLineParams) (exportedData []byte, err error) {
+	exportedIDs := params.ExportIDs
+	if params.ExportAll {
+		exportedIDs, err = keyStore.ListKeyRings()
+		if err != nil {
+			log.WithError(err).Debug("Failed to list available keys")
+			return nil, err
+		}
+	}
+
+	exportedData, err = keyStore.ExportKeyRings(exportedIDs, cryptosuite)
+	if err != nil {
+		log.WithError(err).Debug("Failed to export key rings")
+		return nil, err
+	}
+	return exportedData, nil
+}
+
+// WriteExportedData saves exported key data and ephemeral keys into designated files.
+func WriteExportedData(data, keys []byte, params *CommandLineParams) error {
+	err := writeFileWithMode(data, params.ExportDataFile, ExportKeyPerm)
+	if err != nil {
+		return err
+	}
+	err = writeFileWithMode(keys, params.ExportKeysFile, ExportKeyPerm)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func writeFileWithMode(data []byte, path string, perm os.FileMode) (err error) {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, perm)
+	if err != nil {
+		log.WithField("path", path).WithError(err).Debug("Failed to open file")
+		return err
+	}
+	defer func() {
+		if err2 := file.Close(); err2 != nil {
+			log.WithField("path", path).WithError(err2).Debug("Failed to close file")
+			if err != nil {
+				err = err2
+			}
+		}
+	}()
+
+	fi, err := file.Stat()
+	if err != nil {
+		log.WithField("path", path).WithError(err).Debug("Failed to stat file")
+		return err
+	}
+	if fi.Mode().Perm() != ExportKeyPerm {
+		log.WithField("path", path).WithField("expected", ExportKeyPerm).WithField("actual", fi.Mode().Perm()).
+			Error("Incorrect output file permissions")
+		return ErrIncorrectPerm
+	}
+
+	_, err = utils.WriteFull(data, file)
+	return err
+}

--- a/cmd/acra-keys/keys/keystore.go
+++ b/cmd/acra-keys/keys/keystore.go
@@ -58,6 +58,20 @@ func OpenKeyStoreForModification(params *CommandLineParams) (keystore.KeyMaking,
 	}
 }
 
+// OpenKeyStoreForExportImport opens a key store suitable for export/import operations.
+func OpenKeyStoreForExportImport(params *CommandLineParams) (*keystoreV2.ServerKeyStore, error) {
+	switch params.KeyStoreVersion {
+	case "v1":
+		// Not supported in Acra CE
+		return nil, keystore.ErrNotImplemented
+	case "v2":
+		return openKeyStoreV2(params)
+	default:
+		log.WithField("actual", params.KeyStoreVersion).Error("Unknown key store version")
+		return nil, ErrUnknownKeystoreVersion
+	}
+}
+
 func openKeyStoreV1(params *CommandLineParams) (*filesystemV1.KeyStore, error) {
 	symmetricKey, err := keystoreV1.GetMasterKeyFromEnvironment()
 	if err != nil {

--- a/keystore/v2/keystore/api/keyStore.go
+++ b/keystore/v2/keystore/api/keyStore.go
@@ -51,7 +51,8 @@ type MutableKeyStore interface {
 	// ImportKeyRings unpacks key rings packaged by ExportKeyRings.
 	// The provided cryptosuite is used to verify the signature on the container and decrypt key ring data.
 	// Optional delegate can be used to control various aspects of the import process, such as conflict resolution.
-	ImportKeyRings(exportData []byte, cryptosuite *crypto.KeyStoreSuite, delegate KeyRingImportDelegate) error
+	// Returns a list of processed key rings.
+	ImportKeyRings(exportData []byte, cryptosuite *crypto.KeyStoreSuite, delegate KeyRingImportDelegate) ([]string, error)
 }
 
 // ImportDecision constants describe how to proceed with import conflict resolution.

--- a/keystore/v2/keystore/keyStore.go
+++ b/keystore/v2/keystore/keyStore.go
@@ -98,6 +98,11 @@ func (s *ServerKeyStore) ListKeys() ([]keystore.KeyDescription, error) {
 	if err != nil {
 		return nil, err
 	}
+	return s.DescribeKeys(keyRings)
+}
+
+// DescribeKeys describes requested keys in the key store.
+func (s *ServerKeyStore) DescribeKeys(keyRings []string) ([]keystore.KeyDescription, error) {
 	keys := make([]keystore.KeyDescription, len(keyRings))
 	for i := range keys {
 		description, err := s.describeKeyRing(keyRings[i])


### PR DESCRIPTION
This PR adds `export` and `import` subcommands that handle key export and import respectively.

### Command-line interface

#### Exporting keys

The keys can be exported like this:

```shell
$ acra-keys list
Key purpose                  | Client/Zone ID | Key ID
-----------------------------+----------------+-----------------------------------
client storage key           | ilammy         | client/ilammy/storage
AcraConnector transport key  | ilammy         | client/ilammy/transport/connector
AcraServer transport key     | ilammy         | client/ilammy/transport/server
AcraTranslator transport key | ilammy         | client/ilammy/transport/translator
```

```shell
$ acra-keys export --key_bundle_file encrypted-keys.dat --key_bundle_secret access-keys.json --all
INFO[0000] Exported key data is encrypted and saved here: encrypted-keys.dat 
INFO[0000] New encryption keys for import generated here: access-keys.json 
INFO[0000] DO NOT transport or store these files together 
INFO[0000] Import the keys into another key store like this:
	acra-keys import --key_bundle_file "encrypted-keys.dat" --key_bundle_secret "access-keys.json"
```

(Instead of `--all` you can enumerate specific key IDs from `acra-keys list` output.)

#### Export results

The `encrypted-keys.dat` file contains encrypted and signed key data:

```shell
$ hd encrypted-keys.dat | head -5
00000000  30 82 03 78 30 82 03 43  02 01 04 02 01 02 17 11  |0..x0..C........|
00000010  32 30 30 36 30 31 31 32  34 37 31 34 2b 30 33 30  |200601124714+030|
00000020  30 04 82 03 26 00 01 01  40 0c 00 00 00 10 00 00  |0...&...@.......|
00000030  00 fa 02 00 00 6c 4e e6  1c e5 30 56 bb 4e f7 cb  |.....lN...0V.N..|
00000040  cd 8d de 49 d2 de 4d c4  f8 ce 32 9d 2b b5 c7 3d  |...I..M...2.+..=|
```

The `access-keys.json` contains freshly generated keys used to encrypt and sign the exported data, in plaintext:

```shell
$ cat access-keys.json
{"encryption":"EIufOjLKGXrJRMKpwtYdvbIM1LSaOkYpnEmTVimxnO4=","signature":"upXcpYdj58rpEhX7b8Xnq8asr2718i/z/DlMXgMpojo="}
```

We do not give the user an option to use their own transport keys to encrypt the output. That way we are sure that they keys are never reused.

These two data pieces should be transported separately to the target machine and imported there.

#### Importing keys

The keys can be imported like this, as suggested during export:

```shell
$ acra-keys import --key_bundle_file "encrypted-keys.dat" --key_bundle_secret "access-keys.json"
INFO[0000] successfully imported 4 keys                 
Key purpose                  | Client/Zone ID | Key ID
-----------------------------+----------------+-----------------------------------
client storage key           | ilammy         | client/ilammy/storage
AcraConnector transport key  | ilammy         | client/ilammy/transport/connector
AcraServer transport key     | ilammy         | client/ilammy/transport/server
AcraTranslator transport key | ilammy         | client/ilammy/transport/translator
```

We list the affected keys for the benefit of the user.

Right now it is not possible to import the same data twice, it results in an error:

```shell
$ acra-keys import --key_bundle_file "encrypted-keys.dat" --key_bundle_secret "access-keys.json"
FATA[0000] Failed to import keys                         error="imported key ring already exists"
```

### Peculiarities and open questions

- Are the command-line option names and the overall interface good?

  ~~I'm concerned, for example, that the users might be confused by the `--keys` option.~~
  (Resolved after discussion.)

- Is it okay to save the data encryption keys into a file?

  It's convenient for later import, but that's an unencrypted file with keys after all. They are ephemeral keys, but nevertheless: if they are stored together with the exported data then it's like having the exported keys in plaintext. It's very easy to do the stupid thing and store them together.

### Incomplete features

The following features are currently missing and will be added later:

- It is not possible to export only public keys which is required during initial Acra setup. In fact, I'd rather have `acra-keys export` export only public keys by default, with private/symmetric key export being opt-in (e.g., for backups). I'm working on some `--with-private-keys` switch for that.

- It is not possible to import _updated_ keys (e.g., rotated ones) into existing key store which already has an older version. This feature is supported by the low-level API but the high-level CLI does not have an option for that yet. This will be added later.

- Only key store v2 is supported for both export and import. We could add v1 support in Acra EE on request, but given that v1 → v2 conversion is available and (should) have no downsides, it's okay to leave it out.