### PR TITLE
Do not treat empty directory as key store v1

### DIFF
--- a/cmd/acra-keymaker/acra-keymaker.go
+++ b/cmd/acra-keymaker/acra-keymaker.go
@@ -79,10 +79,12 @@ func main() {
 
 	var store keystore.KeyMaking
 	// If the key store already exists, detect its version automatically and allow to not specify it.
-	if filesystemV2.IsKeyDirectory(*outputDir) {
-		*keystoreVersion = "v2"
-	} else if filesystem.IsKeyDirectory(*outputDir) {
-		*keystoreVersion = "v1"
+	if *keystoreVersion == "" {
+		if filesystemV2.IsKeyDirectory(*outputDir) {
+			*keystoreVersion = "v2"
+		} else if filesystem.IsKeyDirectory(*outputDir) {
+			*keystoreVersion = "v1"
+		}
 	}
 	switch *keystoreVersion {
 	case "v1":


### PR DESCRIPTION
There is no definite easy way to tell whether a directory is key store v1 because it does not have any identifying features like key store v2 has: no version files, nothing. So we have used a conservative approach: if it's a directory, it's a key store v1.

However, this does not account for the case of the empty directory. Yes, it is a directory, but it's probably not a *key* directory. This may cause tools – which all use autodetection now – falsely believe that a directory *is* a key store v1. In particular, acra-keymaker will think that it's a key store v1. It will not require an explicit `--keystore` argument, and will generate v1 keys, which may not be what the user wants to achieve (or rather, what we would like the user to do).

The users might first create a directory, then pass it to `--keys_dir` argument, forget the `--keystore` argument, and they will silently get key store v1. Make sure that they will get an error instead, prompting an explicit choice of the version with `--keystore`.

---

This PR is port of cossacklabs/acra-enterprise#73 to Acra CE. In addition to that, it fixes another issue.

acra-keymaker incorrectly runs key store version detection when the version is explicitly requested by the user. This might trick it into falsely believing that it should create key store v1 when the users asks to create a key store v2.

acra-keymaker should detect the version only when the user did not specify it explicitly. That's how Acra EE does it. Apparently, this condition was lost when the code was ported from Acra EE to Acra CE.

This particular bug has caused a very contriving sequence of events leading to failures in some Acre EE tests when key store v2 is used because some of the generated keys were generated in v1 format and then expected to be read in v2 format.