### PR TITLE
Require explicit key store version

### DIFF
--- a/cmd/acra-addzone/acra-addzone.go
+++ b/cmd/acra-addzone/acra-addzone.go
@@ -54,7 +54,6 @@ var (
 func main() {
 	outputDir := flag.String("keys_output_dir", keystore.DefaultKeyDirShort, "Folder where will be saved generated zone keys")
 	flag.Bool("fs_keystore_enable", true, "Use filesystem key store (deprecated, ignored)")
-	keystoreOpts := flag.String("keystore", "", "force Key Store format: v1 (current), v2 (new)")
 
 	logging.SetLogLevel(logging.LogVerbose)
 
@@ -66,21 +65,10 @@ func main() {
 	}
 
 	var keyStore keystore.StorageKeyCreation
-	if *keystoreOpts == "" {
-		if filesystemV2.IsKeyDirectory(*outputDir) {
-			*keystoreOpts = "v2"
-		} else {
-			*keystoreOpts = "v1"
-		}
-	}
-	switch *keystoreOpts {
-	case "v1":
-		keyStore = openKeyStoreV1(*outputDir)
-	case "v2":
+	if filesystemV2.IsKeyDirectory(*outputDir) {
 		keyStore = openKeyStoreV2(*outputDir)
-	default:
-		log.Errorf("unknown keystore option: %v", *keystoreOpts)
-		os.Exit(1)
+	} else {
+		keyStore = openKeyStoreV1(*outputDir)
 	}
 
 	id, publicKey, err := keyStore.GenerateZoneKey()

--- a/cmd/acra-authmanager/acra_authmanager.go
+++ b/cmd/acra-authmanager/acra_authmanager.go
@@ -179,7 +179,6 @@ func main() {
 	password := flag.String("password", "", "Password")
 	filePath := flag.String("file", cmd.DefaultAcraServerAuthPath, "Auth file")
 	keysDir := flag.String("keys_dir", keystore.DefaultKeyDirShort, "Folder from which will be loaded keys")
-	keystoreOpts := flag.String("keystore", "", "force Key Store format: v1 (current), v2 (new)")
 	debug := flag.Bool("d", false, "Turn on debug logging")
 
 	if err := cmd.Parse(defaultConfigPath, serviceName); err != nil {
@@ -197,21 +196,10 @@ func main() {
 	}
 
 	var keyStore keystore.WebConfigKeyStore
-	if *keystoreOpts == "" {
-		if filesystemV2.IsKeyDirectory(*keysDir) {
-			*keystoreOpts = "v2"
-		} else {
-			*keystoreOpts = "v1"
-		}
-	}
-	switch *keystoreOpts {
-	case "v1":
-		keyStore = openKeyStoreV1(*keysDir)
-	case "v2":
+	if filesystemV2.IsKeyDirectory(*keysDir) {
 		keyStore = openKeyStoreV2(*keysDir)
-	default:
-		log.Errorf("unknown keystore option: %v", *keystoreOpts)
-		os.Exit(1)
+	} else {
+		keyStore = openKeyStoreV1(*keysDir)
 	}
 
 	n := 0

--- a/cmd/acra-connector/acra-connector.go
+++ b/cmd/acra-connector/acra-connector.go
@@ -213,7 +213,6 @@ type Config struct {
 func main() {
 	loggingFormat := flag.String("logging_format", "plaintext", "Logging format: plaintext, json or CEF")
 	keysDir := flag.String("keys_dir", keystore.DefaultKeyDirShort, "Folder from which will be loaded keys")
-	keystoreOpts := flag.String("keystore", "", "force Key Store format: v1 (current), v2 (new)")
 	clientID := flag.String("client_id", "", "Client ID")
 	acraServerHost := flag.String("acraserver_connection_host", "", "IP or domain to AcraServer daemon")
 	acraServerAPIPort := flag.Int("acraserver_api_connection_port", cmd.DefaultAcraServerAPIPort, "Port of Acra HTTP API")
@@ -335,21 +334,10 @@ func main() {
 	// --------- keystore  -----------
 	log.Infof("Initializing keystore...")
 	var keyStore keystore.TransportKeyStore
-	if *keystoreOpts == "" {
-		if filesystemV2.IsKeyDirectory(*keysDir) {
-			*keystoreOpts = "v2"
-		} else {
-			*keystoreOpts = "v1"
-		}
-	}
-	switch *keystoreOpts {
-	case "v1":
-		keyStore = openKeyStoreV1(*keysDir, []byte(*clientID), connectorMode)
-	case "v2":
+	if filesystemV2.IsKeyDirectory(*keysDir) {
 		keyStore = openKeyStoreV2(*keysDir, []byte(*clientID), connectorMode)
-	default:
-		log.Errorf("unknown keystore option: %v", *keystoreOpts)
-		os.Exit(1)
+	} else {
+		keyStore = openKeyStoreV1(*keysDir, []byte(*clientID), connectorMode)
 	}
 	log.Infof("Keystore init OK")
 

--- a/cmd/acra-keymaker/acra-keymaker.go
+++ b/cmd/acra-keymaker/acra-keymaker.go
@@ -79,14 +79,10 @@ func main() {
 
 	var store keystore.KeyMaking
 	// If the key store already exists, detect its version automatically and allow to not specify it.
-	if *keystoreVersion == "" {
-		if fi, err := os.Stat(*outputDir); err == nil && fi.IsDir() {
-			if filesystemV2.IsKeyDirectory(*outputDir) {
-				*keystoreVersion = "v2"
-			} else {
-				*keystoreVersion = "v1"
-			}
-		}
+	if filesystemV2.IsKeyDirectory(*outputDir) {
+		*keystoreVersion = "v2"
+	} else if filesystem.IsKeyDirectory(*outputDir) {
+		*keystoreVersion = "v1"
 	}
 	switch *keystoreVersion {
 	case "v1":

--- a/cmd/acra-keymaker/acra-keymaker.go
+++ b/cmd/acra-keymaker/acra-keymaker.go
@@ -53,7 +53,7 @@ func main() {
 	outputDir := flag.String("keys_output_dir", keystore.DefaultKeyDirShort, "Folder where will be saved keys")
 	outputPublicKey := flag.String("keys_public_output_dir", keystore.DefaultKeyDirShort, "Folder where will be saved public key")
 	masterKey := flag.String("generate_master_key", "", "Generate new random master key and save to file")
-	keystoreOpts := flag.String("keystore", "", "force Key Store format: v1 (current), v2 (new)")
+	keystoreVersion := flag.String("keystore", "", "set key store format: v1 (current), v2 (new)")
 
 	logging.SetLogLevel(logging.LogVerbose)
 
@@ -78,22 +78,26 @@ func main() {
 	}
 
 	var store keystore.KeyMaking
-	if *keystoreOpts == "" {
-		// IsKeyDirectory returns false for missing directories too.
-		// Create keystore v1 by default if it does not exist.
-		if filesystemV2.IsKeyDirectory(*outputDir) {
-			*keystoreOpts = "v2"
-		} else {
-			*keystoreOpts = "v1"
+	// If the key store already exists, detect its version automatically and allow to not specify it.
+	if *keystoreVersion == "" {
+		if fi, err := os.Stat(*outputDir); err == nil && fi.IsDir() {
+			if filesystemV2.IsKeyDirectory(*outputDir) {
+				*keystoreVersion = "v2"
+			} else {
+				*keystoreVersion = "v1"
+			}
 		}
 	}
-	switch *keystoreOpts {
+	switch *keystoreVersion {
 	case "v1":
 		store = openKeyStoreV1(*outputDir, *outputPublicKey)
 	case "v2":
 		store = openKeyStoreV2(*outputDir)
+	case "":
+		log.Errorf("Key store version is required: --keystore={v1|v2}")
+		os.Exit(1)
 	default:
-		log.Errorf("unknown keystore option: %v", *keystoreOpts)
+		log.Errorf("Unknown --keystore option: %v", *keystoreVersion)
 		os.Exit(1)
 	}
 

--- a/cmd/acra-keys/keys/command-line.go
+++ b/cmd/acra-keys/keys/command-line.go
@@ -117,7 +117,6 @@ var Params *CommandLineParams = &CommandLineParams{}
 
 // Register configures command-line parameter parsing.
 func (params *CommandLineParams) Register() {
-	flag.StringVar(&params.KeyStoreVersion, "keystore", "", "force key store format: v1 (current), v2 (new)")
 	flag.StringVar(&params.KeyDir, "keys_dir", DefaultKeyDirectory, "path to key directory")
 	flag.StringVar(&params.KeyDirPublic, "keys_dir_public", "", "path to key directory for public keys")
 	flag.StringVar(&params.ClientID, "client_id", "", "client ID for which to retrieve key")
@@ -300,12 +299,10 @@ func (params *CommandLineParams) ParseSubCommand() error {
 
 // SetDefaults sets dynamically configured default values of command-line parameters.
 func (params *CommandLineParams) SetDefaults() {
-	if params.KeyStoreVersion == "" {
-		if filesystemV2.IsKeyDirectory(params.KeyDir) {
-			params.KeyStoreVersion = "v2"
-		} else {
-			params.KeyStoreVersion = "v1"
-		}
+	if filesystemV2.IsKeyDirectory(params.KeyDir) {
+		params.KeyStoreVersion = "v2"
+	} else {
+		params.KeyStoreVersion = "v1"
 	}
 
 	if params.KeyDirPublic == "" {

--- a/cmd/acra-poisonrecordmaker/acra-poisonrecordmaker.go
+++ b/cmd/acra-poisonrecordmaker/acra-poisonrecordmaker.go
@@ -50,7 +50,6 @@ var (
 
 func main() {
 	keysDir := flag.String("keys_dir", keystore.DefaultKeyDirShort, "Folder from which will be loaded keys")
-	keystoreOpts := flag.String("keystore", "", "force Key Store format: v1 (current), v2 (new)")
 	dataLength := flag.Int("data_length", poison.UseDefaultDataLength, fmt.Sprintf("Length of random data for data block in acrastruct. -1 is random in range 1..%v", poison.DefaultDataLength))
 
 	logging.SetLogLevel(logging.LogDiscard)
@@ -63,21 +62,10 @@ func main() {
 	}
 
 	var store keystore.PoisonKeyStore
-	if *keystoreOpts == "" {
-		if filesystemV2.IsKeyDirectory(*keysDir) {
-			*keystoreOpts = "v2"
-		} else {
-			*keystoreOpts = "v1"
-		}
-	}
-	switch *keystoreOpts {
-	case "v1":
-		store = openKeyStoreV1(*keysDir)
-	case "v2":
+	if filesystemV2.IsKeyDirectory(*keysDir) {
 		store = openKeyStoreV2(*keysDir)
-	default:
-		log.Errorf("unknown keystore option: %v", *keystoreOpts)
-		os.Exit(1)
+	} else {
+		store = openKeyStoreV1(*keysDir)
 	}
 
 	poisonRecord, err := poison.CreatePoisonRecord(store, *dataLength)

--- a/cmd/acra-rollback/acra-rollback.go
+++ b/cmd/acra-rollback/acra-rollback.go
@@ -157,7 +157,6 @@ func (ex *WriteToFileExecutor) Close() {
 
 func main() {
 	keysDir := flag.String("keys_dir", keystore.DefaultKeyDirShort, "Folder from which the keys will be loaded")
-	keystoreOpts := flag.String("keystore", "", "force Key Store format: v1 (current), v2 (new)")
 	clientID := flag.String("client_id", "", "Client ID should be name of file with private key")
 	connectionString := flag.String("connection_string", "", "Connection string for db")
 	sqlSelect := flag.String("select", "", "Query to fetch data for decryption")
@@ -222,21 +221,10 @@ func main() {
 	}
 
 	var keystorage keystore.DecryptionKeyStore
-	if *keystoreOpts == "" {
-		if filesystemV2.IsKeyDirectory(*keysDir) {
-			*keystoreOpts = "v2"
-		} else {
-			*keystoreOpts = "v1"
-		}
-	}
-	switch *keystoreOpts {
-	case "v1":
-		keystorage = openKeyStoreV1(*keysDir)
-	case "v2":
+	if filesystemV2.IsKeyDirectory(*keysDir) {
 		keystorage = openKeyStoreV2(*keysDir)
-	default:
-		log.Errorf("unknown keystore option: %v", *keystoreOpts)
-		os.Exit(1)
+	} else {
+		keystorage = openKeyStoreV1(*keysDir)
 	}
 
 	db, err := sql.Open(dbDriverName, *connectionString)

--- a/cmd/acra-rotate/acra-rotate.go
+++ b/cmd/acra-rotate/acra-rotate.go
@@ -82,7 +82,6 @@ func openKeyStoreV2(keyDirPath string) keystore.RotateStorageKeyStore {
 
 func main() {
 	keysDir := flag.String("keys_dir", keystore.DefaultKeyDirShort, "Folder from which the keys will be loaded")
-	keystoreOpts := flag.String("keystore", "", "force Key Store format: v1 (current), v2 (new)")
 	fileMapConfig := flag.String("file_map_config", "", "Path to file with map of <ZoneId>: <FilePaths> in json format {\"zone_id1\": [\"filepath1\", \"filepath2\"], \"zone_id2\": [\"filepath1\", \"filepath2\"]}")
 
 	sqlSelect := flag.String("sql_select", "", "Select query with ? as placeholders where last columns in result must be ClientId/ZoneId and AcraStruct. Other columns will be passed into insert/update query into placeholders")
@@ -102,21 +101,10 @@ func main() {
 	}
 
 	var keystorage keystore.RotateStorageKeyStore
-	if *keystoreOpts == "" {
-		if filesystemV2.IsKeyDirectory(*keysDir) {
-			*keystoreOpts = "v2"
-		} else {
-			*keystoreOpts = "v1"
-		}
-	}
-	switch *keystoreOpts {
-	case "v1":
-		keystorage = openKeyStoreV1(*keysDir)
-	case "v2":
+	if filesystemV2.IsKeyDirectory(*keysDir) {
 		keystorage = openKeyStoreV2(*keysDir)
-	default:
-		log.Errorf("unknown keystore option: %v", *keystoreOpts)
-		os.Exit(1)
+	} else {
+		keystorage = openKeyStoreV1(*keysDir)
 	}
 
 	if *dryRun {

--- a/cmd/acra-server/acra-server.go
+++ b/cmd/acra-server/acra-server.go
@@ -89,7 +89,6 @@ func main() {
 
 	keysDir := flag.String("keys_dir", keystore.DefaultKeyDirShort, "Folder from which will be loaded keys")
 	keysCacheSize := flag.Int("keystore_cache_size", keystore.InfiniteCacheSize, "Maximum number of keys stored in in-memory LRU cache in encrypted form. 0 - no limits, -1 - turn off cache")
-	keystoreOpts := flag.String("keystore", "", "force Key Store format: v1 (current), v2 (new)")
 
 	_ = flag.Bool("pgsql_hex_bytea", false, "Hex format for Postgresql bytea data (deprecated, ignored)")
 	flag.Bool("pgsql_escape_bytea", false, "Escape format for Postgresql bytea data (deprecated, ignored)")
@@ -207,21 +206,10 @@ func main() {
 
 	log.Infof("Initialising keystore...")
 	var keyStore keystore.ServerKeyStore
-	if *keystoreOpts == "" {
-		if filesystemV2.IsKeyDirectory(*keysDir) {
-			*keystoreOpts = "v2"
-		} else {
-			*keystoreOpts = "v1"
-		}
-	}
-	switch *keystoreOpts {
-	case "v1":
-		keyStore = openKeyStoreV1(*keysDir, *keysCacheSize)
-	case "v2":
+	if filesystemV2.IsKeyDirectory(*keysDir) {
 		keyStore = openKeyStoreV2(*keysDir)
-	default:
-		log.Errorf("unknown keystore option: %v", *keystoreOpts)
-		os.Exit(1)
+	} else {
+		keyStore = openKeyStoreV1(*keysDir, *keysCacheSize)
 	}
 	config.setKeyStore(keyStore)
 	log.Infof("Keystore init OK")

--- a/cmd/acra-translator/acra-translator.go
+++ b/cmd/acra-translator/acra-translator.go
@@ -61,7 +61,6 @@ func main() {
 
 	keysDir := flag.String("keys_dir", keystore.DefaultKeyDirShort, "Folder from which will be loaded keys")
 	keysCacheSize := flag.Int("keystore_cache_size", keystore.InfiniteCacheSize, "Count of keys that will be stored in in-memory LRU cache in encrypted form. 0 - no limits, -1 - turn off cache")
-	keystoreOpts := flag.String("keystore", "", "force Key Store format: v1 (current), v2 (new)")
 
 	secureSessionID := flag.String("securesession_id", "acra_translator", "Id that will be sent in secure session")
 
@@ -116,21 +115,10 @@ func main() {
 
 	log.Infof("Initialising keystore...")
 	var keyStore keystore.TranslationKeyStore
-	if *keystoreOpts == "" {
-		if filesystemV2.IsKeyDirectory(*keysDir) {
-			*keystoreOpts = "v2"
-		} else {
-			*keystoreOpts = "v1"
-		}
-	}
-	switch *keystoreOpts {
-	case "v1":
-		keyStore = openKeyStoreV1(*keysDir, *keysCacheSize)
-	case "v2":
+	if filesystemV2.IsKeyDirectory(*keysDir) {
 		keyStore = openKeyStoreV2(*keysDir)
-	default:
-		log.Errorf("unknown keystore option: %v", *keystoreOpts)
-		os.Exit(1)
+	} else {
+		keyStore = openKeyStoreV1(*keysDir, *keysCacheSize)
 	}
 	log.Infof("Keystore init OK")
 

--- a/configs/acra-addzone.yaml
+++ b/configs/acra-addzone.yaml
@@ -14,6 +14,3 @@ generate_markdown_args_table: false
 # Folder where will be saved generated zone keys
 keys_output_dir: .acrakeys
 
-# force Key Store format: v1 (current), v2 (new)
-keystore: 
-

--- a/configs/acra-authmanager.yaml
+++ b/configs/acra-authmanager.yaml
@@ -17,9 +17,6 @@ generate_markdown_args_table: false
 # Folder from which will be loaded keys
 keys_dir: .acrakeys
 
-# force Key Store format: v1 (current), v2 (new)
-keystore: 
-
 # Password
 password: 
 

--- a/configs/acra-connector.yaml
+++ b/configs/acra-connector.yaml
@@ -83,9 +83,6 @@ jaeger_collector_endpoint:
 # Folder from which will be loaded keys
 keys_dir: .acrakeys
 
-# force Key Store format: v1 (current), v2 (new)
-keystore: 
-
 # Logging format: plaintext, json or CEF
 logging_format: plaintext
 

--- a/configs/acra-keymaker.yaml
+++ b/configs/acra-keymaker.yaml
@@ -35,6 +35,6 @@ keys_output_dir: .acrakeys
 # Folder where will be saved public key
 keys_public_output_dir: .acrakeys
 
-# force Key Store format: v1 (current), v2 (new)
+# set key store format: v1 (current), v2 (new)
 keystore: 
 

--- a/configs/acra-keys.yaml
+++ b/configs/acra-keys.yaml
@@ -17,9 +17,6 @@ keys_dir: .acrakeys
 # path to key directory for public keys
 keys_dir_public: 
 
-# force key store format: v1 (current), v2 (new)
-keystore: 
-
 # zone ID for which to retrieve key
 zone_id: 
 

--- a/configs/acra-keys.yaml
+++ b/configs/acra-keys.yaml
@@ -11,6 +11,9 @@ dump_config: false
 # Generate with yaml config markdown text file with descriptions of all args
 generate_markdown_args_table: false
 
+# use machine-readable JSON output
+json: false
+
 # path to key directory
 keys_dir: .acrakeys
 

--- a/configs/acra-poisonrecordmaker.yaml
+++ b/configs/acra-poisonrecordmaker.yaml
@@ -14,6 +14,3 @@ generate_markdown_args_table: false
 # Folder from which will be loaded keys
 keys_dir: .acrakeys
 
-# force Key Store format: v1 (current), v2 (new)
-keystore: 
-

--- a/configs/acra-rollback.yaml
+++ b/configs/acra-rollback.yaml
@@ -26,9 +26,6 @@ insert:
 # Folder from which the keys will be loaded
 keys_dir: .acrakeys
 
-# force Key Store format: v1 (current), v2 (new)
-keystore: 
-
 # Handle MySQL connections
 mysql_enable: false
 

--- a/configs/acra-rotate.yaml
+++ b/configs/acra-rotate.yaml
@@ -20,9 +20,6 @@ generate_markdown_args_table: false
 # Folder from which the keys will be loaded
 keys_dir: .acrakeys
 
-# force Key Store format: v1 (current), v2 (new)
-keystore: 
-
 # Handle MySQL connections
 mysql_enable: false
 

--- a/configs/acra-server.yaml
+++ b/configs/acra-server.yaml
@@ -83,9 +83,6 @@ jaeger_collector_endpoint:
 # Folder from which will be loaded keys
 keys_dir: .acrakeys
 
-# force Key Store format: v1 (current), v2 (new)
-keystore: 
-
 # Maximum number of keys stored in in-memory LRU cache in encrypted form. 0 - no limits, -1 - turn off cache
 keystore_cache_size: 0
 

--- a/configs/acra-translator.yaml
+++ b/configs/acra-translator.yaml
@@ -38,9 +38,6 @@ jaeger_collector_endpoint:
 # Folder from which will be loaded keys
 keys_dir: .acrakeys
 
-# force Key Store format: v1 (current), v2 (new)
-keystore: 
-
 # Count of keys that will be stored in in-memory LRU cache in encrypted form. 0 - no limits, -1 - turn off cache
 keystore_cache_size: 0
 

--- a/keystore/filesystem/server_keystore.go
+++ b/keystore/filesystem/server_keystore.go
@@ -144,6 +144,16 @@ func (b *KeyStoreBuilder) Build() (*KeyStore, error) {
 	return newFilesystemKeyStore(b.privateKeyDir, b.publicKeyDir, b.storage, b.encryptor, b.cacheSize)
 }
 
+// IsKeyDirectory checks if the local directory contains a key store.
+// This is a conservative check.
+// That is, positive return value does not mean that the directory contains *a valid* key store.
+// However, false value means that the directory definitely is not a valid key store.
+// In particular, false is returned if the directory does not exists or cannot be opened.
+func IsKeyDirectory(keyDirectory string) bool {
+	fi, err := os.Stat(keyDirectory)
+	return err == nil && fi.IsDir()
+}
+
 func newFilesystemKeyStore(privateKeyFolder, publicKeyFolder string, storage Storage, encryptor keystore.KeyEncryptor, cacheSize int) (*KeyStore, error) {
 	fi, err := storage.Stat(privateKeyFolder)
 	if err != nil && !os.IsNotExist(err) {

--- a/tests/test.py
+++ b/tests/test.py
@@ -306,7 +306,7 @@ def get_poison_record():
     if not poison_record:
         poison_record = b64decode(subprocess.check_output([
             './acra-poisonrecordmaker', '--keys_dir={}'.format(KEYS_FOLDER.name),
-            '--keystore={}'.format(KEYSTORE_VERSION)],
+            ],
             timeout=PROCESS_CALL_TIMEOUT))
     return poison_record
 
@@ -380,7 +380,6 @@ def manage_basic_auth_user(action, user_name, user_password):
             '--file={}'.format(ACRAWEBCONFIG_AUTH_DB_PATH),
             '--user={}'.format(user_name),
             '--keys_dir={}'.format(KEYS_FOLDER.name),
-            '--keystore={}'.format(KEYSTORE_VERSION),
             '--password={}'.format(user_password)]
     return subprocess.call(args, cwd=os.getcwd(), timeout=PROCESS_CALL_TIMEOUT)
 
@@ -4831,13 +4830,10 @@ class TestOutdatedServiceConfigs(BaseTestCase, FailedRunProcessMixin):
                                   '--keystore={}'.format(KEYSTORE_VERSION)],
                 'acra-migrate-keys': ['--dry_run', '--src_keys_dir={}'.format(KEYS_FOLDER.name)],
                 'acra-keys': ['--keys_dir={}'.format(KEYS_FOLDER.name)],
-                'acra-poisonrecordmaker': ['-keys_dir={}'.format(tmp_dir),
-                                           '--keystore={}'.format(KEYSTORE_VERSION)],
-                'acra-rollback': {'args': ['-keys_dir={}'.format(tmp_dir),
-                                           '--keystore={}'.format(KEYSTORE_VERSION)],
+                'acra-poisonrecordmaker': ['-keys_dir={}'.format(tmp_dir)],
+                'acra-rollback': {'args': ['-keys_dir={}'.format(tmp_dir)],
                                   'status': 1},
-                'acra-rotate': {'args': ['-keys_dir={}'.format(tmp_dir),
-                                         '--keystore={}'.format(KEYSTORE_VERSION)],
+                'acra-rotate': {'args': ['-keys_dir={}'.format(tmp_dir)],
                                 'status': 0},
                 'acra-translator': {'connection': 'connection_string',
                                    'args': ['-keys_dir={}'.format(KEYS_FOLDER.name),
@@ -4882,13 +4878,10 @@ class TestOutdatedServiceConfigs(BaseTestCase, FailedRunProcessMixin):
                                   '--keystore={}'.format(KEYSTORE_VERSION)],
                 'acra-migrate-keys': ['--dry_run', '--src_keys_dir={}'.format(KEYS_FOLDER.name)],
                 'acra-keys': ['--keys_dir={}'.format(KEYS_FOLDER.name)],
-                'acra-poisonrecordmaker': ['-keys_dir={}'.format(tmp_dir),
-                                           '--keystore={}'.format(KEYSTORE_VERSION)],
-                'acra-rollback': {'args': ['-keys_dir={}'.format(tmp_dir),
-                                           '--keystore={}'.format(KEYSTORE_VERSION)],
+                'acra-poisonrecordmaker': ['-keys_dir={}'.format(tmp_dir)],
+                'acra-rollback': {'args': ['-keys_dir={}'.format(tmp_dir)],
                                   'status': 1},
-                'acra-rotate': {'args': ['-keys_dir={}'.format(tmp_dir),
-                                         '--keystore={}'.format(KEYSTORE_VERSION)],
+                'acra-rotate': {'args': ['-keys_dir={}'.format(tmp_dir)],
                                 'status': 0},
                 'acra-translator': {'connection': 'connection_string',
                                     'args': ['-keys_dir={}'.format(KEYS_FOLDER.name),


### PR DESCRIPTION
As discussed, let's make the behavior of tools more predictable.

All services can already detect the key store version from the actual key store data. They do not need a `--keystore` parameter at all. Remove it from almost all the tools.

However, `acra-keymaker` now requires the `--keystore` option to be specified the first time it generated the keys. That is, when then key store is initialized. It is now an error to not specify it. Requiring the version to be specified explicitly makes infrastructure configuration more predictable.

Another tool which requires explicit key store version is `acra-migrate-keys`. PR #386 takes care of it.