### PR TITLE
Full config for acra-keys

### DIFF
--- a/cmd/acra-keys/keys/command-line.go
+++ b/cmd/acra-keys/keys/command-line.go
@@ -85,6 +85,7 @@ var (
 type Subcommand interface {
 	Name() string
 	RegisterFlags()
+	GetFlagSet() *flag.FlagSet
 	Parse(arguments []string) error
 	Execute()
 }

--- a/cmd/acra-keys/keys/command-line.go
+++ b/cmd/acra-keys/keys/command-line.go
@@ -121,7 +121,18 @@ func ParseParameters(subcommands []Subcommand) Subcommand {
 }
 
 func parseParameters(subcommands []Subcommand) (Subcommand, error) {
-	err := cmd.Parse(DefaultConfigPath, ServiceName)
+	err := cmd.ParseFlagsWithConfig(flag.CommandLine, os.Args[1:], DefaultConfigPath, ServiceName)
+	// If there is "--dump_config" on the command line,
+	// dump configuration for all subcommand and immediately exit.
+	if err == cmd.ErrDumpRequested {
+		flagSets := make([]*flag.FlagSet, len(subcommands)+1)
+		flagSets[0] = flag.CommandLine
+		for i, command := range subcommands {
+			flagSets[i+1] = command.GetFlagSet()
+		}
+		cmd.DumpConfigFromFlagSets(flagSets, DefaultConfigPath, ServiceName, true)
+		os.Exit(0)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/acra-keys/keys/destroy-key.go
+++ b/cmd/acra-keys/keys/destroy-key.go
@@ -54,6 +54,11 @@ func (p *DestroyKeySubcommand) Name() string {
 	return CmdDestroyKey
 }
 
+// GetFlagSet returns flag set of this subcommand.
+func (p *DestroyKeySubcommand) GetFlagSet() *flag.FlagSet {
+	return p.FlagSet
+}
+
 // RegisterFlags registers command-line flags of "acra-keys read".
 func (p *DestroyKeySubcommand) RegisterFlags() {
 	p.FlagSet = flag.NewFlagSet(CmdReadKey, flag.ContinueOnError)

--- a/cmd/acra-keys/keys/export.go
+++ b/cmd/acra-keys/keys/export.go
@@ -112,6 +112,11 @@ func (p *ExportKeysSubcommand) Name() string {
 	return CmdExportKeys
 }
 
+// GetFlagSet returns flag set of this subcommand.
+func (p *ExportKeysSubcommand) GetFlagSet() *flag.FlagSet {
+	return p.FlagSet
+}
+
 // RegisterFlags registers command-line flags of "acra-keys export".
 func (p *ExportKeysSubcommand) RegisterFlags() {
 	p.FlagSet = flag.NewFlagSet(CmdExportKeys, flag.ContinueOnError)
@@ -191,6 +196,11 @@ type ImportKeysSubcommand struct {
 // Name returns the same of this subcommand.
 func (p *ImportKeysSubcommand) Name() string {
 	return CmdImportKeys
+}
+
+// GetFlagSet returns flag set of this subcommand.
+func (p *ImportKeysSubcommand) GetFlagSet() *flag.FlagSet {
+	return p.FlagSet
 }
 
 // RegisterFlags registers command-line flags of "acra-keys import".

--- a/cmd/acra-keys/keys/list-keys.go
+++ b/cmd/acra-keys/keys/list-keys.go
@@ -61,6 +61,11 @@ func (p *ListKeySubcommand) Name() string {
 	return CmdListKeys
 }
 
+// GetFlagSet returns flag set of this subcommand.
+func (p *ListKeySubcommand) GetFlagSet() *flag.FlagSet {
+	return p.FlagSet
+}
+
 // RegisterFlags registers command-line flags of "acra-keys list".
 func (p *ListKeySubcommand) RegisterFlags() {
 	p.FlagSet = flag.NewFlagSet(CmdListKeys, flag.ContinueOnError)

--- a/cmd/acra-keys/keys/read-key.go
+++ b/cmd/acra-keys/keys/read-key.go
@@ -67,6 +67,11 @@ func (p *ReadKeySubcommand) Name() string {
 	return CmdReadKey
 }
 
+// GetFlagSet returns flag set of this subcommand.
+func (p *ReadKeySubcommand) GetFlagSet() *flag.FlagSet {
+	return p.FlagSet
+}
+
 // RegisterFlags registers command-line flags of "acra-keys read".
 func (p *ReadKeySubcommand) RegisterFlags() {
 	p.FlagSet = flag.NewFlagSet(CmdReadKey, flag.ContinueOnError)

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -181,13 +181,30 @@ func PrintFlags(flags *flag_.FlagSet) {
 	})
 }
 
+func visitFlagSets(flagSets []*flag_.FlagSet, visit func(flag *flag_.Flag)) {
+	seenNames := make(map[string]struct{})
+	for _, flags := range flagSets {
+		flags.VisitAll(func(flag *flag_.Flag) {
+			if _, visited := seenNames[flag.Name]; !visited {
+				visit(flag)
+				seenNames[flag.Name] = struct{}{}
+			}
+		})
+	}
+}
+
 // GenerateYaml generates YAML file from CLI params
 func GenerateYaml(output io.Writer, useDefault bool) {
+	GenerateYamlFromFlagSets([]*flag_.FlagSet{flag_.CommandLine}, output, useDefault)
+}
+
+// GenerateYamlFromFlagSets generates YAML file from CLI flag sets.
+func GenerateYamlFromFlagSets(flagSets []*flag_.FlagSet, output io.Writer, useDefault bool) {
 	// write version as first line in yaml format
 	if _, err := fmt.Fprintf(output, "version: %s\n", utils.VERSION); err != nil {
 		panic(err)
 	}
-	flag_.CommandLine.VisitAll(func(flag *flag_.Flag) {
+	visitFlagSets(flagSets, func(flag *flag_.Flag) {
 		var s string
 		if useDefault {
 			s = fmt.Sprintf("# %v\n%v: %v\n", flag.Usage, flag.Name, flag.DefValue)
@@ -200,6 +217,11 @@ func GenerateYaml(output io.Writer, useDefault bool) {
 
 // GenerateMarkdownDoc generates Markdown file from CLI params
 func GenerateMarkdownDoc(output io.Writer, serviceName string) {
+	GenerateMarkdownDocFromFlagSets([]*flag_.FlagSet{flag_.CommandLine}, output, serviceName)
+}
+
+// GenerateMarkdownDocFromFlagSets generates Markdown file from CLI flag sets.
+func GenerateMarkdownDocFromFlagSets(flagSets []*flag_.FlagSet, output io.Writer, serviceName string) {
 	// escape column separator symbol from text
 	escapeColumn := func(text string) string {
 		return strings.Replace(text, "|", "\\|", -1)
@@ -208,14 +230,18 @@ func GenerateMarkdownDoc(output io.Writer, serviceName string) {
 	// |serviceName | arg name | rename to | default value | description|
 	// |:-:         |:-:       |:-:        |:-:            |:-:         |
 	fmt.Fprintf(output, "|%v|||||\n|:-:|:-:|:-:|:-:|:-:|\n", serviceName)
-	flag_.CommandLine.VisitAll(func(flag *flag_.Flag) {
-
+	visitFlagSets(flagSets, func(flag *flag_.Flag) {
 		fmt.Fprintf(output, "||%v||%v|%v|\n", flag.Name, flag.DefValue, escapeColumn(flag.Usage))
 	})
 }
 
 // DumpConfig writes CLI params to configPath
 func DumpConfig(configPath, serviceName string, useDefault bool) error {
+	return DumpConfigFromFlagSets([]*flag_.FlagSet{flag_.CommandLine}, configPath, serviceName, useDefault)
+}
+
+// DumpConfigFromFlagSets writes CLI params to configPath
+func DumpConfigFromFlagSets(flagSets []*flag_.FlagSet, configPath, serviceName string, useDefault bool) error {
 	var absPath string
 	var err error
 
@@ -243,7 +269,7 @@ func DumpConfig(configPath, serviceName string, useDefault bool) error {
 	}
 	defer file.Close()
 
-	GenerateYaml(file, useDefault)
+	GenerateYamlFromFlagSets(flagSets, file, useDefault)
 
 	if *generateMarkdownArgTable {
 		file2, err := os.Create(fmt.Sprintf("%v/markdown_%v.md", dirPath, serviceName))
@@ -251,7 +277,7 @@ func DumpConfig(configPath, serviceName string, useDefault bool) error {
 			return err
 		}
 
-		GenerateMarkdownDoc(file2, serviceName)
+		GenerateMarkdownDocFromFlagSets(flagSets, file2, serviceName)
 	}
 	log.Infof("Config dumped to %s", configPath)
 	return nil

--- a/configs/acra-keys.yaml
+++ b/configs/acra-keys.yaml
@@ -8,3 +8,30 @@ dump_config: false
 # Generate with yaml config markdown text file with descriptions of all args
 generate_markdown_args_table: false
 
+# use machine-readable JSON output
+json: false
+
+# path to key directory
+keys_dir: .acrakeys
+
+# path to key directory for public keys
+keys_dir_public: 
+
+# export all keys
+all: false
+
+# path to output file for exported key bundle
+key_bundle_file: 
+
+# path to output file for key encryption keys
+key_bundle_secret: 
+
+# export private key data
+private_keys: false
+
+# client ID for which to retrieve key
+client_id: 
+
+# zone ID for which to retrieve key
+zone_id: 
+


### PR DESCRIPTION
As noted by @vixentael in #396, `acra-keys` currently has incomplete configuration file template. The configuration still works, but the users won't know that they can set a particular value in the configuration file instead of passing it over and over on the command line.

The issue here is that the `DumpConfig` function used to handle the `--dump_config` flag is very tightly coupled with the global flag set (`flag.CommandLine`). However, `acra-keys` has most of its flags in flags sets of individual subcommands, not the global one.

To fix this issue, introduce a bunch of sister functions to `DumpConfig` and friends, which can accept an arbitrary list of flag sets to work with. `acra-keys` will use these functions to pass its flag sets. Other tools continue using the old functions which keep their behavior.

Also, `--dump_config` flag causes the process to immediately exit after dumping the config. This is an okay thing to do in `cmd.Parse` which works with only with the global flag set, but if we work with multiple flag sets, we would like to decide which flag sets we include. Make `ParseFlagsWithConfig` to return a special error (like `flag.ErrHelp`) when `--dump_config` is requested, and handle it the way we want to. The old `Parse` will still exit as before.

In the end, this allows the `acra-keys.yaml` to be properly populated with all available configuration options.