### PR TITLE
Drop KeyStoreFactory interface

### DIFF
--- a/cmd/acra-keys/acra-keys.go
+++ b/cmd/acra-keys/acra-keys.go
@@ -31,5 +31,5 @@ import (
 
 func main() {
 	keys.ParseParams()
-	keys.ExecuteCommand(keys.Params, nil)
+	keys.ExecuteCommand(keys.Params)
 }

--- a/cmd/acra-keys/acra-keys.go
+++ b/cmd/acra-keys/acra-keys.go
@@ -31,7 +31,5 @@ import (
 
 func main() {
 	keys.ParseParams()
-
-	factory := &keys.DefaultKeyStoreFactory{}
-	keys.ExecuteCommand(keys.Params, factory)
+	keys.ExecuteCommand(keys.Params, nil)
 }

--- a/cmd/acra-keys/keys/acra-keys.go
+++ b/cmd/acra-keys/keys/acra-keys.go
@@ -28,7 +28,7 @@ import (
 )
 
 // ExecuteCommand executes the command requsted on the command line
-func ExecuteCommand(params *CommandLineParams, factory KeyStoreFactory) {
+func ExecuteCommand(params *CommandLineParams) {
 	switch params.Command {
 	case CmdListKeys:
 		keyStore, err := OpenKeyStoreForReading(params)

--- a/cmd/acra-keys/keys/acra-keys.go
+++ b/cmd/acra-keys/keys/acra-keys.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/cossacklabs/acra/keystore"
+	"github.com/cossacklabs/acra/keystore/v2/keystore/api"
 	"github.com/cossacklabs/acra/utils"
 	log "github.com/sirupsen/logrus"
 )
@@ -29,15 +31,45 @@ import (
 func ExecuteCommand(params *CommandLineParams, factory KeyStoreFactory) {
 	switch params.Command {
 	case CmdListKeys:
-		ListKeysCommand(params, factory)
+		keyStore, err := OpenKeyStoreForReading(params)
+		if err != nil {
+			log.WithError(err).Fatal("Failed to open key store")
+		}
+		ListKeysCommand(params, keyStore)
+
 	case CmdExportKeys:
-		ExportKeysCommand(params, factory)
+		keyStore, err := OpenKeyStoreForExport(params)
+		if err != nil {
+			if err == ErrNotImplementedV1 {
+				warnKeystoreV2Only(CmdExportKeys)
+			}
+			log.WithError(err).Fatal("Failed to open key store")
+		}
+		ExportKeysCommand(params, keyStore)
+
 	case CmdImportKeys:
-		ImportKeysCommand(params, factory)
+		keyStore, err := OpenKeyStoreForImport(params)
+		if err != nil {
+			if err == ErrNotImplementedV1 {
+				warnKeystoreV2Only(CmdExportKeys)
+			}
+			log.WithError(err).Fatal("Failed to open key store")
+		}
+		ImportKeysCommand(params, keyStore)
+
 	case CmdReadKey:
-		PrintKeyCommand(params, factory)
+		keyStore, err := OpenKeyStoreForReading(params)
+		if err != nil {
+			log.WithError(err).Fatal("Failed to open key store")
+		}
+		PrintKeyCommand(params, keyStore)
+
 	case CmdDestroyKey:
-		DestroyKeyCommand(params, factory)
+		keyStore, err := OpenKeyStoreForWriting(params)
+		if err != nil {
+			log.WithError(err).Fatal("Failed to open key store")
+		}
+		DestroyKeyCommand(params, keyStore)
 	}
 }
 
@@ -49,12 +81,7 @@ func warnKeystoreV2Only(command string) {
 }
 
 // ListKeysCommand implements the "list" command.
-func ListKeysCommand(params *CommandLineParams, factory KeyStoreFactory) {
-	keyStore, err := factory.OpenKeyStoreForReading(params)
-	if err != nil {
-		log.WithError(err).Fatal("Failed to open key store")
-	}
-
+func ListKeysCommand(params *CommandLineParams, keyStore keystore.ServerKeyStore) {
 	keyDescriptions, err := keyStore.ListKeys()
 	if err != nil {
 		if err == ErrNotImplementedV1 {
@@ -70,15 +97,7 @@ func ListKeysCommand(params *CommandLineParams, factory KeyStoreFactory) {
 }
 
 // ExportKeysCommand implements the "export" command.
-func ExportKeysCommand(params *CommandLineParams, factory KeyStoreFactory) {
-	keyStore, err := factory.OpenKeyStoreForExport(params)
-	if err != nil {
-		if err == ErrNotImplementedV1 {
-			warnKeystoreV2Only(CmdExportKeys)
-		}
-		log.WithError(err).Fatal("Failed to open key store")
-	}
-
+func ExportKeysCommand(params *CommandLineParams, keyStore api.KeyStore) {
 	encryptionKeyData, cryptosuite, err := PrepareExportEncryptionKeys()
 	if err != nil {
 		log.WithError(err).Fatal("Failed to prepare encryption keys")
@@ -102,15 +121,7 @@ func ExportKeysCommand(params *CommandLineParams, factory KeyStoreFactory) {
 }
 
 // ImportKeysCommand implements the "import" command.
-func ImportKeysCommand(params *CommandLineParams, factory KeyStoreFactory) {
-	keyStore, err := factory.OpenKeyStoreForImport(params)
-	if err != nil {
-		if err == ErrNotImplementedV1 {
-			warnKeystoreV2Only(CmdExportKeys)
-		}
-		log.WithError(err).Fatal("Failed to open key store")
-	}
-
+func ImportKeysCommand(params *CommandLineParams, keyStore api.MutableKeyStore) {
 	exportedData, err := ReadExportedData(params)
 	if err != nil {
 		log.WithError(err).Fatal("Failed to read exported data")
@@ -135,12 +146,7 @@ func ImportKeysCommand(params *CommandLineParams, factory KeyStoreFactory) {
 }
 
 // PrintKeyCommand implements the "read" command.
-func PrintKeyCommand(params *CommandLineParams, factory KeyStoreFactory) {
-	keyStore, err := factory.OpenKeyStoreForReading(params)
-	if err != nil {
-		log.WithError(err).Fatal("Failed to open key store")
-	}
-
+func PrintKeyCommand(params *CommandLineParams, keyStore keystore.ServerKeyStore) {
 	keyBytes, err := ReadKeyBytes(params, keyStore)
 	if err != nil {
 		log.WithError(err).Fatal("Failed to read key")
@@ -154,13 +160,8 @@ func PrintKeyCommand(params *CommandLineParams, factory KeyStoreFactory) {
 }
 
 // DestroyKeyCommand implements the "destroy" command.
-func DestroyKeyCommand(params *CommandLineParams, factory KeyStoreFactory) {
-	keyStore, err := factory.OpenKeyStoreForWriting(params)
-	if err != nil {
-		log.WithError(err).Fatal("Failed to open key store")
-	}
-
-	err = DestroyKey(params, keyStore)
+func DestroyKeyCommand(params *CommandLineParams, keyStore keystore.KeyMaking) {
+	err := DestroyKey(params, keyStore)
 	if err != nil {
 		log.WithError(err).Fatal("Failed to destroy key")
 	}

--- a/cmd/acra-keys/keys/command-line.go
+++ b/cmd/acra-keys/keys/command-line.go
@@ -83,8 +83,8 @@ var (
 
 // CommandLineParams describes all command-line options of acra-keys.
 type CommandLineParams struct {
-	KeyDir       string
-	KeyDirPublic string
+	keyDir       string
+	keyDirPublic string
 
 	ClientID string
 	ZoneID   string
@@ -114,8 +114,8 @@ var Params *CommandLineParams = &CommandLineParams{}
 
 // Register configures command-line parameter parsing.
 func (params *CommandLineParams) Register() {
-	flag.StringVar(&params.KeyDir, "keys_dir", DefaultKeyDirectory, "path to key directory")
-	flag.StringVar(&params.KeyDirPublic, "keys_dir_public", "", "path to key directory for public keys")
+	flag.StringVar(&params.keyDir, "keys_dir", DefaultKeyDirectory, "path to key directory")
+	flag.StringVar(&params.keyDirPublic, "keys_dir_public", "", "path to key directory for public keys")
 	flag.StringVar(&params.ClientID, "client_id", "", "client ID for which to retrieve key")
 	flag.StringVar(&params.ZoneID, "zone_id", "", "zone ID for which to retrieve key")
 	flag.BoolVar(&params.UseJSON, "json", false, "use machine-readable JSON output")
@@ -185,6 +185,16 @@ func usage() {
 
 	fmt.Fprintf(os.Stderr, "\n")
 	Params.destroyFlags.Usage()
+}
+
+// KeyDir returns path to key directory.
+func (params *CommandLineParams) KeyDir() string {
+	return params.keyDir
+}
+
+// KeyDirPublic returns path to public key directory (if different from key directory).
+func (params *CommandLineParams) KeyDirPublic() string {
+	return params.keyDirPublic
 }
 
 // Parse parses complete command-line.
@@ -296,8 +306,8 @@ func (params *CommandLineParams) ParseSubCommand() error {
 
 // SetDefaults sets dynamically configured default values of command-line parameters.
 func (params *CommandLineParams) SetDefaults() {
-	if params.KeyDirPublic == "" {
-		params.KeyDirPublic = params.KeyDir
+	if params.keyDirPublic == "" {
+		params.keyDirPublic = params.keyDir
 	}
 }
 

--- a/cmd/acra-keys/keys/keystore.go
+++ b/cmd/acra-keys/keys/keystore.go
@@ -28,16 +28,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// KeyStoreFactory defines how to construct key stores by parameters.
-// Export and import are available only for key store v2 so they are kept separate,
-// return an error if they cannot be provided (e.g, key store v1 is requested).
-type KeyStoreFactory interface {
-	OpenKeyStoreForReading(params *CommandLineParams) (keystore.ServerKeyStore, error)
-	OpenKeyStoreForWriting(params *CommandLineParams) (keystore.KeyMaking, error)
-	OpenKeyStoreForExport(params *CommandLineParams) (api.KeyStore, error)
-	OpenKeyStoreForImport(params *CommandLineParams) (api.MutableKeyStore, error)
-}
-
 // KeyStoreFactory should return one of those errors when it is not able to construct requested key store.
 var (
 	ErrNotImplementedV1 = errors.New("not implemented for key store v1")


### PR DESCRIPTION
I thought this interface is *the thing* that makes reusing code in Acra EE easier, but in fact it does not help much (and causes trouble).

I was trying to move `acra-migrate-keys` functionality into `acra-keys` multitool and ran into an architectural issue. `acra-keys` expect that key store parameters are global and there is only one set of those parameters. All subcommands of `acra-keys` acted on a single key store so that made sense.  `acra-migrate-keys` needs to specify *two* parameter sets: old and new key store. Thus, `acra-keys` in its current form cannot support the needs of `acra-migrate-keys`.

Well, it's not like `acra-keys` has been architectured beforehand in any proper way... So I'll just pretend that we're using *Agile™ Methodology* and let the code base evolve natually.

#### Introduce KeyStoreParameters interface

Replace `DefaultKeyStoreFactory` with a more flexible way to construct key stores in Acra CE for `acra-keys` utility. After all, Acra EE key store parameter is a bit different, so Acra EE cannot reuse Acra CE's key factory. Therefore, we do not need the `KeyStoreFactory` interface.

Remove `DefaultKeyStoreFactory` and make all its methods free functions. However, instead of directly accepting concrete `struct CommandLineParams` they now accept a `KeyStoreParameters` interface. This will allow us to have multiple structs describing key store parameters which will be useful later.

Go does not allow a struct to have a field and a method with the same name, so rename KeyDir and KeyDirPublic fields to avoid issues. They are not used directly now anyway.

#### Inject key stores into command implementations

The `...Command()` functions describe business logic of the `acra-keys` utility. They only use a provided abstract key store and can be reused by Acra EE. However, for that they need to stop constructing the key store since Acra EE has different parameter set used for that and cannot use Acra CE key store factory.

Instead of accepting a factory, construct an appropriate key store outside of the command implementation and inject it there.

####  Drop KeyStoreFactory interface

Finally, `KeyStoreFactory` is not used anywhere and can be dropped.