### PR TITLE
Improve acra-keys extensibility in Acra EE

### DIFF
--- a/cmd/acra-keys/keys/export.go
+++ b/cmd/acra-keys/keys/export.go
@@ -23,7 +23,6 @@ import (
 	"os"
 
 	"github.com/cossacklabs/acra/keystore"
-	keystoreV2 "github.com/cossacklabs/acra/keystore/v2/keystore"
 	"github.com/cossacklabs/acra/keystore/v2/keystore/api"
 	"github.com/cossacklabs/acra/keystore/v2/keystore/crypto"
 	"github.com/cossacklabs/acra/utils"
@@ -100,7 +99,7 @@ func ReadImportEncryptionKeys(params *CommandLineParams) (*crypto.KeyStoreSuite,
 }
 
 // ExportKeys exports requested key rings.
-func ExportKeys(keyStore *keystoreV2.ServerKeyStore, cryptosuite *crypto.KeyStoreSuite, params *CommandLineParams) (exportedData []byte, err error) {
+func ExportKeys(keyStore api.KeyStore, cryptosuite *crypto.KeyStoreSuite, params *CommandLineParams) (exportedData []byte, err error) {
 	exportedIDs := params.ExportIDs
 	if params.ExportAll {
 		exportedIDs, err = keyStore.ListKeyRings()
@@ -123,7 +122,7 @@ func ExportKeys(keyStore *keystoreV2.ServerKeyStore, cryptosuite *crypto.KeyStor
 }
 
 // ImportKeys imports available key rings.
-func ImportKeys(exportedData []byte, keyStore *keystoreV2.ServerKeyStore, cryptosuite *crypto.KeyStoreSuite, params *CommandLineParams) ([]keystore.KeyDescription, error) {
+func ImportKeys(exportedData []byte, keyStore api.MutableKeyStore, cryptosuite *crypto.KeyStoreSuite, params *CommandLineParams) ([]keystore.KeyDescription, error) {
 	keyIDs, err := keyStore.ImportKeyRings(exportedData, cryptosuite, nil)
 	if err != nil {
 		log.WithError(err).Debug("Failed to import key rings")

--- a/cmd/acra-keys/keys/export.go
+++ b/cmd/acra-keys/keys/export.go
@@ -23,6 +23,7 @@ import (
 	"os"
 
 	"github.com/cossacklabs/acra/keystore"
+	keystoreV2 "github.com/cossacklabs/acra/keystore/v2/keystore"
 	"github.com/cossacklabs/acra/keystore/v2/keystore/api"
 	"github.com/cossacklabs/acra/keystore/v2/keystore/crypto"
 	"github.com/cossacklabs/acra/utils"
@@ -128,7 +129,7 @@ func ImportKeys(exportedData []byte, keyStore api.MutableKeyStore, cryptosuite *
 		log.WithError(err).Debug("Failed to import key rings")
 		return nil, err
 	}
-	descriptions, err := keyStore.DescribeKeys(keyIDs)
+	descriptions, err := keystoreV2.DescribeKeyRings(keyIDs, keyStore)
 	if err != nil {
 		log.WithError(err).Debug("Failed to describe imported key rings")
 		return nil, err

--- a/keystore/v2/keystore/api/keyStore.go
+++ b/keystore/v2/keystore/api/keyStore.go
@@ -18,6 +18,7 @@
 package api
 
 import (
+	keystoreV1 "github.com/cossacklabs/acra/keystore"
 	"github.com/cossacklabs/acra/keystore/v2/keystore/asn1"
 	"github.com/cossacklabs/acra/keystore/v2/keystore/crypto"
 )
@@ -38,6 +39,9 @@ type KeyStore interface {
 	// Key ring data is encrypted and signed using given cryptosuite.
 	// Resulting container can be imported into existing or different key store with ImportKeyRings().
 	ExportKeyRings(paths []string, cryptosuite *crypto.KeyStoreSuite, mode ExportMode) ([]byte, error)
+
+	// DescribeKeyRing describes key ring by its purpose path.
+	DescribeKeyRing(purpose string) (*keystoreV1.KeyDescription, error)
 }
 
 // ExportMode constants describe which data to export from key storage.

--- a/keystore/v2/keystore/filesystem/keyStore.go
+++ b/keystore/v2/keystore/filesystem/keyStore.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	keystoreV1 "github.com/cossacklabs/acra/keystore"
 	"github.com/cossacklabs/acra/keystore/v2/keystore/api"
 	"github.com/cossacklabs/acra/keystore/v2/keystore/asn1"
 	"github.com/cossacklabs/acra/keystore/v2/keystore/crypto"
@@ -31,6 +32,11 @@ import (
 )
 
 const serviceName = "keystore"
+
+// Errors returned by basuc key store.
+var (
+	ErrNotImplemented = errors.New("not implemented")
+)
 
 // KeyStore is a filesystem-like key store which keeps key rings in files.
 //
@@ -165,6 +171,13 @@ func (s *KeyStore) ListKeyRings() (rings []string, err error) {
 		rings[i] = strings.TrimSuffix(rings[i], keyringSuffix)
 	}
 	return rings, nil
+}
+
+// DescribeKeyRing describes key ring by its purpose path.
+func (s *KeyStore) DescribeKeyRing(path string) (*keystoreV1.KeyDescription, error) {
+	// This is basic key store which does not define any particular key rings.
+	// This method will be overridden by actual key store implementation.
+	return nil, ErrNotImplemented
 }
 
 // ExportKeyRings packages specified key rings for export.

--- a/keystore/v2/keystore/keyStore.go
+++ b/keystore/v2/keystore/keyStore.go
@@ -98,14 +98,14 @@ func (s *ServerKeyStore) ListKeys() ([]keystore.KeyDescription, error) {
 	if err != nil {
 		return nil, err
 	}
-	return s.DescribeKeys(keyRings)
+	return DescribeKeyRings(keyRings, s)
 }
 
-// DescribeKeys describes requested keys in the key store.
-func (s *ServerKeyStore) DescribeKeys(keyRings []string) ([]keystore.KeyDescription, error) {
+// DescribeKeyRings describes multiple key rings by their purpose paths.
+func DescribeKeyRings(keyRings []string, keyStore api.KeyStore) ([]keystore.KeyDescription, error) {
 	keys := make([]keystore.KeyDescription, len(keyRings))
 	for i := range keys {
-		description, err := s.describeKeyRing(keyRings[i])
+		description, err := keyStore.DescribeKeyRing(keyRings[i])
 		if err != nil {
 			return nil, err
 		}
@@ -114,7 +114,8 @@ func (s *ServerKeyStore) DescribeKeys(keyRings []string) ([]keystore.KeyDescript
 	return keys, nil
 }
 
-func (s *ServerKeyStore) describeKeyRing(path string) (*keystore.KeyDescription, error) {
+// DescribeKeyRing describes key ring by its purpose path.
+func (s *ServerKeyStore) DescribeKeyRing(path string) (*keystore.KeyDescription, error) {
 	if path == poisonKeyPath {
 		return &keystore.KeyDescription{
 			ID:      path,


### PR DESCRIPTION
Improve some of the interfaces so that they can be properly extended by Acra EE.

Avoid using Acra CE types directly in import/export interfaces of the `acra-keys` common code. Use key store interfaces instead. This enables Acra EE to use its own extended types.

Extract key description (for human-readable lists) into an overridable method so that Acra EE can add its own keys there.