### PR TITLE
Export only public keys by default and test it

### DIFF
--- a/cmd/acra-keys/keys/command-line.go
+++ b/cmd/acra-keys/keys/command-line.go
@@ -101,6 +101,7 @@ type CommandLineParams struct {
 	ExportAll      bool
 	ExportDataFile string
 	ExportKeysFile string
+	ExportPrivate  bool
 
 	UseJSON bool
 
@@ -133,6 +134,7 @@ func (params *CommandLineParams) Register() {
 	params.exportFlags.BoolVar(&params.ExportAll, "all", false, "export all keys")
 	params.exportFlags.StringVar(&params.ExportDataFile, "key_bundle_file", "", "path to output file for exported key bundle")
 	params.exportFlags.StringVar(&params.ExportKeysFile, "key_bundle_secret", "", "path to output file for key encryption keys")
+	params.exportFlags.BoolVar(&params.ExportPrivate, "private_keys", false, "export private key data")
 	params.exportFlags.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Command \"%s\": export keys from the key store\n", CmdExportKeys)
 		fmt.Fprintf(os.Stderr, "\n\t%s %s [options...] --key_bundle_file <file> --key_bundle_secret <file> <key-ID...>\n", os.Args[0], CmdExportKeys)

--- a/cmd/acra-keys/keys/export.go
+++ b/cmd/acra-keys/keys/export.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/cossacklabs/acra/keystore"
 	keystoreV2 "github.com/cossacklabs/acra/keystore/v2/keystore"
+	"github.com/cossacklabs/acra/keystore/v2/keystore/api"
 	"github.com/cossacklabs/acra/keystore/v2/keystore/crypto"
 	"github.com/cossacklabs/acra/utils"
 	log "github.com/sirupsen/logrus"
@@ -109,7 +110,11 @@ func ExportKeys(keyStore *keystoreV2.ServerKeyStore, cryptosuite *crypto.KeyStor
 		}
 	}
 
-	exportedData, err = keyStore.ExportKeyRings(exportedIDs, cryptosuite)
+	mode := api.ExportPublicOnly
+	if params.ExportPrivate {
+		mode = api.ExportPrivateKeys
+	}
+	exportedData, err = keyStore.ExportKeyRings(exportedIDs, cryptosuite, mode)
 	if err != nil {
 		log.WithError(err).Debug("Failed to export key rings")
 		return nil, err

--- a/keystore/v2/keystore/api/keyStore.go
+++ b/keystore/v2/keystore/api/keyStore.go
@@ -37,8 +37,19 @@ type KeyStore interface {
 	// ExportKeyRings packages specified key rings for export.
 	// Key ring data is encrypted and signed using given cryptosuite.
 	// Resulting container can be imported into existing or different key store with ImportKeyRings().
-	ExportKeyRings(paths []string, cryptosuite *crypto.KeyStoreSuite) ([]byte, error)
+	ExportKeyRings(paths []string, cryptosuite *crypto.KeyStoreSuite, mode ExportMode) ([]byte, error)
 }
+
+// ExportMode constants describe which data to export from key storage.
+type ExportMode int
+
+// ExportMode flags.
+const (
+	// Export only public key data.
+	ExportPublicOnly ExportMode = 0
+	// Export private and public key data.
+	ExportPrivateKeys = (1 << iota)
+)
 
 // MutableKeyStore interface to KeyStore allowing write access.
 type MutableKeyStore interface {

--- a/keystore/v2/keystore/api/tests/keyStore.go
+++ b/keystore/v2/keystore/api/tests/keyStore.go
@@ -232,7 +232,7 @@ func testKeyStoreCleanImport(t *testing.T, newKeyStore NewKeyStore) {
 	setupDemoKeyStore(s, t)
 	cryptosuite := newExportStoreSuite(t)
 
-	exported, err := s.ExportKeyRings(exportRingAll, cryptosuite)
+	exported, err := s.ExportKeyRings(exportRingAll, cryptosuite, api.ExportPrivateKeys)
 	if err != nil {
 		t.Fatalf("failed to export key rings: %v", err)
 	}
@@ -276,7 +276,7 @@ func testKeyStoreDuplicateImport(t *testing.T, newKeyStore NewKeyStore) {
 	cryptosuite := newExportStoreSuite(t)
 
 	keyRingList := []string{exportRingPublic}
-	exported1, err := s.ExportKeyRings(keyRingList, cryptosuite)
+	exported1, err := s.ExportKeyRings(keyRingList, cryptosuite, api.ExportPrivateKeys)
 	if err != nil {
 		t.Fatalf("failed to export public key ring: %v", err)
 	}
@@ -289,7 +289,7 @@ func testKeyStoreDuplicateImport(t *testing.T, newKeyStore NewKeyStore) {
 		t.Errorf("incorrect imported list: %v", imported1)
 	}
 
-	exported2, err := s.ExportKeyRings([]string{exportRingKeyPair, exportRingPublic, exportRingSymmetric}, cryptosuite)
+	exported2, err := s.ExportKeyRings([]string{exportRingKeyPair, exportRingPublic, exportRingSymmetric}, cryptosuite, api.ExportPrivateKeys)
 	if err != nil {
 		t.Fatalf("failed to export key rings: %v", err)
 	}
@@ -335,7 +335,7 @@ func testKeyStoreDuplicateImportSkip(t *testing.T, newKeyStore NewKeyStore) {
 	cryptosuite := newExportStoreSuite(t)
 
 	keyRingList1 := []string{exportRingPublic}
-	exported1, err := s.ExportKeyRings(keyRingList1, cryptosuite)
+	exported1, err := s.ExportKeyRings(keyRingList1, cryptosuite, api.ExportPrivateKeys)
 	if err != nil {
 		t.Fatalf("failed to export public key ring: %v", err)
 	}
@@ -349,7 +349,7 @@ func testKeyStoreDuplicateImportSkip(t *testing.T, newKeyStore NewKeyStore) {
 	}
 
 	keyRingList2 := []string{exportRingKeyPair, exportRingPublic, exportRingSymmetric}
-	exported2, err := s.ExportKeyRings(keyRingList2, cryptosuite)
+	exported2, err := s.ExportKeyRings(keyRingList2, cryptosuite, api.ExportPrivateKeys)
 	if err != nil {
 		t.Fatalf("failed to export key rings: %v", err)
 	}
@@ -447,7 +447,7 @@ func testKeyStoreDuplicateImportOverwrite(t *testing.T, newKeyStore NewKeyStore)
 	cryptosuite := newExportStoreSuite(t)
 
 	keyRingList1 := []string{exportRingPublic}
-	exported1, err := s.ExportKeyRings(keyRingList1, cryptosuite)
+	exported1, err := s.ExportKeyRings(keyRingList1, cryptosuite, api.ExportPrivateKeys)
 	if err != nil {
 		t.Fatalf("failed to export public key ring: %v", err)
 	}
@@ -484,7 +484,7 @@ func testKeyStoreDuplicateImportOverwrite(t *testing.T, newKeyStore NewKeyStore)
 	}
 
 	keyRingList2 := []string{exportRingKeyPair, exportRingPublic, exportRingSymmetric}
-	exported2, err := s.ExportKeyRings(keyRingList2, cryptosuite)
+	exported2, err := s.ExportKeyRings(keyRingList2, cryptosuite, api.ExportPrivateKeys)
 	if err != nil {
 		t.Fatalf("failed to export key rings: %v", err)
 	}

--- a/keystore/v2/keystore/filesystem/export.go
+++ b/keystore/v2/keystore/filesystem/export.go
@@ -33,7 +33,7 @@ var (
 	ErrKeyRingExists = errors.New("imported key ring already exists")
 )
 
-func (s *KeyStore) exportKeyRings(paths []string) (rings []asn1.KeyRing, err error) {
+func (s *KeyStore) exportKeyRings(paths []string, mode api.ExportMode) (rings []asn1.KeyRing, err error) {
 	rings = make([]asn1.KeyRing, len(paths))
 	defer func() {
 		if err != nil {
@@ -41,7 +41,7 @@ func (s *KeyStore) exportKeyRings(paths []string) (rings []asn1.KeyRing, err err
 		}
 	}()
 	for i, path := range paths {
-		err := s.exportKeyRing(path, &rings[i])
+		err := s.exportKeyRing(path, &rings[i], mode)
 		if err != nil {
 			return nil, err
 		}
@@ -49,13 +49,13 @@ func (s *KeyStore) exportKeyRings(paths []string) (rings []asn1.KeyRing, err err
 	return rings, nil
 }
 
-func (s *KeyStore) exportKeyRing(path string, ringData *asn1.KeyRing) error {
+func (s *KeyStore) exportKeyRing(path string, ringData *asn1.KeyRing, mode api.ExportMode) error {
 	ring := newKeyRing(s, path)
 	err := s.readKeyRing(ring)
 	if err != nil {
 		return err
 	}
-	*ringData, err = ring.exportASN1()
+	*ringData, err = ring.exportASN1(mode)
 	if err != nil {
 		return err
 	}
@@ -167,7 +167,7 @@ func (s *KeyStore) decryptAndVerifyKeyRings(ringData []byte, cryptosuite *crypto
 	return keys.KeyRings, nil
 }
 
-func (r *KeyRing) exportASN1() (exported asn1.KeyRing, err error) {
+func (r *KeyRing) exportASN1(mode api.ExportMode) (exported asn1.KeyRing, err error) {
 	exported = asn1.KeyRing{
 		Purpose: r.data.Purpose,
 		Current: r.data.Current,
@@ -180,7 +180,7 @@ func (r *KeyRing) exportASN1() (exported asn1.KeyRing, err error) {
 		}
 	}()
 	for i := range exported.Keys {
-		decrypted, err := r.decryptAllKeyData(exported.Keys[i].Data, exported.Keys[i].Seqnum)
+		decrypted, err := r.decryptAllKeyData(exported.Keys[i].Data, exported.Keys[i].Seqnum, mode)
 		if err != nil {
 			return exported, err
 		}
@@ -207,7 +207,7 @@ func (r *KeyRing) importASN1(ringData *asn1.KeyRing) error {
 	return err
 }
 
-func (r *KeyRing) decryptAllKeyData(encrypted []asn1.KeyData, seqnum int) (decrypted []asn1.KeyData, err error) {
+func (r *KeyRing) decryptAllKeyData(encrypted []asn1.KeyData, seqnum int, mode api.ExportMode) (decrypted []asn1.KeyData, err error) {
 	decrypted = make([]asn1.KeyData, len(encrypted))
 	copy(decrypted, encrypted)
 	defer func() {
@@ -216,7 +216,7 @@ func (r *KeyRing) decryptAllKeyData(encrypted []asn1.KeyData, seqnum int) (decry
 		}
 	}()
 	for i := range decrypted {
-		err = r.decryptKeyData(&decrypted[i], seqnum)
+		err = r.decryptKeyData(&decrypted[i], seqnum, mode)
 		if err != nil {
 			return nil, err
 		}
@@ -224,7 +224,14 @@ func (r *KeyRing) decryptAllKeyData(encrypted []asn1.KeyData, seqnum int) (decry
 	return decrypted, nil
 }
 
-func (r *KeyRing) decryptKeyData(data *asn1.KeyData, seqnum int) error {
+func (r *KeyRing) decryptKeyData(data *asn1.KeyData, seqnum int, mode api.ExportMode) error {
+	// If we do not export private key data then remove it without decryption.
+	if mode&api.ExportPrivateKeys == 0 {
+		data.PrivateKey = nil
+		data.SymmetricKey = nil
+		return nil
+	}
+
 	if len(data.PrivateKey) != 0 {
 		privateKey, err := r.decryptPrivateKey(seqnum, data.PrivateKey)
 		if err != nil {

--- a/keystore/v2/keystore/filesystem/keyStore.go
+++ b/keystore/v2/keystore/filesystem/keyStore.go
@@ -170,8 +170,8 @@ func (s *KeyStore) ListKeyRings() (rings []string, err error) {
 // ExportKeyRings packages specified key rings for export.
 // Key ring data is encrypted and signed using given cryptosuite.
 // Resulting container can be imported into existing or different key store with ImportKeyRings().
-func (s *KeyStore) ExportKeyRings(paths []string, cryptosuite *crypto.KeyStoreSuite) ([]byte, error) {
-	keyRings, err := s.exportKeyRings(paths)
+func (s *KeyStore) ExportKeyRings(paths []string, cryptosuite *crypto.KeyStoreSuite, mode api.ExportMode) ([]byte, error) {
+	keyRings, err := s.exportKeyRings(paths, mode)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR makes `acra-keys export` use a bit more safe defaults, and adds integration tests for it.

### New option: `--private_keys`

`acra-keys export` is intended to be used primarily for transferring public keys between servers running various Acra components. For this use case private keys must never leave the machine which generated them. Make sure that we do not export private keys by default. In order to export private keys (e.g., for backup) the user has to explicitly opt-in by specifying the `--private_keys` option. Without that option the private keys will not be decrypted and will not be included into the exported data set.

Specifics of the export are controlled by a new parameter: `ExportMode`. Right now it's binary (public-only or full) but later we might want to extend it and add more options, so this parameter is a bitmask.

### Skip symmetric keys when `--private_keys` is not specified

Note that the "private keys" concept includes symmetric keys as well which are intended for the server-only use and should not be shared.

If the user did not request private key export but specified a key which has only private data (e.g., a symmetric key) then instead of exporting an empty key ring (with full metadata but without actual key material) skip that key ring entirely.

If we do not skip such key rings, the resulting exported bundle cannot be imported: we do not allow to import keys without any data which are not destroyed.

Normally this situation can happen if the user intends to export `--all` public keys at the same time to simplify transfer. Instead of making the user manually spell out all the keys except for the internal symmetric ones, allow them to do the export easily.

### Integration test for key exchange sequence
    
Replace the existing crude code for key exchange with a proper one. Instead of simply copying the entire key store, do as users would do in real-world usage: generate the keys for AcraServer and AcraConnector separately, in their respective key stores, and then exchange only the public keys.
    
For key store v1 we have to copy the files manually. acra-keys does not support export for key store v1. This copying is what the administrators
are expected to do right now to exchange the keys.

For key store v2 (and later) we can use acra-keys to export and then import appropriate keys. For now, we support only key store v2 so we can hardcode key IDs there. Nevertheless, this verifies that acra-keys is capable of transferring keys, and that AcraServer and AcraConnector work after performing the transfer with acra-keys.
