### PR TITLE
Use correct zone prefix for key store v2

### DIFF
--- a/keystore/v2/keystore/storage_zone.go
+++ b/keystore/v2/keystore/storage_zone.go
@@ -95,7 +95,7 @@ func (s *ServerKeyStore) HasZonePrivateKey(zoneID []byte) bool {
 // StorageKeyCreation interface (zones)
 //
 
-const zonePrefix = "client"
+const zonePrefix = "zone"
 
 func (s *ServerKeyStore) zoneStorageKeyPairPath(zoneID []byte) string {
 	return filepath.Join(zonePrefix, string(zoneID), storageSuffix)


### PR DESCRIPTION
The prefix for zone storage keys is incorrect, it should be `zone`. That way the keys will be placed into correct subdirectory.