### PR TITLE
Test key store v2 with all databases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,8 +59,20 @@ jobs:
       # generate test data for integration tests
       - run: python3 tests/generate_random_data.py
       # each iteration pass to test different ports for forks to avoid problems with TCP TIME WAIT between tests
-      - run: .circleci/integration.sh
-      - run: if [ -f  $FILEPATH_ERROR_FLAG ]; then cat "$FILEPATH_ERROR_FLAG"; rm "$FILEPATH_ERROR_FLAG"; exit 1; fi
+      - run:
+          name: Integration tests (key store v1)
+          environment:
+            TEST_KEYSTORE: v1
+          command: |
+            .circleci/integration.sh
+            if [ -f  $FILEPATH_ERROR_FLAG ]; then cat "$FILEPATH_ERROR_FLAG"; rm "$FILEPATH_ERROR_FLAG"; exit 1; fi
+      - run:
+          name: Integration tests (key store v2)
+          environment:
+            TEST_KEYSTORE: v2
+          command: |
+            .circleci/integration.sh
+            if [ -f  $FILEPATH_ERROR_FLAG ]; then cat "$FILEPATH_ERROR_FLAG"; rm "$FILEPATH_ERROR_FLAG"; exit 1; fi
       - store_test_results:
           path: /home/user/tests_output
       - store_artifacts:
@@ -95,56 +107,20 @@ jobs:
       # generate test data for integration tests
       - run: python3 tests/generate_random_data.py
       # each iteration pass to test different ports for forks to avoid problems with TCP TIME WAIT between tests
-      - run: .circleci/integration.sh
-      - run: if [ -f  $FILEPATH_ERROR_FLAG ]; then cat "$FILEPATH_ERROR_FLAG"; rm "$FILEPATH_ERROR_FLAG"; exit 1; fi
-      - store_test_results:
-          path: /home/user/tests_output
-      - store_artifacts:
-          path: /home/user/tests_output
-
-  postgresql-keystoreV2:
-    docker:
-      - image: cossacklabs/android-build
-      - image: postgres:11-alpine
-        environment:
-          POSTGRES_PASSWORD: test
-          POSTGRES_USER: test
-          POSTGRES_DB: test
-    environment:
-      FILEPATH_ERROR_FLAG: /tmp/test_fail
-      VERSIONS: 1.11.5 1.12
-      TEST_DB_PORT: 5432
-      GOPATH_FOLDER: gopath
-      TEST_RANDOM_DATA_FOLDER: /tmp/test_data
-      TEST_TLS: "off"
-      TEST_KEYSTORE: v2
-      # $HOME/$GOPATH_FOLDER
-      GOPATH: /home/user/gopath
-      # set default goroot instead system available
-      GOROOT: /home/user/go_root_1.11.5/go
-      GO111MODULE: "on"
-    steps:
-      - checkout
       - run:
-          name: Prepare test harness
-          command: .circleci/prepare.sh
-      - run:
-          name: Prepare PostgreSQL client
-          command: |
-            sudo apt-get install -y postgresql-client
-            pg_isready -U${POSTGRES_USER} -d${POSTGRES_DB} -h127.0.0.1
-      - run:
-          name: Generate test data for integration tests
-          command: python3 tests/generate_random_data.py
-      - run:
-          name: Run integration tests
+          name: Integration tests (key store v1)
+          environment:
+            TEST_KEYSTORE: v1
           command: |
             .circleci/integration.sh
-            if [[ -e "$FILEPATH_ERROR_FLAG" ]]; then
-              cat "$FILEPATH_ERROR_FLAG"
-              rm "$FILEPATH_ERROR_FLAG"
-              exit 1
-            fi
+            if [ -f  $FILEPATH_ERROR_FLAG ]; then cat "$FILEPATH_ERROR_FLAG"; rm "$FILEPATH_ERROR_FLAG"; exit 1; fi
+      - run:
+          name: Integration tests (key store v2)
+          environment:
+            TEST_KEYSTORE: v2
+          command: |
+            .circleci/integration.sh
+            if [ -f  $FILEPATH_ERROR_FLAG ]; then cat "$FILEPATH_ERROR_FLAG"; rm "$FILEPATH_ERROR_FLAG"; exit 1; fi
       - store_test_results:
           path: /home/user/tests_output
       - store_artifacts:
@@ -184,8 +160,20 @@ jobs:
     # generate test data for integration tests
     - run: python3 tests/generate_random_data.py
     # each iteration pass to test different ports for forks to avoid problems with TCP TIME WAIT between tests
-    - run: .circleci/integration.sh
-    - run: if [ -f  $FILEPATH_ERROR_FLAG ]; then cat "$FILEPATH_ERROR_FLAG"; rm "$FILEPATH_ERROR_FLAG"; exit 1; fi
+    - run:
+        name: Integration tests (key store v1)
+        environment:
+          TEST_KEYSTORE: v1
+        command: |
+          .circleci/integration.sh
+          if [ -f  $FILEPATH_ERROR_FLAG ]; then cat "$FILEPATH_ERROR_FLAG"; rm "$FILEPATH_ERROR_FLAG"; exit 1; fi
+    - run:
+        name: Integration tests (key store v2)
+        environment:
+          TEST_KEYSTORE: v2
+        command: |
+          .circleci/integration.sh
+          if [ -f  $FILEPATH_ERROR_FLAG ]; then cat "$FILEPATH_ERROR_FLAG"; rm "$FILEPATH_ERROR_FLAG"; exit 1; fi
     - store_test_results:
         path: /home/user/tests_output
     - store_artifacts:
@@ -225,8 +213,20 @@ jobs:
       # generate test data for integration tests
       - run: python3 tests/generate_random_data.py
       # each iteration pass to test different ports for forks to avoid problems with TCP TIME WAIT between tests
-      - run: .circleci/integration.sh
-      - run: if [ -f  $FILEPATH_ERROR_FLAG ]; then cat "$FILEPATH_ERROR_FLAG"; rm "$FILEPATH_ERROR_FLAG"; exit 1; fi
+      - run:
+          name: Integration tests (key store v1)
+          environment:
+            TEST_KEYSTORE: v1
+          command: |
+            .circleci/integration.sh
+            if [ -f  $FILEPATH_ERROR_FLAG ]; then cat "$FILEPATH_ERROR_FLAG"; rm "$FILEPATH_ERROR_FLAG"; exit 1; fi
+      - run:
+          name: Integration tests (key store v2)
+          environment:
+            TEST_KEYSTORE: v2
+          command: |
+            .circleci/integration.sh
+            if [ -f  $FILEPATH_ERROR_FLAG ]; then cat "$FILEPATH_ERROR_FLAG"; rm "$FILEPATH_ERROR_FLAG"; exit 1; fi
       - store_test_results:
           path: /home/user/tests_output
       - store_artifacts:
@@ -266,8 +266,20 @@ jobs:
     # generate test data for integration tests
     - run: python3 tests/generate_random_data.py
     # each iteration pass to test different ports for forks to avoid problems with TCP TIME WAIT between tests
-    - run: .circleci/integration.sh
-    - run: if [ -f  $FILEPATH_ERROR_FLAG ]; then cat "$FILEPATH_ERROR_FLAG"; rm "$FILEPATH_ERROR_FLAG"; exit 1; fi
+    - run:
+        name: Integration tests (key store v1)
+        environment:
+          TEST_KEYSTORE: v1
+        command: |
+          .circleci/integration.sh
+          if [ -f  $FILEPATH_ERROR_FLAG ]; then cat "$FILEPATH_ERROR_FLAG"; rm "$FILEPATH_ERROR_FLAG"; exit 1; fi
+    - run:
+        name: Integration tests (key store v2)
+        environment:
+          TEST_KEYSTORE: v2
+        command: |
+          .circleci/integration.sh
+          if [ -f  $FILEPATH_ERROR_FLAG ]; then cat "$FILEPATH_ERROR_FLAG"; rm "$FILEPATH_ERROR_FLAG"; exit 1; fi
     - store_test_results:
         path: /home/user/tests_output
     - store_artifacts:
@@ -305,8 +317,20 @@ jobs:
       # generate test data for integration tests
       - run: python3 tests/generate_random_data.py
       # each iteration pass to test different ports for forks to avoid problems with TCP TIME WAIT between tests
-      - run: .circleci/integration.sh
-      - run: if [ -f  $FILEPATH_ERROR_FLAG ]; then cat "$FILEPATH_ERROR_FLAG"; rm "$FILEPATH_ERROR_FLAG"; exit 1; fi
+      - run:
+          name: Integration tests (key store v1)
+          environment:
+            TEST_KEYSTORE: v1
+          command: |
+            .circleci/integration.sh
+            if [ -f  $FILEPATH_ERROR_FLAG ]; then cat "$FILEPATH_ERROR_FLAG"; rm "$FILEPATH_ERROR_FLAG"; exit 1; fi
+      - run:
+          name: Integration tests (key store v2)
+          environment:
+            TEST_KEYSTORE: v2
+          command: |
+            .circleci/integration.sh
+            if [ -f  $FILEPATH_ERROR_FLAG ]; then cat "$FILEPATH_ERROR_FLAG"; rm "$FILEPATH_ERROR_FLAG"; exit 1; fi
       - store_test_results:
           path: /home/user/tests_output
       - store_artifacts:
@@ -319,7 +343,6 @@ workflows:
       - general_validation
       - postgresql
       - postgresql-ssl
-      - postgresql-keystoreV2
       - mysql
       - mysql-ssl
       - mariadb


### PR DESCRIPTION
Instead of having a dedicated job (with costly startup costs) for testing key store v2, verify this flavor with all databases along with key store v1. The integration tests use separate temporary directories and clean up the database after use, so we can run the tests back to back.

MySQL support code has a slightly different code path, so it might be using keys for data decryption is some weird way. TLS flavors should not be much different, but let's test them as well for consistency.