### PR TITLE
More reusable code of acra-keys

### DIFF
--- a/cmd/acra-keys/keys/acra-keys.go
+++ b/cmd/acra-keys/keys/acra-keys.go
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2020, Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package keys defines reusable business logic of `acra-keys` utility.
+package keys
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/cossacklabs/acra/utils"
+	log "github.com/sirupsen/logrus"
+)
+
+// ExecuteCommand executes the command requsted on the command line
+func ExecuteCommand(params *CommandLineParams, factory KeyStoreFactory) {
+	switch params.Command {
+	case CmdListKeys:
+		ListKeysCommand(params, factory)
+	case CmdExportKeys:
+		ExportKeysCommand(params, factory)
+	case CmdImportKeys:
+		ImportKeysCommand(params, factory)
+	case CmdReadKey:
+		PrintKeyCommand(params, factory)
+	case CmdDestroyKey:
+		DestroyKeyCommand(params, factory)
+	}
+}
+
+func warnKeystoreV2Only(command string) {
+	log.Error(fmt.Sprintf("\"%s\" is not implemented for key store v1", command))
+	log.Info("You can convert key store v1 into v2 with \"acra-migrate-keys\"")
+	// TODO(ilammy, 2020-05-19): production documentation does not describe migration yet
+	log.Info("Read more: https://docs.cossacklabs.com/pages/documentation-acra/#key-management")
+}
+
+// ListKeysCommand implements the "list" command.
+func ListKeysCommand(params *CommandLineParams, factory KeyStoreFactory) {
+	keyStore, err := factory.OpenKeyStoreForReading(params)
+	if err != nil {
+		log.WithError(err).Fatal("Failed to open key store")
+	}
+
+	keyDescriptions, err := keyStore.ListKeys()
+	if err != nil {
+		if err == ErrNotImplementedV1 {
+			warnKeystoreV2Only(CmdListKeys)
+		}
+		log.WithError(err).Fatal("Failed to read key list")
+	}
+
+	err = PrintKeys(keyDescriptions, os.Stdout, params)
+	if err != nil {
+		log.WithError(err).Fatal("Failed to print key list")
+	}
+}
+
+// ExportKeysCommand implements the "export" command.
+func ExportKeysCommand(params *CommandLineParams, factory KeyStoreFactory) {
+	keyStore, err := factory.OpenKeyStoreForExport(params)
+	if err != nil {
+		if err == ErrNotImplementedV1 {
+			warnKeystoreV2Only(CmdExportKeys)
+		}
+		log.WithError(err).Fatal("Failed to open key store")
+	}
+
+	encryptionKeyData, cryptosuite, err := PrepareExportEncryptionKeys()
+	if err != nil {
+		log.WithError(err).Fatal("Failed to prepare encryption keys")
+	}
+	defer utils.ZeroizeSymmetricKey(encryptionKeyData)
+
+	exportedData, err := ExportKeys(keyStore, cryptosuite, params)
+	if err != nil {
+		log.WithError(err).Fatal("Failed to export keys")
+	}
+
+	err = WriteExportedData(exportedData, encryptionKeyData, params)
+	if err != nil {
+		log.WithError(err).Fatal("Failed to write exported data")
+	}
+
+	log.Infof("Exported key data is encrypted and saved here: %s", params.ExportDataFile)
+	log.Infof("New encryption keys for import generated here: %s", params.ExportKeysFile)
+	log.Infof("DO NOT transport or store these files together")
+	log.Infof("Import the keys into another key store like this:\n\tacra-keys import --key_bundle_file \"%s\" --key_bundle_secret \"%s\"", params.ExportDataFile, params.ExportKeysFile)
+}
+
+// ImportKeysCommand implements the "import" command.
+func ImportKeysCommand(params *CommandLineParams, factory KeyStoreFactory) {
+	keyStore, err := factory.OpenKeyStoreForImport(params)
+	if err != nil {
+		if err == ErrNotImplementedV1 {
+			warnKeystoreV2Only(CmdExportKeys)
+		}
+		log.WithError(err).Fatal("Failed to open key store")
+	}
+
+	exportedData, err := ReadExportedData(params)
+	if err != nil {
+		log.WithError(err).Fatal("Failed to read exported data")
+	}
+
+	cryptosuite, err := ReadImportEncryptionKeys(params)
+	if err != nil {
+		log.WithError(err).Fatal("Failed to prepare encryption keys")
+	}
+
+	descriptions, err := ImportKeys(exportedData, keyStore, cryptosuite, params)
+	if err != nil {
+		log.WithError(err).Fatal("Failed to import keys")
+	}
+
+	log.Infof("successfully imported %d keys", len(descriptions))
+
+	err = PrintKeys(descriptions, os.Stdout, params)
+	if err != nil {
+		log.WithError(err).Fatal("Failed to print imported key list")
+	}
+}
+
+// PrintKeyCommand implements the "read" command.
+func PrintKeyCommand(params *CommandLineParams, factory KeyStoreFactory) {
+	keyStore, err := factory.OpenKeyStoreForReading(params)
+	if err != nil {
+		log.WithError(err).Fatal("Failed to open key store")
+	}
+
+	keyBytes, err := ReadKeyBytes(params, keyStore)
+	if err != nil {
+		log.WithError(err).Fatal("Failed to read key")
+	}
+	defer utils.ZeroizeSymmetricKey(keyBytes)
+
+	_, err = os.Stdout.Write(keyBytes)
+	if err != nil {
+		log.WithError(err).Fatal("Failed to write key")
+	}
+}
+
+// DestroyKeyCommand implements the "destroy" command.
+func DestroyKeyCommand(params *CommandLineParams, factory KeyStoreFactory) {
+	keyStore, err := factory.OpenKeyStoreForWriting(params)
+	if err != nil {
+		log.WithError(err).Fatal("Failed to open key store")
+	}
+
+	err = DestroyKey(params, keyStore)
+	if err != nil {
+		log.WithError(err).Fatal("Failed to destroy key")
+	}
+}

--- a/cmd/acra-keys/keys/command-line.go
+++ b/cmd/acra-keys/keys/command-line.go
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-// Package keys defines reusable business logic of `acra-keys` utility.
 package keys
 
 import (

--- a/cmd/acra-keys/keys/command-line.go
+++ b/cmd/acra-keys/keys/command-line.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/cossacklabs/acra/cmd"
 	keystoreV1 "github.com/cossacklabs/acra/keystore"
-	filesystemV2 "github.com/cossacklabs/acra/keystore/v2/keystore/filesystem"
 	"github.com/cossacklabs/acra/logging"
 	"github.com/cossacklabs/acra/utils"
 	log "github.com/sirupsen/logrus"
@@ -85,9 +84,8 @@ var (
 
 // CommandLineParams describes all command-line options of acra-keys.
 type CommandLineParams struct {
-	KeyStoreVersion string
-	KeyDir          string
-	KeyDirPublic    string
+	KeyDir       string
+	KeyDirPublic string
 
 	ClientID string
 	ZoneID   string
@@ -299,12 +297,6 @@ func (params *CommandLineParams) ParseSubCommand() error {
 
 // SetDefaults sets dynamically configured default values of command-line parameters.
 func (params *CommandLineParams) SetDefaults() {
-	if filesystemV2.IsKeyDirectory(params.KeyDir) {
-		params.KeyStoreVersion = "v2"
-	} else {
-		params.KeyStoreVersion = "v1"
-	}
-
 	if params.KeyDirPublic == "" {
 		params.KeyDirPublic = params.KeyDir
 	}

--- a/cmd/acra-keys/keys/keystore.go
+++ b/cmd/acra-keys/keys/keystore.go
@@ -17,8 +17,6 @@
 package keys
 
 import (
-	"errors"
-
 	"github.com/cossacklabs/acra/keystore"
 	keystoreV1 "github.com/cossacklabs/acra/keystore"
 	filesystemV1 "github.com/cossacklabs/acra/keystore/filesystem"
@@ -27,49 +25,29 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// Key store access errors:
-var (
-	ErrUnknownKeystoreVersion = errors.New("unknown key store version")
-)
-
 // OpenKeyStoreForReading opens a key store suitable for reading keys.
 func OpenKeyStoreForReading(params *CommandLineParams) (keystore.ServerKeyStore, error) {
-	switch params.KeyStoreVersion {
-	case "v1":
-		return openKeyStoreV1(params)
-	case "v2":
+	if filesystemV2.IsKeyDirectory(params.KeyDir) {
 		return openKeyStoreV2(params)
-	default:
-		log.WithField("actual", params.KeyStoreVersion).Error("Unknown key store version")
-		return nil, ErrUnknownKeystoreVersion
 	}
+	return openKeyStoreV1(params)
 }
 
 // OpenKeyStoreForModification opens a key store suitable for modifications.
 func OpenKeyStoreForModification(params *CommandLineParams) (keystore.KeyMaking, error) {
-	switch params.KeyStoreVersion {
-	case "v1":
-		return openKeyStoreV1(params)
-	case "v2":
+	if filesystemV2.IsKeyDirectory(params.KeyDir) {
 		return openKeyStoreV2(params)
-	default:
-		log.WithField("actual", params.KeyStoreVersion).Error("Unknown key store version")
-		return nil, ErrUnknownKeystoreVersion
 	}
+	return openKeyStoreV1(params)
 }
 
 // OpenKeyStoreForExportImport opens a key store suitable for export/import operations.
 func OpenKeyStoreForExportImport(params *CommandLineParams) (*keystoreV2.ServerKeyStore, error) {
-	switch params.KeyStoreVersion {
-	case "v1":
-		// Not supported in Acra CE
-		return nil, keystore.ErrNotImplemented
-	case "v2":
+	if filesystemV2.IsKeyDirectory(params.KeyDir) {
 		return openKeyStoreV2(params)
-	default:
-		log.WithField("actual", params.KeyStoreVersion).Error("Unknown key store version")
-		return nil, ErrUnknownKeystoreVersion
 	}
+	// Not supported in Acra CE
+	return nil, keystore.ErrNotImplemented
 }
 
 func openKeyStoreV1(params *CommandLineParams) (*filesystemV1.KeyStore, error) {


### PR DESCRIPTION
Introduce a `KeyStoreFactory` interface which encapsulates the differences between Acra CE and Acra EE implementations of `acra-keys` utility. It turns out that this is the only thing that needs to be changed. We can reuse the rest of the code.

After adapting the code to the new interface, move the business logic into the common `keys` module. Now the implementation is basically three lines:

1. Parse the command line.
2. Construct an appropriate factory.
3. Execute requested command.

The commands are the same for both Acra CE and Acra EE. New shared commands can be added to Acra CE. If there is a need for exclusive commands in Acra EE, we can add them there and reuse the common code from Acra CE for the rest of the commands.