### PR TITLE
Add non-exiting signal handler

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -85,6 +85,11 @@ func (handler *SignalHandler) AddCallback(callback SignalCallback) {
 
 // Register should be called as goroutine
 func (handler *SignalHandler) Register() {
+	handler.RegisterWithoutExiting()
+	os.Exit(0)
+}
+
+func (handler *SignalHandler) RegisterWithoutExiting() {
 	signal.Notify(handler.ch, handler.signals...)
 
 	<-handler.ch
@@ -95,7 +100,6 @@ func (handler *SignalHandler) Register() {
 	for _, callback := range handler.callbacks {
 		callback()
 	}
-	os.Exit(0)
 }
 
 // ValidateClientID checks that clientID has digits, letters, _ - ' '

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -89,6 +89,7 @@ func (handler *SignalHandler) Register() {
 	os.Exit(0)
 }
 
+// RegisterWithoutExiting is a no-exit version of Register function
 func (handler *SignalHandler) RegisterWithoutExiting() {
 	signal.Notify(handler.ch, handler.signals...)
 


### PR DESCRIPTION
This PR just adds new utility function `RegisterWithoutExiting` to system signal handler that behaves similar to `Register` but it does not call `os.Exit(0)` in the end. As we discussed, it is desirable to have better control on points of exiting from the Acra services and ideally to minimize them to the single place of exiting. `Register` is still in place, so if some of the services rely on it's `os.Exit(0)` it will not break their behavior.