### PR TITLE
Improve acra-migrate-key reusability

### DIFF
--- a/cmd/acra-migrate-keys/acra-migrate-keys.go
+++ b/cmd/acra-migrate-keys/acra-migrate-keys.go
@@ -79,7 +79,7 @@ func main() {
 // MigrateV1toV2 transfers keys from key store v1 to v2.
 func MigrateV1toV2(srcV1 filesystemV1.KeyExport, dstV2 keystoreV2.KeyFileImportV1, params migratekeys.MiscParams) error {
 	log.Trace("Enumerating keys for export")
-	keys, err := srcV1.EnumerateExportedKeys()
+	keys, err := filesystemV1.EnumerateExportedKeys(srcV1)
 	if err != nil {
 		log.WithError(err).Debug("Failed to enumerate exported keys")
 		return err

--- a/cmd/acra-migrate-keys/acra-migrate-keys.go
+++ b/cmd/acra-migrate-keys/acra-migrate-keys.go
@@ -48,7 +48,10 @@ func main() {
 			WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantReadServiceConfig).
 			Fatal("Cannot parse arguments")
 	}
-	params.SetDefaults()
+	err = params.SetDefaults()
+	if err != nil {
+		log.WithError(err).Fatal("Invalid arguments")
+	}
 
 	if params.Src.KeyStoreVersion == "v1" && params.Dst.KeyStoreVersion == "v2" {
 		keyStoreV1, err := OpenKeyStoreV1(migratekeys.OpenSrc, params.Src, params.Misc)

--- a/cmd/acra-migrate-keys/acra-migrate-keys.go
+++ b/cmd/acra-migrate-keys/acra-migrate-keys.go
@@ -23,7 +23,6 @@ package main
 import (
 	"errors"
 
-	"github.com/cossacklabs/acra/cmd"
 	migratekeys "github.com/cossacklabs/acra/cmd/acra-migrate-keys/migrate-keys"
 	keystoreV1 "github.com/cossacklabs/acra/keystore"
 	filesystemV1 "github.com/cossacklabs/acra/keystore/filesystem"
@@ -31,26 +30,16 @@ import (
 	keystoreApiV2 "github.com/cossacklabs/acra/keystore/v2/keystore/api"
 	filesystemV2 "github.com/cossacklabs/acra/keystore/v2/keystore/filesystem"
 	"github.com/cossacklabs/acra/logging"
-	"github.com/cossacklabs/acra/utils"
 	log "github.com/sirupsen/logrus"
-)
-
-var (
-	defaultConfigPath = utils.GetConfigPathByName("acra-migrate-keys")
-	serviceName       = "acra-migrate-keys"
 )
 
 func main() {
 	params := migratekeys.RegisterCommandLineParams()
-	err := cmd.Parse(defaultConfigPath, serviceName)
+	err := params.Parse()
 	if err != nil {
 		log.WithError(err).
 			WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantReadServiceConfig).
 			Fatal("Cannot parse arguments")
-	}
-	err = params.SetDefaults()
-	if err != nil {
-		log.WithError(err).Fatal("Invalid arguments")
 	}
 
 	if params.Src.KeyStoreVersion == "v1" && params.Dst.KeyStoreVersion == "v2" {

--- a/cmd/acra-migrate-keys/migrate-keys/command-line.go
+++ b/cmd/acra-migrate-keys/migrate-keys/command-line.go
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2020, Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package migratekeys implements common procedures for "acra-migrate-keys" tool.
+package migratekeys
+
+import (
+	"flag"
+
+	keystoreV1 "github.com/cossacklabs/acra/keystore"
+	"github.com/cossacklabs/acra/utils"
+	log "github.com/sirupsen/logrus"
+)
+
+var (
+	defaultConfigPath = utils.GetConfigPathByName("acra-migrate-keys")
+	serviceName       = "acra-migrate-keys"
+
+	defaultSrcDir       = keystoreV1.DefaultKeyDirShort
+	defaultDstDirSuffix = ".migrated"
+)
+
+// CommandLineParams - command-line options.
+type CommandLineParams struct {
+	Src, Dst KeyStoreParams
+	Misc     MiscParams
+}
+
+// KeyStoreParams - key store parameters.
+type KeyStoreParams struct {
+	KeyStoreVersion string
+	KeyDir          string
+	KeyDirPublic    string
+}
+
+// MiscParams - miscellaneous parameters.
+type MiscParams struct {
+	DryRun bool
+	Force  bool
+
+	LogDebug   bool
+	LogVerbose bool
+}
+
+// OpenMode - whether key store is source or destination.
+type OpenMode int
+
+// OpenMode constant values:
+const (
+	OpenSrc OpenMode = iota
+	OpenDst
+)
+
+// Params stores command-line parameters of "acra-migrate-keys" tool.
+var Params CommandLineParams
+
+// RegisterCommandLineParams registers command-line options for parsing.
+func RegisterCommandLineParams() *CommandLineParams {
+	// Source key store
+	flag.StringVar(&Params.Src.KeyStoreVersion, "src_keystore", "v1", "key store format to use: v1 (current), v2 (new)")
+	flag.StringVar(&Params.Src.KeyDir, "src_keys_dir", defaultSrcDir, "path to source key directory")
+	flag.StringVar(&Params.Src.KeyDirPublic, "src_keys_dir_public", defaultSrcDir, "path to source key directory for public keys")
+	// Destination key store
+	flag.StringVar(&Params.Dst.KeyStoreVersion, "dst_keystore", "v2", "key store format to use: v1 (current), v2 (new)")
+	flag.StringVar(&Params.Dst.KeyDir, "dst_keys_dir", "", "path to destination key directory (default \".acrakeys.migrated\")")
+	flag.StringVar(&Params.Dst.KeyDirPublic, "dst_keys_dir_public", "", "path to destination key directory for public keys (default \".acrakeys.migrated\")")
+	// Miscellaneous
+	flag.BoolVar(&Params.Misc.DryRun, "dry_run", false, "try migration without writing to the output key store")
+	flag.BoolVar(&Params.Misc.Force, "force", false, "write to output key store even if it exists")
+	flag.BoolVar(&Params.Misc.LogDebug, "d", false, "log debug messages to stderr")
+	flag.BoolVar(&Params.Misc.LogVerbose, "v", false, "log everything to stderr")
+
+	return &Params
+}
+
+// SetDefaults initializes default paramater values.
+func (params *CommandLineParams) SetDefaults() {
+	if params.Misc.LogDebug {
+		log.SetLevel(log.DebugLevel)
+	}
+	if params.Misc.LogVerbose {
+		log.SetLevel(log.TraceLevel)
+	}
+
+	if params.Dst.KeyDir == "" {
+		params.Dst.KeyDir = params.Src.KeyDir + defaultDstDirSuffix
+	}
+	if params.Dst.KeyDirPublic == "" {
+		params.Dst.KeyDirPublic = params.Src.KeyDirPublic + defaultDstDirSuffix
+	}
+}

--- a/cmd/acra-migrate-keys/migrate-keys/command-line.go
+++ b/cmd/acra-migrate-keys/migrate-keys/command-line.go
@@ -58,9 +58,8 @@ type MiscParams struct {
 	DryRun bool
 	Force  bool
 
-	LogLevel   log.Level
-	logDebug   bool
-	logVerbose bool
+	LogDebug   bool
+	LogVerbose bool
 }
 
 // OpenMode - whether key store is source or destination.
@@ -88,9 +87,8 @@ func RegisterCommandLineParams() *CommandLineParams {
 	// Miscellaneous
 	flag.BoolVar(&Params.Misc.DryRun, "dry_run", false, "try migration without writing to the output key store")
 	flag.BoolVar(&Params.Misc.Force, "force", false, "write to output key store even if it exists")
-	flag.BoolVar(&Params.Misc.logDebug, "d", false, "log debug messages to stderr")
-	flag.BoolVar(&Params.Misc.logVerbose, "v", false, "log everything to stderr")
-	Params.Misc.LogLevel = log.GetLevel()
+	flag.BoolVar(&Params.Misc.LogDebug, "d", false, "log debug messages to stderr")
+	flag.BoolVar(&Params.Misc.LogVerbose, "v", false, "log everything to stderr")
 
 	return &Params
 }
@@ -112,13 +110,12 @@ func (params *CommandLineParams) Parse() error {
 		return ErrMissingFormat
 	}
 
-	if params.Misc.logDebug {
-		params.Misc.LogLevel = log.DebugLevel
+	if params.Misc.LogDebug {
+		log.SetLevel(log.DebugLevel)
 	}
-	if params.Misc.logVerbose {
-		params.Misc.LogLevel = log.TraceLevel
+	if params.Misc.LogVerbose {
+		log.SetLevel(log.TraceLevel)
 	}
-	log.SetLevel(params.Misc.LogLevel)
 
 	if params.Dst.KeyDir == "" {
 		params.Dst.KeyDir = params.Src.KeyDir + defaultDstDirSuffix

--- a/cmd/acra-migrate-keys/migrate-keys/command-line.go
+++ b/cmd/acra-migrate-keys/migrate-keys/command-line.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"flag"
 
+	"github.com/cossacklabs/acra/cmd"
 	keystoreV1 "github.com/cossacklabs/acra/keystore"
 	"github.com/cossacklabs/acra/utils"
 	log "github.com/sirupsen/logrus"
@@ -92,8 +93,23 @@ func RegisterCommandLineParams() *CommandLineParams {
 	return &Params
 }
 
-// SetDefaults initializes default paramater values.
-func (params *CommandLineParams) SetDefaults() error {
+// Parse parses command-line, validates commad-line options, and initializes default paramater values.
+func (params *CommandLineParams) Parse() error {
+	err := cmd.Parse(defaultConfigPath, serviceName)
+	if err != nil {
+		return err
+	}
+
+	if params.Src.KeyStoreVersion == "" {
+		log.Warning("Missing required argument: --src_keystore={v1|v2}")
+	}
+	if params.Dst.KeyStoreVersion == "" {
+		log.Warning("Missing required argument: --dst_keystore={v1|v2}")
+	}
+	if params.Src.KeyStoreVersion == "" || params.Dst.KeyStoreVersion == "" {
+		return ErrMissingFormat
+	}
+
 	if params.Misc.LogDebug {
 		log.SetLevel(log.DebugLevel)
 	}
@@ -106,16 +122,6 @@ func (params *CommandLineParams) SetDefaults() error {
 	}
 	if params.Dst.KeyDirPublic == "" {
 		params.Dst.KeyDirPublic = params.Src.KeyDirPublic + defaultDstDirSuffix
-	}
-
-	if params.Src.KeyStoreVersion == "" {
-		log.Warning("Missing required argument: --src_keystore={v1|v2}")
-	}
-	if params.Dst.KeyStoreVersion == "" {
-		log.Warning("Missing required argument: --dst_keystore={v1|v2}")
-	}
-	if params.Src.KeyStoreVersion == "" || params.Dst.KeyStoreVersion == "" {
-		return ErrMissingFormat
 	}
 
 	return nil

--- a/cmd/acra-migrate-keys/migrate-keys/command-line.go
+++ b/cmd/acra-migrate-keys/migrate-keys/command-line.go
@@ -58,8 +58,9 @@ type MiscParams struct {
 	DryRun bool
 	Force  bool
 
-	LogDebug   bool
-	LogVerbose bool
+	LogLevel   log.Level
+	logDebug   bool
+	logVerbose bool
 }
 
 // OpenMode - whether key store is source or destination.
@@ -87,8 +88,9 @@ func RegisterCommandLineParams() *CommandLineParams {
 	// Miscellaneous
 	flag.BoolVar(&Params.Misc.DryRun, "dry_run", false, "try migration without writing to the output key store")
 	flag.BoolVar(&Params.Misc.Force, "force", false, "write to output key store even if it exists")
-	flag.BoolVar(&Params.Misc.LogDebug, "d", false, "log debug messages to stderr")
-	flag.BoolVar(&Params.Misc.LogVerbose, "v", false, "log everything to stderr")
+	flag.BoolVar(&Params.Misc.logDebug, "d", false, "log debug messages to stderr")
+	flag.BoolVar(&Params.Misc.logVerbose, "v", false, "log everything to stderr")
+	Params.Misc.LogLevel = log.GetLevel()
 
 	return &Params
 }
@@ -110,12 +112,13 @@ func (params *CommandLineParams) Parse() error {
 		return ErrMissingFormat
 	}
 
-	if params.Misc.LogDebug {
-		log.SetLevel(log.DebugLevel)
+	if params.Misc.logDebug {
+		params.Misc.LogLevel = log.DebugLevel
 	}
-	if params.Misc.LogVerbose {
-		log.SetLevel(log.TraceLevel)
+	if params.Misc.logVerbose {
+		params.Misc.LogLevel = log.TraceLevel
 	}
+	log.SetLevel(params.Misc.LogLevel)
 
 	if params.Dst.KeyDir == "" {
 		params.Dst.KeyDir = params.Src.KeyDir + defaultDstDirSuffix

--- a/cmd/acra-migrate-keys/migrate-keys/command-line.go
+++ b/cmd/acra-migrate-keys/migrate-keys/command-line.go
@@ -88,7 +88,7 @@ func RegisterCommandLineParams() *CommandLineParams {
 	flag.BoolVar(&Params.Misc.DryRun, "dry_run", false, "try migration without writing to the output key store")
 	flag.BoolVar(&Params.Misc.Force, "force", false, "write to output key store even if it exists")
 	flag.BoolVar(&Params.Misc.LogDebug, "d", false, "log debug messages to stderr")
-	flag.BoolVar(&Params.Misc.LogVerbose, "v", false, "log everything to stderr")
+	flag.BoolVar(&Params.Misc.LogVerbose, "v", false, "log more information to stderr")
 
 	return &Params
 }
@@ -111,10 +111,10 @@ func (params *CommandLineParams) Parse() error {
 	}
 
 	if params.Misc.LogDebug {
-		log.SetLevel(log.DebugLevel)
+		log.SetLevel(log.TraceLevel)
 	}
 	if params.Misc.LogVerbose {
-		log.SetLevel(log.TraceLevel)
+		log.SetLevel(log.DebugLevel)
 	}
 
 	if params.Dst.KeyDir == "" {

--- a/configs/acra-migrate-keys.yaml
+++ b/configs/acra-migrate-keys.yaml
@@ -15,7 +15,7 @@ dst_keys_dir:
 dst_keys_dir_public: 
 
 # key store format to use: v1 (current), v2 (new)
-dst_keystore: v2
+dst_keystore: 
 
 # dump config
 dump_config: false
@@ -33,7 +33,7 @@ src_keys_dir: .acrakeys
 src_keys_dir_public: .acrakeys
 
 # key store format to use: v1 (current), v2 (new)
-src_keystore: v1
+src_keystore: 
 
 # log everything to stderr
 v: false

--- a/keystore/filesystem/server_keystore_test.go
+++ b/keystore/filesystem/server_keystore_test.go
@@ -521,7 +521,7 @@ func TestFilesystemKeyStoreExport(t *testing.T) {
 	}
 
 	// Test setup complete, now we can finally verify exporting.
-	exportedKeys, err := keyStore.EnumerateExportedKeys()
+	exportedKeys, err := EnumerateExportedKeys(keyStore)
 	if err != nil {
 		t.Errorf("EnumerateExportedKeys() failed: %v", err)
 	}

--- a/keystore/v2/keystore/importV1_test.go
+++ b/keystore/v2/keystore/importV1_test.go
@@ -126,7 +126,7 @@ func TestImportKeyStoreV1(t *testing.T) {
 	}
 
 	// Test setup complete, now we transfer the keys.
-	exportedKeys, err := keyStoreV1.EnumerateExportedKeys()
+	exportedKeys, err := filesystemV1.EnumerateExportedKeys(keyStoreV1)
 	if err != nil {
 		t.Fatalf("EnumerateExportedKeys() failed: %v", err)
 	}


### PR DESCRIPTION
* **Common acra-migrate-keys package**

Move command-line processing into a shared `migratekeys` package which could be reused in Acra EE to provide the same command-line interface as Acra CE without a lot of copypasta.

We'll still need to use copy-paste inheritance for key store initialization and the migration process, but that's a necessary evil
because the key store instances are different. Common command-line parameters are the same, on the other hand.

* **Improve reusability of `filesystem.KeyExport`**

The main difference between Acra CE and Acra EE in key exporting is the list of keys that need to be exported and the method by which they are exported. Acra EE will need to extend and/or override these methods.

The exporting approach can be readily overridden in `ExportPublicKey()` methods, etc. That will be easy to do. However, the key list is different. Current Acra CE code does not expose the key list itself, instead it provides the `EnumerateExportedKeys()` method which queries the list and processes it using the classifier to determine which key paths correspond to which keys.

The classification process itself is the same for both Acra CE and EE, but in the current form it cannot be reused in Acra EE: it is too coupled with path enumertion. Acre CE supports only raw filesystem, but Acra EE supports more options and cannot use `ioutil.ReadDir()` directly.

Introduce a new interface for enumerating the key paths alone, and move the existing `EnumerateExportedKeys()` methods into free functions. This way Acra EE can provide its own path enumeration, its own extended classifier, but reuse the rest of the export workflow.