### PR TITLE
Move acra-keys parameters into interfaces

### DIFF
--- a/cmd/acra-keys/keys/acra-keys.go
+++ b/cmd/acra-keys/keys/acra-keys.go
@@ -97,7 +97,7 @@ func ListKeysCommand(params ListKeysParams, keyStore keystore.ServerKeyStore) {
 }
 
 // ExportKeysCommand implements the "export" command.
-func ExportKeysCommand(params *CommandLineParams, keyStore api.KeyStore) {
+func ExportKeysCommand(params ExportKeysParams, keyStore api.KeyStore) {
 	encryptionKeyData, cryptosuite, err := PrepareExportEncryptionKeys()
 	if err != nil {
 		log.WithError(err).Fatal("Failed to prepare encryption keys")
@@ -114,10 +114,10 @@ func ExportKeysCommand(params *CommandLineParams, keyStore api.KeyStore) {
 		log.WithError(err).Fatal("Failed to write exported data")
 	}
 
-	log.Infof("Exported key data is encrypted and saved here: %s", params.ExportDataFile)
-	log.Infof("New encryption keys for import generated here: %s", params.ExportKeysFile)
+	log.Infof("Exported key data is encrypted and saved here: %s", params.ExportDataFile())
+	log.Infof("New encryption keys for import generated here: %s", params.ExportKeysFile())
 	log.Infof("DO NOT transport or store these files together")
-	log.Infof("Import the keys into another key store like this:\n\tacra-keys import --key_bundle_file \"%s\" --key_bundle_secret \"%s\"", params.ExportDataFile, params.ExportKeysFile)
+	log.Infof("Import the keys into another key store like this:\n\tacra-keys import --key_bundle_file \"%s\" --key_bundle_secret \"%s\"", params.ExportDataFile(), params.ExportKeysFile())
 }
 
 // ImportKeysCommand implements the "import" command.

--- a/cmd/acra-keys/keys/acra-keys.go
+++ b/cmd/acra-keys/keys/acra-keys.go
@@ -160,7 +160,7 @@ func PrintKeyCommand(params ReadKeyParams, keyStore keystore.ServerKeyStore) {
 }
 
 // DestroyKeyCommand implements the "destroy" command.
-func DestroyKeyCommand(params *CommandLineParams, keyStore keystore.KeyMaking) {
+func DestroyKeyCommand(params DestroyKeyParams, keyStore keystore.KeyMaking) {
 	err := DestroyKey(params, keyStore)
 	if err != nil {
 		log.WithError(err).Fatal("Failed to destroy key")

--- a/cmd/acra-keys/keys/acra-keys.go
+++ b/cmd/acra-keys/keys/acra-keys.go
@@ -146,7 +146,7 @@ func ImportKeysCommand(params ImportKeysParams, keyStore api.MutableKeyStore) {
 }
 
 // PrintKeyCommand implements the "read" command.
-func PrintKeyCommand(params *CommandLineParams, keyStore keystore.ServerKeyStore) {
+func PrintKeyCommand(params ReadKeyParams, keyStore keystore.ServerKeyStore) {
 	keyBytes, err := ReadKeyBytes(params, keyStore)
 	if err != nil {
 		log.WithError(err).Fatal("Failed to read key")

--- a/cmd/acra-keys/keys/acra-keys.go
+++ b/cmd/acra-keys/keys/acra-keys.go
@@ -121,7 +121,7 @@ func ExportKeysCommand(params ExportKeysParams, keyStore api.KeyStore) {
 }
 
 // ImportKeysCommand implements the "import" command.
-func ImportKeysCommand(params *CommandLineParams, keyStore api.MutableKeyStore) {
+func ImportKeysCommand(params ImportKeysParams, keyStore api.MutableKeyStore) {
 	exportedData, err := ReadExportedData(params)
 	if err != nil {
 		log.WithError(err).Fatal("Failed to read exported data")

--- a/cmd/acra-keys/keys/acra-keys.go
+++ b/cmd/acra-keys/keys/acra-keys.go
@@ -81,7 +81,7 @@ func warnKeystoreV2Only(command string) {
 }
 
 // ListKeysCommand implements the "list" command.
-func ListKeysCommand(params *CommandLineParams, keyStore keystore.ServerKeyStore) {
+func ListKeysCommand(params ListKeysParams, keyStore keystore.ServerKeyStore) {
 	keyDescriptions, err := keyStore.ListKeys()
 	if err != nil {
 		if err == ErrNotImplementedV1 {

--- a/cmd/acra-keys/keys/command-line.go
+++ b/cmd/acra-keys/keys/command-line.go
@@ -92,7 +92,7 @@ type CommandLineParams struct {
 	Command string
 
 	readKeyKind    string
-	DestroyKeyKind string
+	destroyKeyKind string
 
 	exportIDs      []string
 	exportAll      bool
@@ -242,6 +242,11 @@ func (params *CommandLineParams) ZoneID() []byte {
 	return []byte(params.zoneID)
 }
 
+// DestroyKeyKind returns requested kind of the key to destroy.
+func (params *CommandLineParams) DestroyKeyKind() string {
+	return params.destroyKeyKind
+}
+
 // Parse parses complete command-line.
 func (params *CommandLineParams) Parse() error {
 	err := cmd.Parse(DefaultConfigPath, ServiceName)
@@ -339,8 +344,8 @@ func (params *CommandLineParams) ParseSubCommand() error {
 			log.Errorf("\"%s\" command does not support more than one key kind", CmdDestroyKey)
 			return ErrMultipleKeyKinds
 		}
-		params.DestroyKeyKind = args[0]
-		return params.CheckForKeyKind(params.DestroyKeyKind)
+		params.destroyKeyKind = args[0]
+		return params.CheckForKeyKind(params.destroyKeyKind)
 
 	default:
 		log.WithField("expected", SupportedSubCommands).
@@ -362,7 +367,7 @@ func (params *CommandLineParams) Check() {
 		log.Fatal("--client_id and --zone_id cannot be used simultaneously")
 	}
 
-	if params.readKeyKind != "" && params.DestroyKeyKind != "" {
+	if params.readKeyKind != "" && params.destroyKeyKind != "" {
 		log.Fatal("--read_key and --destroy_key cannot be used simultaneously")
 	}
 }

--- a/cmd/acra-keys/keys/command-line.go
+++ b/cmd/acra-keys/keys/command-line.go
@@ -100,7 +100,7 @@ type CommandLineParams struct {
 	ExportKeysFile string
 	ExportPrivate  bool
 
-	UseJSON bool
+	useJSON bool
 
 	exportFlags  *flag.FlagSet
 	importFlags  *flag.FlagSet
@@ -118,7 +118,7 @@ func (params *CommandLineParams) Register() {
 	flag.StringVar(&params.keyDirPublic, "keys_dir_public", "", "path to key directory for public keys")
 	flag.StringVar(&params.ClientID, "client_id", "", "client ID for which to retrieve key")
 	flag.StringVar(&params.ZoneID, "zone_id", "", "zone ID for which to retrieve key")
-	flag.BoolVar(&params.UseJSON, "json", false, "use machine-readable JSON output")
+	flag.BoolVar(&params.useJSON, "json", false, "use machine-readable JSON output")
 
 	params.listFlags = flag.NewFlagSet(CmdListKeys, flag.ContinueOnError)
 	params.listFlags.Usage = func() {
@@ -195,6 +195,11 @@ func (params *CommandLineParams) KeyDir() string {
 // KeyDirPublic returns path to public key directory (if different from key directory).
 func (params *CommandLineParams) KeyDirPublic() string {
 	return params.keyDirPublic
+}
+
+// UseJSON tells if machine-readable JSON should be used.
+func (params *CommandLineParams) UseJSON() bool {
+	return params.useJSON
 }
 
 // Parse parses complete command-line.

--- a/cmd/acra-keys/keys/destroy-key.go
+++ b/cmd/acra-keys/keys/destroy-key.go
@@ -28,11 +28,18 @@ var SupportedDestroyKeyKinds = []string{
 	KeyTransportTranslator,
 }
 
+// DestroyKeyParams are parameters of "acra-keys destroy" subcommand.
+type DestroyKeyParams interface {
+	DestroyKeyKind() string
+	ClientID() []byte
+}
+
 // DestroyKey destroys data of the requsted key.
-func DestroyKey(params *CommandLineParams, keyStore keystore.KeyMaking) error {
-	switch params.DestroyKeyKind {
+func DestroyKey(params DestroyKeyParams, keyStore keystore.KeyMaking) error {
+	kind := params.DestroyKeyKind()
+	switch kind {
 	case KeyTransportConnector:
-		err := keyStore.DestroyConnectorKeypair([]byte(params.clientID))
+		err := keyStore.DestroyConnectorKeypair(params.ClientID())
 		if err != nil {
 			log.WithError(err).Error("Cannot destroy AcraConnector transport key pair")
 			return err
@@ -40,7 +47,7 @@ func DestroyKey(params *CommandLineParams, keyStore keystore.KeyMaking) error {
 		return nil
 
 	case KeyTransportServer:
-		err := keyStore.DestroyServerKeypair([]byte(params.clientID))
+		err := keyStore.DestroyServerKeypair(params.ClientID())
 		if err != nil {
 			log.WithError(err).Error("Cannot destroy AcraServer transport key pair")
 			return err
@@ -48,7 +55,7 @@ func DestroyKey(params *CommandLineParams, keyStore keystore.KeyMaking) error {
 		return nil
 
 	case KeyTransportTranslator:
-		err := keyStore.DestroyTranslatorKeypair([]byte(params.clientID))
+		err := keyStore.DestroyTranslatorKeypair(params.ClientID())
 		if err != nil {
 			log.WithError(err).Error("Cannot destroy AcraTranslator transport key pair")
 			return err
@@ -56,8 +63,7 @@ func DestroyKey(params *CommandLineParams, keyStore keystore.KeyMaking) error {
 		return nil
 
 	default:
-		log.WithField("expected", SupportedDestroyKeyKinds).
-			Errorf("Unknown key kind: %s", Params.DestroyKeyKind)
+		log.WithField("expected", SupportedDestroyKeyKinds).Errorf("Unknown key kind: %s", kind)
 		return ErrUnknownKeyKind
 	}
 }

--- a/cmd/acra-keys/keys/destroy-key.go
+++ b/cmd/acra-keys/keys/destroy-key.go
@@ -32,7 +32,7 @@ var SupportedDestroyKeyKinds = []string{
 func DestroyKey(params *CommandLineParams, keyStore keystore.KeyMaking) error {
 	switch params.DestroyKeyKind {
 	case KeyTransportConnector:
-		err := keyStore.DestroyConnectorKeypair([]byte(params.ClientID))
+		err := keyStore.DestroyConnectorKeypair([]byte(params.clientID))
 		if err != nil {
 			log.WithError(err).Error("Cannot destroy AcraConnector transport key pair")
 			return err
@@ -40,7 +40,7 @@ func DestroyKey(params *CommandLineParams, keyStore keystore.KeyMaking) error {
 		return nil
 
 	case KeyTransportServer:
-		err := keyStore.DestroyServerKeypair([]byte(params.ClientID))
+		err := keyStore.DestroyServerKeypair([]byte(params.clientID))
 		if err != nil {
 			log.WithError(err).Error("Cannot destroy AcraServer transport key pair")
 			return err
@@ -48,7 +48,7 @@ func DestroyKey(params *CommandLineParams, keyStore keystore.KeyMaking) error {
 		return nil
 
 	case KeyTransportTranslator:
-		err := keyStore.DestroyTranslatorKeypair([]byte(params.ClientID))
+		err := keyStore.DestroyTranslatorKeypair([]byte(params.clientID))
 		if err != nil {
 			log.WithError(err).Error("Cannot destroy AcraTranslator transport key pair")
 			return err
@@ -57,7 +57,7 @@ func DestroyKey(params *CommandLineParams, keyStore keystore.KeyMaking) error {
 
 	default:
 		log.WithField("expected", SupportedDestroyKeyKinds).
-			Errorf("Unknown key kind: %s", Params.ReadKeyKind)
+			Errorf("Unknown key kind: %s", Params.DestroyKeyKind)
 		return ErrUnknownKeyKind
 	}
 }

--- a/cmd/acra-keys/keys/list-keys.go
+++ b/cmd/acra-keys/keys/list-keys.go
@@ -25,9 +25,14 @@ import (
 	"github.com/cossacklabs/acra/utils"
 )
 
+// ListKeysParams ara parameters of "acra-keys list" subcommand.
+type ListKeysParams interface {
+	UseJSON() bool
+}
+
 // PrintKeys prints key list prettily into the given writer.
-func PrintKeys(keys []keystore.KeyDescription, writer io.Writer, params *CommandLineParams) error {
-	if params.UseJSON {
+func PrintKeys(keys []keystore.KeyDescription, writer io.Writer, params ListKeysParams) error {
+	if params.UseJSON() {
 		return printKeysJSON(keys, writer)
 	}
 	return printKeysTable(keys, writer)

--- a/cmd/acra-keys/keys/list-keys_test.go
+++ b/cmd/acra-keys/keys/list-keys_test.go
@@ -39,7 +39,7 @@ func TestPrintKeysDefault(t *testing.T) {
 	}
 
 	output := strings.Builder{}
-	err := PrintKeys(keys, &output, &CommandLineParams{UseJSON: false})
+	err := PrintKeys(keys, &output, &CommandLineParams{useJSON: false})
 	if err != nil {
 		t.Fatalf("Failed to print keys: %v", err)
 	}
@@ -69,7 +69,7 @@ func TestPrintKeysJSON(t *testing.T) {
 	}
 
 	output := bytes.Buffer{}
-	err := PrintKeys(keys, &output, &CommandLineParams{UseJSON: true})
+	err := PrintKeys(keys, &output, &CommandLineParams{useJSON: true})
 	if err != nil {
 		t.Fatalf("Failed to print keys: %v", err)
 	}


### PR DESCRIPTION
Another issue with `acra-keys` interfaces for Acra EE is that it uses `CommandLineParameters` struct directly. This means that Acra EE is forced to use Acra CE command-line parameter set and cannot add anything else there. This is problematic because Acra EE *needs* to add more key store configuration parameters.

Instead of accepting `CommandLineParameters` and accessing its fields directly, introduce a bunch of interface with accessors, delimiting options for various commands. This decouples business logic of `acra-keys` from concrete storage of parameters (and unrelated parameters). It will also allow further refactoring of `CommandLineParameters` – I'd like to split it into multiple structs later to provide a better command-line help and key store parameter CLI.

This is only implementation refactoring. Actual CLI stays the same.

Dependencies:

- [x] #394 Drop KeyStoreFactory (pending merge and rebase)