### PR TITLE
MySQL decryption notifications

### DIFF
--- a/decryptor/base/decryptionNotification.go
+++ b/decryptor/base/decryptionNotification.go
@@ -103,3 +103,79 @@ type ColumnDecryptionNotifier interface {
 	SubscribeOnAllColumnsDecryption(subscriber DecryptionSubscriber)
 	Unsubscribe(DecryptionSubscriber)
 }
+
+// ColumnDecryptionObserver is a simple ColumnDecryptionNotifier implementation.
+type ColumnDecryptionObserver struct {
+	perColumn  map[int][]DecryptionSubscriber
+	allColumns []DecryptionSubscriber
+}
+
+// NewColumnDecryptionObserver makes a new observer.
+func NewColumnDecryptionObserver() ColumnDecryptionObserver {
+	// Reserve some memory for a typical amount of subscribers.
+	return ColumnDecryptionObserver{
+		perColumn:  make(map[int][]DecryptionSubscriber, 10),
+		allColumns: make([]DecryptionSubscriber, 0, 5),
+	}
+}
+
+// SubscribeOnColumnDecryption subscribes for notifications about the column, indexed from left to right starting with zero.
+func (o *ColumnDecryptionObserver) SubscribeOnColumnDecryption(column int, subscriber DecryptionSubscriber) {
+	subscribers := o.perColumn[column]
+	for _, existing := range subscribers {
+		if existing == subscriber {
+			return
+		}
+	}
+	o.perColumn[column] = append(subscribers, subscriber)
+}
+
+// SubscribeOnAllColumnsDecryption subscribes for notifications on each column.
+func (o *ColumnDecryptionObserver) SubscribeOnAllColumnsDecryption(subscriber DecryptionSubscriber) {
+	for _, existing := range o.allColumns {
+		if existing == subscriber {
+			return
+		}
+	}
+	o.allColumns = append(o.allColumns, subscriber)
+}
+
+// Unsubscribe a subscriber from all notifications.
+func (o *ColumnDecryptionObserver) Unsubscribe(subscriber DecryptionSubscriber) {
+	for column, observers := range o.perColumn {
+		for i, existing := range observers {
+			if existing == subscriber {
+				o.perColumn[column] = append(observers[:i], observers[i+1:]...)
+				break
+			}
+		}
+	}
+	for i, existing := range o.allColumns {
+		if existing == subscriber {
+			o.allColumns = append(o.allColumns[:i], o.allColumns[i+1:]...)
+			break
+		}
+	}
+}
+
+// OnColumnDecryption notifies all subscribers about a change in given column, passing the context and data to them.
+// Returns the data and error returned by subscribers.
+// If a subscriber returns an error, it is immediately returned and other subscribers are not notified.
+func (o *ColumnDecryptionObserver) OnColumnDecryption(ctx context.Context, column int, data []byte) ([]byte, error) {
+	var err error
+	// Avoid creating a map entry if it does not exist.
+	subscribers, _ := o.perColumn[column]
+	for _, subscriber := range subscribers {
+		ctx, data, err = subscriber.OnColumn(ctx, data)
+		if err != nil {
+			return data, err
+		}
+	}
+	for _, subscriber := range o.allColumns {
+		ctx, data, err = subscriber.OnColumn(ctx, data)
+		if err != nil {
+			return data, err
+		}
+	}
+	return data, nil
+}

--- a/decryptor/base/decryptionNotification.go
+++ b/decryptor/base/decryptionNotification.go
@@ -1,6 +1,10 @@
 package base
 
-import "context"
+import (
+	"context"
+
+	"github.com/sirupsen/logrus"
+)
 
 // ColumnInfo interface describe available metadata for column
 type ColumnInfo interface {
@@ -95,6 +99,7 @@ func ColumnInfoFromContext(ctx context.Context) (ColumnInfo, bool) {
 // DecryptionSubscriber interface to subscribe on column's data in db responses
 type DecryptionSubscriber interface {
 	OnColumn(context.Context, []byte) (context.Context, []byte, error)
+	ID() string
 }
 
 // ColumnDecryptionNotifier interface to subscribe/unsubscribe on OnColumn events
@@ -168,12 +173,14 @@ func (o *ColumnDecryptionObserver) OnColumnDecryption(ctx context.Context, colum
 	for _, subscriber := range subscribers {
 		ctx, data, err = subscriber.OnColumn(ctx, data)
 		if err != nil {
+			logrus.WithField("subscriber", subscriber.ID()).WithError(err).Errorln("OnColumn error")
 			return data, err
 		}
 	}
 	for _, subscriber := range o.allColumns {
 		ctx, data, err = subscriber.OnColumn(ctx, data)
 		if err != nil {
+			logrus.WithField("subscriber", subscriber.ID()).WithError(err).Errorln("OnColumn error")
 			return data, err
 		}
 	}

--- a/decryptor/mysql/column_field.go
+++ b/decryptor/mysql/column_field.go
@@ -59,35 +59,35 @@ func ParseResultField(data []byte) (*ColumnDescription, error) {
 	pos += n
 
 	//schema
-	field.Schema, _, n, err = LengthEncodedString(data[pos:])
+	field.Schema, n, err = LengthEncodedString(data[pos:])
 	if err != nil {
 		return nil, err
 	}
 	pos += n
 
 	//table
-	field.Table, _, n, err = LengthEncodedString(data[pos:])
+	field.Table, n, err = LengthEncodedString(data[pos:])
 	if err != nil {
 		return nil, err
 	}
 	pos += n
 
 	//org_table
-	field.OrgTable, _, n, err = LengthEncodedString(data[pos:])
+	field.OrgTable, n, err = LengthEncodedString(data[pos:])
 	if err != nil {
 		return nil, err
 	}
 	pos += n
 
 	//name
-	field.Name, _, n, err = LengthEncodedString(data[pos:])
+	field.Name, n, err = LengthEncodedString(data[pos:])
 	if err != nil {
 		return nil, err
 	}
 	pos += n
 
 	//org_name
-	field.OrgName, _, n, err = LengthEncodedString(data[pos:])
+	field.OrgName, n, err = LengthEncodedString(data[pos:])
 	if err != nil {
 		return nil, err
 	}

--- a/decryptor/mysql/decryptor.go
+++ b/decryptor/mysql/decryptor.go
@@ -355,4 +355,5 @@ func (decryptor *Decryptor) DecryptBlock(block []byte) ([]byte, error) {
 // SetDataProcessor replace current with new processor
 func (decryptor *Decryptor) SetDataProcessor(processor base.DataProcessor) {
 	decryptor.dataProcessor = processor
+	decryptor.Decryptor.SetDataProcessor(processor)
 }

--- a/decryptor/mysql/proxy.go
+++ b/decryptor/mysql/proxy.go
@@ -57,5 +57,6 @@ func (factory *proxyFactory) New(ctx context.Context, clientID []byte, dbConnect
 		}
 		proxy.AddQueryObserver(queryEncryptor)
 	}
+	proxy.SubscribeOnAllColumnsDecryption(decryptor)
 	return proxy, nil
 }

--- a/decryptor/mysql/response_proxy.go
+++ b/decryptor/mysql/response_proxy.go
@@ -414,7 +414,7 @@ func (handler *Handler) processTextDataRow(ctx context.Context, rowData []byte, 
 	handler.logger.Debugln("Process data rows in text protocol")
 	for i := range fields {
 		fieldLogger = handler.logger.WithField("field_index", i)
-		value, _, n, err = LengthEncodedString(rowData[pos:])
+		value, n, err = LengthEncodedString(rowData[pos:])
 		if err != nil {
 			return nil, err
 		}
@@ -481,7 +481,7 @@ func (handler *Handler) processBinaryDataRow(ctx context.Context, rowData []byte
 			continue
 		}
 		if handler.isFieldToDecrypt(fields[i]) {
-			value, _, n, err = LengthEncodedString(rowData[pos:])
+			value, n, err = LengthEncodedString(rowData[pos:])
 			if err != nil {
 				handler.logger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorDecryptorCantDecryptBinary).
 					Errorln("Can't handle length encoded string binary value")
@@ -575,7 +575,7 @@ func (handler *Handler) processBinaryDataRow(ctx context.Context, rowData []byte
 			continue
 
 		case TypeDecimal, TypeNewDecimal, TypeBit, TypeEnum, TypeSet, TypeGeometry, TypeDate, TypeNewDate, TypeTimestamp, TypeDatetime, TypeTime:
-			value, _, n, err = LengthEncodedString(rowData[pos:])
+			value, n, err = LengthEncodedString(rowData[pos:])
 			if err != nil {
 				handler.logger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorDecryptorCantDecryptBinary).
 					Errorln("Can't handle length encoded string non binary value")

--- a/decryptor/mysql/response_proxy.go
+++ b/decryptor/mysql/response_proxy.go
@@ -812,12 +812,8 @@ func (handler *Handler) QueryResponseHandler(ctx context.Context, packet *Packet
 						Debugln("Can't process binary data row")
 					return err
 				}
-				dataLength := fieldDataPacket.GetPacketPayloadLength()
-				// decrypted data always less than ecrypted
-				if len(newData) < dataLength {
-					handler.logger.WithFields(logrus.Fields{"oldLength": dataLength, "newLength": len(newData)}).Debugln("Update row data")
-					fieldDataPacket.SetData(newData)
-				}
+				handler.logger.WithFields(logrus.Fields{"oldLength": fieldDataPacket.GetPacketPayloadLength(), "newLength": len(newData)}).Debugln("Update row data")
+				fieldDataPacket.SetData(newData)
 			}
 		} else {
 			var dataLog *logrus.Entry
@@ -846,13 +842,8 @@ func (handler *Handler) QueryResponseHandler(ctx context.Context, packet *Packet
 						Debugln("Can't process text data row")
 					return err
 				}
-				dataLength := fieldDataPacket.GetPacketPayloadLength()
-				// decrypted data always less than ecrypted
-				if len(newData) < dataLength {
-					dataLog.WithFields(logrus.Fields{"oldLength": dataLength, "newLength": len(newData)}).Debugln("Update row data")
-					fieldDataPacket.SetData(newData)
-				}
-
+				dataLog.WithFields(logrus.Fields{"oldLength": fieldDataPacket.GetPacketPayloadLength(), "newLength": len(newData)}).Debugln("Update row data")
+				fieldDataPacket.SetData(newData)
 			}
 		}
 

--- a/decryptor/postgresql/pg_general_decryptor.go
+++ b/decryptor/postgresql/pg_general_decryptor.go
@@ -409,6 +409,11 @@ func (decryptor *PgDecryptor) SetDataProcessor(processor base.DataProcessor) {
 	decryptor.dataProcessor = processor
 }
 
+// ID returns decryption subscriber identification.
+func (decryptor *PgDecryptor) ID() string {
+	return "PgDecryptor"
+}
+
 // OnColumn handler which process column data on db response and try to decrypt/detect poison record
 func (decryptor *PgDecryptor) OnColumn(ctx context.Context, data []byte) (context.Context, []byte, error) {
 	logger := logging.GetLoggerFromContext(ctx)

--- a/decryptor/postgresql/proxy_test.go
+++ b/decryptor/postgresql/proxy_test.go
@@ -46,6 +46,10 @@ func (t testDecryptor) GetTagBeginLength() int {
 	panic("implement me")
 }
 
+func (t testDecryptor) ID() string {
+	panic("implement me")
+}
+
 func (t testDecryptor) OnColumn(context.Context, []byte) (context.Context, []byte, error) {
 	panic("implement me")
 }

--- a/encryptor/dbDataCoder.go
+++ b/encryptor/dbDataCoder.go
@@ -45,7 +45,7 @@ func (*MysqlDBDataCoder) Decode(expr sqlparser.Expr) ([]byte, error) {
 	switch val := expr.(type) {
 	case *sqlparser.SQLVal:
 		switch val.Type {
-		case sqlparser.StrVal:
+		case sqlparser.IntVal, sqlparser.StrVal:
 			return val.Val, nil
 		case sqlparser.HexVal:
 			binValue := make([]byte, hex.DecodedLen(len(val.Val)))
@@ -65,7 +65,7 @@ func (*MysqlDBDataCoder) Encode(expr sqlparser.Expr, data []byte) ([]byte, error
 	switch val := expr.(type) {
 	case *sqlparser.SQLVal:
 		switch val.Type {
-		case sqlparser.StrVal:
+		case sqlparser.IntVal, sqlparser.StrVal:
 			return data, nil
 		case sqlparser.HexVal:
 			output := make([]byte, hex.EncodedLen(len(data)))

--- a/encryptor/dbDataCoder_test.go
+++ b/encryptor/dbDataCoder_test.go
@@ -27,71 +27,81 @@ import (
 )
 
 func TestMysqlDBDataCoder_Decode(t *testing.T) {
-	testData := []byte("some data")
 	coder := &MysqlDBDataCoder{}
-	testCases := []sqlparser.Expr{
-		sqlparser.NewHexVal([]byte(hex.EncodeToString(testData))),
-		sqlparser.NewStrVal(testData)}
-	for _, expr := range testCases {
-		data, err := coder.Decode(expr)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !bytes.Equal(data, testData) {
-			t.Fatalf("Expr: %s\nTook: %s\nExpected: %s", sqlparser.String(expr), string(data), string(testData))
-		}
-	}
-
-	errTestCases := []struct {
-		Err  error
-		Expr sqlparser.Expr
+	testCases := []struct {
+		Input  sqlparser.Expr
+		Output []byte
+		Err    error
 	}{
 		{
-			Err: hex.ErrLength,
-			// incorrect hex value with incorrect length
-			Expr: sqlparser.NewHexVal([]byte(hex.EncodeToString(testData))[1:]),
+			Input:  sqlparser.NewHexVal([]byte(hex.EncodeToString([]byte("test data")))),
+			Output: []byte("test data"),
 		},
 		{
-			Err:  errUnsupportedExpression,
-			Expr: sqlparser.NewIntVal([]byte{1}),
+			Input:  sqlparser.NewStrVal([]byte("test data")),
+			Output: []byte("test data"),
+		},
+		{
+			Input:  sqlparser.NewIntVal([]byte("12345678")),
+			Output: []byte("12345678"),
+		},
+		{
+			Input: sqlparser.NewFloatVal([]byte("-2.71828")),
+			Err:   errUnsupportedExpression,
 		},
 	}
-	for _, testCase := range errTestCases {
-		_, err := coder.Decode(testCase.Expr)
+	for _, testCase := range testCases {
+		data, err := coder.Decode(testCase.Input)
 		if err != testCase.Err {
-			t.Fatalf("Incorrect error. Took: %s; Expected: %s", err.Error(), testCase.Err.Error())
+			t.Errorf("Expr: %s\nUnexpected error\nExpected: %v\nActual: %v", sqlparser.String(testCase.Input), testCase.Err, err)
+			continue
+		}
+		if !bytes.Equal(data, testCase.Output) {
+			t.Errorf("Expr: %s\nIncorrect output\nActual:   %s\nExpected: %s", sqlparser.String(testCase.Input), string(data), string(testCase.Output))
+			continue
 		}
 	}
 }
 
 func TestMysqlDBDataCoder_Encode(t *testing.T) {
-	testData := []byte("some data")
 	coder := &MysqlDBDataCoder{}
 	testCases := []struct {
 		Expr   sqlparser.Expr
 		Output []byte
+		Input  []byte
+		Err    error
 	}{
 		{
-			Output: []byte(hex.EncodeToString(testData)),
-			Expr:   sqlparser.NewHexVal([]byte(hex.EncodeToString(testData))),
+			Expr:   sqlparser.NewHexVal([]byte(hex.EncodeToString([]byte("some data")))),
+			Input:  []byte("some data"),
+			Output: []byte(hex.EncodeToString([]byte("some data"))),
 		},
 		{
-			Output: testData,
-			Expr:   sqlparser.NewStrVal(testData),
+			Expr:   sqlparser.NewStrVal([]byte("some data")),
+			Input:  []byte("some data"),
+			Output: []byte("some data"),
+		},
+		{
+			Expr:   sqlparser.NewIntVal([]byte("1234")),
+			Input:  []byte("1234"),
+			Output: []byte("1234"),
+		},
+		{
+			Expr:  sqlparser.NewFloatVal([]byte("3.1415")),
+			Input: []byte("3.1415"),
+			Err:   errUnsupportedExpression,
 		},
 	}
 	for _, testCase := range testCases {
-		coded, err := coder.Encode(testCase.Expr, testData)
-		if err != nil {
-			t.Fatal(err)
+		coded, err := coder.Encode(testCase.Expr, testCase.Input)
+		if err != testCase.Err {
+			t.Errorf("Expr: %s\nUnexpected error\nExpected: %v\nActual: %v", sqlparser.String(testCase.Expr), testCase.Err, err)
+			continue
 		}
 		if !bytes.Equal(coded, testCase.Output) {
-			t.Fatalf("Expr: %s\nTook: %s\nExpected: %s", sqlparser.String(testCase.Expr), string(coded), string(testCase.Output))
+			t.Errorf("Expr: %s\nIncorrect output\nActual:   %s\nExpected: %s", sqlparser.String(testCase.Expr), string(coded), string(testCase.Output))
+			continue
 		}
-	}
-
-	if _, err := coder.Encode(sqlparser.NewIntVal([]byte{1}), testData); err != errUnsupportedExpression {
-		t.Fatalf("Incorrect error. Took: %s; Expected: %s", err.Error(), errUnsupportedExpression.Error())
 	}
 }
 


### PR DESCRIPTION
This is a sizeable but coherent changeset improving various aspects of MySQL processing in Acra CE, with the goal of providing a better platform for Acra EE features relying on additional data processing, such as pseudonymization.

The overarching idea is that PostgreSQL proxy backend implements the `ColumnDecryptionNotifier` interface which enables subscribers to observe and modify per-column data during is processing in responses and requests. MySQL does not support this interface. Moreover, there are some other issues related to its use which are fixed up here to keep the build green.

- Integer support in MysqlDBDataCoder

First of all MySQL request parser did not support integer fields in requests. This breaks any tests for MySQL using integers because Acra simply passes such requests through unchanged. Integers are represented with textual strings, so they are easy to add.

- Common ColumnDecryptionNotifier implementation
- Use common observer in PostgreSQL decryptor
- Implement ColumnDecryptionNotifier for MySQL proxy

The bulk of `ColumnDecryptionNotifier` implementation is completely independent of the database engine and its protocol. These commits introduce a shared utility that makes it trivial to implement the notification interface. The utility is based on the current PostgreSQL code, with some improvements.

- Observe decryption events for text data rows
- Observe decryption events for binary rows: decryptable strings
- Observe decryption events for binary rows: other strings
- Observe decryption events for binary rows: fixed-size numbers

These commits add calls to `OnColumnDecrypted` notifications, letting the subscribers know that a column is being decrypted. MySQL protocol is tricky because there are several representations of data, including text and binary. The subscribers expect the data to come as text, so we need to convert binary data into text, let the subscribers process it, and then reencode the result back.

This results is somewhat awful copypasta. If anyone has suggestions on how to reduce it, please voice them. I don't really like it.

- Require DecryptionSubscribers to ID themselves

This commit incorporates some extensions made by Acra EE, allowing to reduce code duplication in Acra EE, and to avoid some subtle issues related to context handling.

- Always update data after processing
- Special handling of NULL value encoding
- Propagate DataProcessor in mysql.Decryptor

Adding the new processing flow requires some additional attention to the data, as it needs to be returned into MySQL packet in the correct format. See commit messages for more details.