### PR TITLE
Make --{src,dst}_keys_dir parameters required

### DIFF
--- a/configs/acra-migrate-keys.yaml
+++ b/configs/acra-migrate-keys.yaml
@@ -8,10 +8,10 @@ d: false
 # try migration without writing to the output key store
 dry_run: false
 
-# path to destination key directory (default ".acrakeys.migrated")
+# path to destination key directory
 dst_keys_dir: 
 
-# path to destination key directory for public keys (default ".acrakeys.migrated")
+# path to destination key directory for public keys
 dst_keys_dir_public: 
 
 # key store format to use: v1 (current), v2 (new)
@@ -27,14 +27,14 @@ force: false
 generate_markdown_args_table: false
 
 # path to source key directory
-src_keys_dir: .acrakeys
+src_keys_dir: 
 
 # path to source key directory for public keys
-src_keys_dir_public: .acrakeys
+src_keys_dir_public: 
 
 # key store format to use: v1 (current), v2 (new)
 src_keystore: 
 
-# log everything to stderr
+# log more information to stderr
 v: false
 


### PR DESCRIPTION
The user might not like the new name of the key store to be `.acrakeys.migrated`. While it is not much of a problem for
filesystem-based key store, this might become a problem for other types, like Redis, where renaming the key store is not that straightforward.

Instead of pondering on a better name, have the user to explicitly specify it. That way the user can either choose a different name, or may keep it `.acrakeys` (but hosted in a different place).

The `--src_keys_dir` is required as well. Previously it defaulted to `.acrakeys` used by Acra by default. However, let's make it required as well for the sake of symmetry and predictability. The user already has to specify the version of the key stores and other details. It's good to make them aware of the key directory name at this moment too.

Public key directory (`--src_keys_dir_public`) is still optional. It defaults to whatever is used for the private key directory. Key store v2 ignores this setting as it always stores both parts of the key pair together if they are available.