### PR TITLE
implementation of common exit handler for Acra services

### DIFF
--- a/cmd/exit_handler.go
+++ b/cmd/exit_handler.go
@@ -1,0 +1,284 @@
+package cmd
+
+import (
+	"net"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+type Priority int
+const (
+	Last Priority = iota
+	Indifferent
+)
+
+// SignalCallback callback function
+type SignalCallback_ struct {
+	callbackFunc func()
+	priority Priority
+}
+
+func NewSignalCallback(callback func(), priority Priority) *SignalCallback_ {
+	return &SignalCallback_{
+		callback,
+		priority,
+	}
+}
+
+func (s *SignalCallback_) GetPriority() Priority {
+	return s.priority
+}
+
+func (s *SignalCallback_) Call() {
+	s.callbackFunc()
+}
+
+// SignalHandler sends Signal to listeners and call registered callbacks
+type SignalHandler_ struct {
+	ch        chan os.Signal
+	listeners []net.Listener
+	callbacks []*SignalCallback_
+	signals   []os.Signal
+}
+
+// NewSignalHandler returns new SignalHandler registered for particular os.Signals
+func NewSignalHandler_(handledSignals []os.Signal) (*SignalHandler_, error) {
+	return &SignalHandler_{ch: make(chan os.Signal), signals: handledSignals}, nil
+}
+
+// AddListener to listeners list
+func (handler *SignalHandler_) AddListener(listener net.Listener) {
+	handler.listeners = append(handler.listeners, listener)
+}
+
+// GetChannel returns channel of os.Signal
+func (handler *SignalHandler_) GetChannel() chan os.Signal {
+	return handler.ch
+}
+
+// AddCallback to callbacks list
+func (handler *SignalHandler_) AddCallback(callback *SignalCallback_) {
+	handler.callbacks = append(handler.callbacks, callback)
+}
+
+// Register should be called as goroutine
+func (handler *SignalHandler_) Register() {
+	signal.Notify(handler.ch, handler.signals...)
+
+	<-handler.ch
+
+	for _, listener := range handler.listeners {
+		listener.Close()
+	}
+	for _, callback := range handler.callbacks {
+		callback.Call()
+	}
+	os.Exit(0)
+}
+
+type AcraExitHandler interface {
+	AddExitSignalHandler(signal AcraSignal, priority Priority)
+	AddDeferFunc(deferFunc func(), priority Priority)
+	ExitZero()
+	ExitOne()
+}
+
+type ExitHandler struct {
+	deferFunctions []DeferFunction
+	signalHandlers []AcraSignal
+	notification chan os.Signal
+}
+
+func NewExitHandler() (*ExitHandler, error) {
+	return &ExitHandler{
+		deferFunctions: nil,
+		signalHandlers: nil,
+		notification: make(chan os.Signal),
+	}, nil
+}
+
+func NewSigTERMHandler() AcraSignal {
+	return &SigTERMHandler{
+		nil,
+		nil,
+	}
+}
+
+func NewSigINTHandler() AcraSignal {
+	return &SigINTHandler{
+		NewSigTERMHandler().(*SigTERMHandler),
+	}
+}
+
+func (s *ExitHandler) AddExitSignalHandler(input AcraSignal) {
+	s.signalHandlers = append(s.signalHandlers, input)
+}
+
+func (s *ExitHandler) waitForExitSystemSignal(exitFuncOnSigINT func(), exitFuncOnSigTERM func()) {
+	signal.Notify(s.notification, s.getSignals()...)
+
+	switch <-s.notification {
+	case syscall.SIGINT:
+		exitFuncOnSigINT()
+	case syscall.SIGTERM:
+		exitFuncOnSigTERM()
+	}
+}
+
+func (s *ExitHandler) WaitForExitSystemSignal() {
+	s.waitForExitSystemSignal(s.ExitZero, s.ExitZero)
+}
+
+func (s *ExitHandler) getSignals() []os.Signal{
+	var result []os.Signal
+	for _, signal := range s.signalHandlers {
+		result = append(result, signal.GetSignal())
+	}
+	return result
+}
+
+func (s *ExitHandler) AddDeferFunc(input DeferFunction) {
+	inputHasLastPriority := input.GetPriority() == Last
+	for _, deferFunc := range s.deferFunctions {
+		if deferFunc.GetPriority() == Last && inputHasLastPriority {
+			panic("defer function with 'Last' priority has been already specified")
+		}
+	}
+	s.deferFunctions = append(s.deferFunctions, input)
+}
+
+func (s *ExitHandler) ExitZero() {
+	s.gracefulExit()
+	os.Exit(0)
+}
+
+func (s *ExitHandler) ExitOne() {
+	s.gracefulExit()
+	os.Exit(1)
+}
+
+func (s *ExitHandler) gracefulExit() {
+	// at first we finalize our handlers (close listeners and call callbacks)
+	s.executeFinalizeOnHandlers()
+	// finally we call defer functions
+	s.executeDeferFunctions()
+}
+
+func (s *ExitHandler) executeDeferFunctions() {
+	var lastDefer DeferFunction
+	for _, deferFunction := range s.deferFunctions {
+		if deferFunction.GetPriority() == Last {
+			lastDefer = deferFunction
+		}
+		deferFunction.Call()
+	}
+	// defer function with last priority has not been found
+	if lastDefer == nil {
+		return
+	}
+	lastDefer.Call()
+}
+
+func (s *ExitHandler) executeFinalizeOnHandlers() {
+	for _, handler := range s.signalHandlers {
+		handler.Finalize()
+	}
+}
+
+type AcraSignal interface {
+	Finalize()
+	GetSignal() os.Signal
+	AddCallback(callback *SignalCallback_)
+	AddListener(listener net.Listener)
+}
+
+// SIGTERM
+type SigTERMHandler struct {
+	listeners []net.Listener
+	callbacks []*SignalCallback_
+}
+
+func (s *SigTERMHandler) AddCallback(input *SignalCallback_) {
+	inputHasLastPriority := input.GetPriority() == Last
+	for _, callback := range s.callbacks {
+		if callback.GetPriority() == Last && inputHasLastPriority {
+			panic("callback with 'Last' priority has been already specified")
+		}
+	}
+	s.callbacks = append(s.callbacks, input)
+}
+
+// AddListener to listeners list
+func (s *SigTERMHandler) AddListener(listener net.Listener) {
+	s.listeners = append(s.listeners, listener)
+}
+
+func (s *SigTERMHandler) Finalize() {
+	for _, listener := range s.listeners {
+		listener.Close()
+	}
+	var lastCallback *SignalCallback_
+	for _, callback := range s.callbacks {
+		if callback.GetPriority() == Last {
+			lastCallback = callback
+		}
+		callback.Call()
+	}
+	// defer function with last priority has not been found
+	if lastCallback == nil {
+		return
+	}
+	lastCallback.Call()
+}
+
+func (s *SigTERMHandler) GetSignal() os.Signal {
+	return syscall.SIGTERM
+}
+
+// SIGINT (in Acra we do not distinguish between SIGINT and SIGTERM signals)
+type SigINTHandler struct {
+	handler *SigTERMHandler
+}
+
+func (s *SigINTHandler) Finalize() {
+	s.handler.Finalize()
+}
+
+func (s *SigINTHandler) GetSignal() os.Signal {
+	return syscall.SIGINT
+}
+
+// AddListener to listeners list
+func (s *SigINTHandler) AddListener(listener net.Listener) {
+	s.handler.AddListener(listener)
+}
+
+func (s *SigINTHandler) AddCallback(input *SignalCallback_) {
+	s.handler.AddCallback(input)
+}
+
+type DeferFunction interface {
+	GetPriority() Priority
+	Call()
+}
+
+type DeferFunc struct {
+	deferFunc func()
+	priority Priority
+}
+
+func NewDeferFunction(deferFunc func(), priority Priority) DeferFunction {
+	return &DeferFunc{
+		deferFunc,
+		priority,
+	}
+}
+
+func (d *DeferFunc) GetPriority() Priority {
+	return d.priority
+}
+
+func (d *DeferFunc) Call() {
+	d.deferFunc()
+}

--- a/cmd/exit_handler.go
+++ b/cmd/exit_handler.go
@@ -7,7 +7,9 @@ import (
 	"syscall"
 )
 
+
 type Priority int
+
 const (
 	Last Priority = iota
 	Indifferent
@@ -16,7 +18,7 @@ const (
 // SignalCallback callback function
 type SignalCallback_ struct {
 	callbackFunc func()
-	priority Priority
+	priority     Priority
 }
 
 func NewSignalCallback(callback func(), priority Priority) *SignalCallback_ {
@@ -87,14 +89,14 @@ type AcraExitHandler interface {
 type ExitHandler struct {
 	deferFunctions []DeferFunction
 	signalHandlers []AcraSignal
-	notification chan os.Signal
+	notification   chan os.Signal
 }
 
 func NewExitHandler() (*ExitHandler, error) {
 	return &ExitHandler{
 		deferFunctions: nil,
 		signalHandlers: nil,
-		notification: make(chan os.Signal),
+		notification:   make(chan os.Signal),
 	}, nil
 }
 
@@ -130,7 +132,7 @@ func (s *ExitHandler) WaitForExitSystemSignal() {
 	s.waitForExitSystemSignal(s.ExitZero, s.ExitZero)
 }
 
-func (s *ExitHandler) getSignals() []os.Signal{
+func (s *ExitHandler) getSignals() []os.Signal {
 	var result []os.Signal
 	for _, signal := range s.signalHandlers {
 		result = append(result, signal.GetSignal())
@@ -265,7 +267,7 @@ type DeferFunction interface {
 
 type DeferFunc struct {
 	deferFunc func()
-	priority Priority
+	priority  Priority
 }
 
 func NewDeferFunction(deferFunc func(), priority Priority) DeferFunction {

--- a/cmd/exit_handler_test.go
+++ b/cmd/exit_handler_test.go
@@ -1,0 +1,129 @@
+package cmd
+
+import (
+	"os"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestDeferFunctionsPriority(t *testing.T) {
+	exitHandler, err := NewExitHandler()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// we use slice of strings that will be filled by defer functions
+	var results []string
+
+	auditLogDefer := func() {
+		// we need that logFinalize to be called strictly as last defer function
+		results = append(results, "audit_log defer")
+	}
+	stubDefer1 := func(){
+		results = append(results, "stub1 defer")
+	}
+	stubDefer2 := func(){
+		results = append(results, "stub2 defer")
+	}
+
+	exitHandler.AddDeferFunc(NewDeferFunction(auditLogDefer, Last))
+	exitHandler.AddDeferFunc(NewDeferFunction(stubDefer1, Indifferent))
+	exitHandler.AddDeferFunc(NewDeferFunction(stubDefer2, Indifferent))
+
+	exitHandler.executeDeferFunctions()
+
+	// finally check indication of last string in results
+	if results[len(results) - 1] != "audit_log defer" {
+		t.Fatal("auditLogDefer has not been executed as last defer")
+	}
+}
+
+func TestExitHandler(t *testing.T) {
+	testExitHandler(t, syscall.SIGTERM)
+	testExitHandler(t, syscall.SIGINT)
+	testExitHandlerWithCallbacks(t, syscall.SIGTERM)
+	testExitHandlerWithCallbacks(t, syscall.SIGINT)
+}
+
+func testExitHandlerWithCallbacks(t *testing.T, signalToExit os.Signal) {
+	exitHandler, err := NewExitHandler()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sigTERMHandler := NewSigTERMHandler()
+	sigINTHandler := NewSigINTHandler()
+
+
+	var results []string
+	auditLogCallback := func() {
+		// put special messages strictly in the end of log stream
+		results = append(results, "audit_log callback")
+	}
+
+	stubCallback1 := func() {
+		// some other stuff like Prometheus server stop
+		results = append(results, "Prometheus stop 1 callback")
+	}
+
+	stubCallback2 := func() {
+		// some other stuff like Prometheus server stop
+		results = append(results, "Prometheus stop 2 callback")
+	}
+
+	// create exit signal handlers and feed them to common exit handler mechanism
+	sigTERMHandler.AddCallback(NewSignalCallback(auditLogCallback, Last))
+	sigTERMHandler.AddCallback(NewSignalCallback(stubCallback1, Indifferent))
+	sigTERMHandler.AddCallback(NewSignalCallback(stubCallback2, Indifferent))
+
+	sigINTHandler.AddCallback(NewSignalCallback(auditLogCallback, Last))
+	sigINTHandler.AddCallback(NewSignalCallback(stubCallback1, Indifferent))
+	sigINTHandler.AddCallback(NewSignalCallback(stubCallback2, Indifferent))
+
+	exitHandler.AddExitSignalHandler(sigTERMHandler)
+	exitHandler.AddExitSignalHandler(sigINTHandler)
+
+	go func() {
+		time.Sleep(time.Millisecond * 50)
+		process, err := os.FindProcess(os.Getpid())
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = process.Signal(signalToExit)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	exitHandler.waitForExitSystemSignal(exitHandler.gracefulExit, exitHandler.gracefulExit)
+
+	// finally check indication of last string in results
+	if results[len(results) - 1] != "audit_log callback" {
+		t.Fatal("auditLogCallback has not been executed as last callback")
+	}
+}
+
+func testExitHandler(t *testing.T, signalToExit os.Signal) {
+	exitHandler, err := NewExitHandler()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	exitHandler.AddExitSignalHandler(NewSigTERMHandler())
+	exitHandler.AddExitSignalHandler(NewSigINTHandler())
+
+	go func() {
+		time.Sleep(time.Millisecond * 50)
+		process, err := os.FindProcess(os.Getpid())
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = process.Signal(signalToExit)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	exitHandler.waitForExitSystemSignal(exitHandler.gracefulExit, exitHandler.gracefulExit)
+}

--- a/cmd/exit_handler_test.go
+++ b/cmd/exit_handler_test.go
@@ -72,13 +72,13 @@ func testExitHandlerWithCallbacks(t *testing.T, signalToExit os.Signal) {
 	}
 
 	// create exit signal handlers and feed them to common exit handler mechanism
-	sigTERMHandler.AddCallback(NewSignalCallback(auditLogCallback, Last))
-	sigTERMHandler.AddCallback(NewSignalCallback(stubCallback1, Indifferent))
-	sigTERMHandler.AddCallback(NewSignalCallback(stubCallback2, Indifferent))
+	sigTERMHandler.AddCallback(NewSystemSignalCallback(auditLogCallback, Last))
+	sigTERMHandler.AddCallback(NewSystemSignalCallback(stubCallback1, Indifferent))
+	sigTERMHandler.AddCallback(NewSystemSignalCallback(stubCallback2, Indifferent))
 
-	sigINTHandler.AddCallback(NewSignalCallback(auditLogCallback, Last))
-	sigINTHandler.AddCallback(NewSignalCallback(stubCallback1, Indifferent))
-	sigINTHandler.AddCallback(NewSignalCallback(stubCallback2, Indifferent))
+	sigINTHandler.AddCallback(NewSystemSignalCallback(auditLogCallback, Last))
+	sigINTHandler.AddCallback(NewSystemSignalCallback(stubCallback1, Indifferent))
+	sigINTHandler.AddCallback(NewSystemSignalCallback(stubCallback2, Indifferent))
 
 	exitHandler.AddExitSignalHandler(sigTERMHandler)
 	exitHandler.AddExitSignalHandler(sigINTHandler)
@@ -95,7 +95,7 @@ func testExitHandlerWithCallbacks(t *testing.T, signalToExit os.Signal) {
 		}
 	}()
 
-	exitHandler.waitForExitSystemSignal(exitHandler.gracefulExit, exitHandler.gracefulExit)
+	exitHandler.waitAndHandle(exitHandler.gracefulExit, exitHandler.gracefulExit)
 
 	// finally check indication of last string in results
 	if results[len(results)-1] != "audit_log callback" {
@@ -124,5 +124,5 @@ func testExitHandler(t *testing.T, signalToExit os.Signal) {
 		}
 	}()
 
-	exitHandler.waitForExitSystemSignal(exitHandler.gracefulExit, exitHandler.gracefulExit)
+	exitHandler.waitAndHandle(exitHandler.gracefulExit, exitHandler.gracefulExit)
 }

--- a/cmd/exit_handler_test.go
+++ b/cmd/exit_handler_test.go
@@ -20,10 +20,10 @@ func TestDeferFunctionsPriority(t *testing.T) {
 		// we need that logFinalize to be called strictly as last defer function
 		results = append(results, "audit_log defer")
 	}
-	stubDefer1 := func(){
+	stubDefer1 := func() {
 		results = append(results, "stub1 defer")
 	}
-	stubDefer2 := func(){
+	stubDefer2 := func() {
 		results = append(results, "stub2 defer")
 	}
 
@@ -34,7 +34,7 @@ func TestDeferFunctionsPriority(t *testing.T) {
 	exitHandler.executeDeferFunctions()
 
 	// finally check indication of last string in results
-	if results[len(results) - 1] != "audit_log defer" {
+	if results[len(results)-1] != "audit_log defer" {
 		t.Fatal("auditLogDefer has not been executed as last defer")
 	}
 }
@@ -54,7 +54,6 @@ func testExitHandlerWithCallbacks(t *testing.T, signalToExit os.Signal) {
 
 	sigTERMHandler := NewSigTERMHandler()
 	sigINTHandler := NewSigINTHandler()
-
 
 	var results []string
 	auditLogCallback := func() {
@@ -99,7 +98,7 @@ func testExitHandlerWithCallbacks(t *testing.T, signalToExit os.Signal) {
 	exitHandler.waitForExitSystemSignal(exitHandler.gracefulExit, exitHandler.gracefulExit)
 
 	// finally check indication of last string in results
-	if results[len(results) - 1] != "audit_log callback" {
+	if results[len(results)-1] != "audit_log callback" {
 		t.Fatal("auditLogCallback has not been executed as last callback")
 	}
 }


### PR DESCRIPTION
This PR is a work in progress of task https://ph.cossacklabs.com/T1661

Basically in T1661 we defined a mechanism that handles all system signals that can be used in Acra services. There are 3 such signals (SIGTERM, SIGINT, SIGHUP) in CE version and one addition system signal is used in EE version. We should note that SIGTERM and SIGINT signals imply execution of some logic and then service shutdowns (we use them for service's graceful exit), while SIGHUP implies execution of some logic and switching to new process (we use it for reloading configuration). For this reason, we need to have some kind of "composite" architecture in order to express mentioned behavior. In this PR I started with part of the mechanism that handles exiting signals (SIGTERM and SIGINT). Currently we do not distinguish between them (https://github.com/cossacklabs/acra/blob/master/cmd/acra-server/acra-server.go#L265) and use little `SignalHandler` object for each system signal (https://github.com/cossacklabs/acra/blob/master/cmd/utils.go#L59). 

In new mechanism we basically combine all this `SignalHandler` objects into global handler and add prioritization to execution of `defer` functions and callbacks. Prioritization became rather important after introducing Audit Log feature in EE version. On high level, we need at least one `defer` function and at least one callback to be executed strictly last in the queue. For this reason, now when we specify callback or `defer` function we have to provide a `Last` or `Indifferent` priority for them. `Last` priority guarantees that this `defer` or callback (if system signal comes) will be executed strictly last in queue. 

Additionaly, this new mechanism is intended to become a single point of application exiting.

Basic unit tests are used in order to test this new functionality.

Next is an addition to this logic that will allow to properly handle SIGHUP signal that do not imply shutdown, but fork of a new process.