### PR TITLE
Use single ACRA_MASTER_KEY for key store v2

### DIFF
--- a/cmd/acra-addzone/acra-addzone.go
+++ b/cmd/acra-addzone/acra-addzone.go
@@ -87,7 +87,7 @@ func main() {
 func openKeyStoreV1(output string) keystore.StorageKeyCreation {
 	masterKey, err := keystore.GetMasterKeyFromEnvironment()
 	if err != nil {
-		log.WithError(err).Errorln("Can't load master key")
+		log.WithError(err).Errorln("Cannot load master key")
 		os.Exit(1)
 	}
 	scellEncryptor, err := keystore.NewSCellKeyEncryptor(masterKey)
@@ -106,7 +106,7 @@ func openKeyStoreV1(output string) keystore.StorageKeyCreation {
 func openKeyStoreV2(keyDirPath string) keystore.StorageKeyCreation {
 	encryption, signature, err := keystoreV2.GetMasterKeysFromEnvironment()
 	if err != nil {
-		log.WithError(err).Error("cannot read master keys from environment")
+		log.WithError(err).Errorln("Cannot load master key")
 		os.Exit(1)
 	}
 	suite, err := keystoreV2.NewSCellSuite(encryption, signature)

--- a/cmd/acra-authmanager/acra_authmanager.go
+++ b/cmd/acra-authmanager/acra_authmanager.go
@@ -243,7 +243,7 @@ func main() {
 func openKeyStoreV1(keysDir string) keystore.WebConfigKeyStore {
 	masterKey, err := keystore.GetMasterKeyFromEnvironment()
 	if err != nil {
-		log.WithError(err).Errorln("Can't load master key")
+		log.WithError(err).Errorln("Cannot load master key")
 		os.Exit(1)
 	}
 	encryptor, err := keystore.NewSCellKeyEncryptor(masterKey)
@@ -262,7 +262,7 @@ func openKeyStoreV1(keysDir string) keystore.WebConfigKeyStore {
 func openKeyStoreV2(keyDirPath string) keystore.WebConfigKeyStore {
 	encryption, signature, err := keystoreV2.GetMasterKeysFromEnvironment()
 	if err != nil {
-		log.WithError(err).Error("cannot read master keys from environment")
+		log.WithError(err).Errorln("Cannot load master key")
 		os.Exit(1)
 	}
 	suite, err := keystoreV2.NewSCellSuite(encryption, signature)

--- a/cmd/acra-connector/acra-connector.go
+++ b/cmd/acra-connector/acra-connector.go
@@ -505,7 +505,9 @@ func main() {
 func openKeyStoreV1(keysDir string, clientID []byte, connectorMode connector_mode.ConnectorMode) keystore.TransportKeyStore {
 	masterKey, err := keystore.GetMasterKeyFromEnvironment()
 	if err != nil {
-		log.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantLoadMasterKey).WithError(err).Errorln("Can't load master key")
+		log.WithError(err).
+			WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantLoadMasterKey).
+			Errorln("Cannot load master key")
 		os.Exit(1)
 	}
 	scellEncryptor, err := keystore.NewSCellKeyEncryptor(masterKey)
@@ -527,7 +529,7 @@ func openKeyStoreV2(outputDir string, clientID []byte, mode connector_mode.Conne
 	if err != nil {
 		log.WithError(err).
 			WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantLoadMasterKey).
-			Error("cannot read master keys from environment")
+			Errorln("Cannot load master key")
 		os.Exit(1)
 	}
 	suite, err := keystoreV2.NewSCellSuite(encryption, signature)

--- a/cmd/acra-keymaker/acra-keymaker.go
+++ b/cmd/acra-keymaker/acra-keymaker.go
@@ -67,12 +67,24 @@ func main() {
 	cmd.ValidateClientID(*clientID)
 
 	if *masterKey != "" {
-		newKey, err := keystore.GenerateSymmetricKey()
+		var newKey []byte
+		switch *keystoreVersion {
+		case "v1":
+			newKey, err = keystore.GenerateSymmetricKey()
+		case "":
+			log.Errorf("Key store version is required: --keystore={v1|v2}")
+			os.Exit(1)
+		default:
+			log.Errorf("Unknown --keystore option: %v", *keystoreVersion)
+			os.Exit(1)
+		}
 		if err != nil {
-			panic(err)
+			log.WithError(err).Errorln("Failed to generate master key")
+			os.Exit(1)
 		}
 		if err := ioutil.WriteFile(*masterKey, newKey, 0600); err != nil {
-			panic(err)
+			log.WithError(err).WithField("path", *masterKey).Errorln("Failed to write master key")
+			os.Exit(1)
 		}
 		os.Exit(0)
 	}

--- a/cmd/acra-keymaker/acra-keymaker.go
+++ b/cmd/acra-keymaker/acra-keymaker.go
@@ -169,11 +169,7 @@ func main() {
 func openKeyStoreV1(outputDir, outputPublicKey string) keystore.KeyMaking {
 	symmetricKey, err := keystore.GetMasterKeyFromEnvironment()
 	if err != nil {
-		if err == keystore.ErrEmptyMasterKey {
-			log.Infof("You must pass master key via %v environment variable", keystore.AcraMasterKeyVarName)
-			os.Exit(1)
-		}
-		log.WithError(err).Errorln("Can't load master key")
+		log.WithError(err).Errorln("Cannot load master key")
 		os.Exit(1)
 	}
 	scellEncryptor, err := keystore.NewSCellKeyEncryptor(symmetricKey)
@@ -197,7 +193,7 @@ func openKeyStoreV1(outputDir, outputPublicKey string) keystore.KeyMaking {
 func openKeyStoreV2(keyDirPath string) keystore.KeyMaking {
 	encryption, signature, err := keystoreV2.GetMasterKeysFromEnvironment()
 	if err != nil {
-		log.WithError(err).Error("cannot read master keys from environment")
+		log.WithError(err).Errorln("Cannot load master key")
 		os.Exit(1)
 	}
 	suite, err := keystoreV2.NewSCellSuite(encryption, signature)

--- a/cmd/acra-keymaker/acra-keymaker.go
+++ b/cmd/acra-keymaker/acra-keymaker.go
@@ -71,6 +71,8 @@ func main() {
 		switch *keystoreVersion {
 		case "v1":
 			newKey, err = keystore.GenerateSymmetricKey()
+		case "v2":
+			newKey, err = keystoreV2.NewSerializedMasterKeys()
 		case "":
 			log.Errorf("Key store version is required: --keystore={v1|v2}")
 			os.Exit(1)

--- a/cmd/acra-keys/keys/keystore.go
+++ b/cmd/acra-keys/keys/keystore.go
@@ -110,7 +110,7 @@ func OpenKeyStoreForImport(params KeyStoreParameters) (api.MutableKeyStore, erro
 func openKeyStoreV1(params KeyStoreParameters) (*filesystemV1.KeyStore, error) {
 	symmetricKey, err := keystoreV1.GetMasterKeyFromEnvironment()
 	if err != nil {
-		log.WithError(err).Errorln("Cannot read master keys from environment")
+		log.WithError(err).Errorln("Cannot load master key")
 		return nil, err
 	}
 	scellEncryptor, err := keystoreV1.NewSCellKeyEncryptor(symmetricKey)
@@ -136,7 +136,7 @@ func openKeyStoreV1(params KeyStoreParameters) (*filesystemV1.KeyStore, error) {
 func openKeyStoreV2(params KeyStoreParameters) (*keystoreV2.ServerKeyStore, error) {
 	encryption, signature, err := keystoreV2.GetMasterKeysFromEnvironment()
 	if err != nil {
-		log.WithError(err).Error("Cannot read master keys from environment")
+		log.WithError(err).Errorln("Cannot load master key")
 		return nil, err
 	}
 	suite, err := keystoreV2.NewSCellSuite(encryption, signature)

--- a/cmd/acra-migrate-keys/acra-migrate-keys.go
+++ b/cmd/acra-migrate-keys/acra-migrate-keys.go
@@ -150,7 +150,7 @@ func OpenKeyStoreV1(mode migratekeys.OpenMode, store migratekeys.KeyStoreParams,
 func OpenKeyStoreV2(mode migratekeys.OpenMode, store migratekeys.KeyStoreParams, params migratekeys.MiscParams) (*keystoreV2.ServerKeyStore, error) {
 	encryption, signature, err := keystoreV2.GetMasterKeysFromEnvironmentVariable(keyVarName(mode))
 	if err != nil {
-		log.WithError(err).Error("Cannot read master keys from environment")
+		log.WithError(err).Errorln("Cannot load master key")
 		return nil, err
 	}
 	suite, err := keystoreV2.NewSCellSuite(encryption, signature)

--- a/cmd/acra-migrate-keys/acra-migrate-keys.go
+++ b/cmd/acra-migrate-keys/acra-migrate-keys.go
@@ -33,6 +33,12 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// Environment variables from which master keys are read.
+const (
+	SrcMasterKeyVarName = "SRC_" + keystoreV1.AcraMasterKeyVarName
+	DstMasterKeyVarName = "DST_" + keystoreV1.AcraMasterKeyVarName
+)
+
 func main() {
 	params := migratekeys.RegisterCommandLineParams()
 	err := params.Parse()
@@ -104,9 +110,20 @@ func MigrateV1toV2(srcV1 filesystemV1.KeyExport, dstV2 keystoreV2.KeyFileImportV
 	return nil
 }
 
+func keyVarName(mode migratekeys.OpenMode) string {
+	switch mode {
+	case migratekeys.OpenSrc:
+		return SrcMasterKeyVarName
+	case migratekeys.OpenDst:
+		return DstMasterKeyVarName
+	default:
+		panic("unknown mode")
+	}
+}
+
 // OpenKeyStoreV1 opens key store v1 for given purpose.
 func OpenKeyStoreV1(mode migratekeys.OpenMode, store migratekeys.KeyStoreParams, params migratekeys.MiscParams) (*filesystemV1.KeyStore, error) {
-	masterKey, err := keystoreV1.GetMasterKeyFromEnvironment()
+	masterKey, err := keystoreV1.GetMasterKeyFromEnvironmentVariable(keyVarName(mode))
 	if err != nil {
 		log.WithError(err).Error("Cannot load master key")
 		return nil, err
@@ -131,7 +148,7 @@ func OpenKeyStoreV1(mode migratekeys.OpenMode, store migratekeys.KeyStoreParams,
 
 // OpenKeyStoreV2 opens key store v2 for given purpose.
 func OpenKeyStoreV2(mode migratekeys.OpenMode, store migratekeys.KeyStoreParams, params migratekeys.MiscParams) (*keystoreV2.ServerKeyStore, error) {
-	encryption, signature, err := keystoreV2.GetMasterKeysFromEnvironment()
+	encryption, signature, err := keystoreV2.GetMasterKeysFromEnvironmentVariable(keyVarName(mode))
 	if err != nil {
 		log.WithError(err).Error("Cannot read master keys from environment")
 		return nil, err

--- a/cmd/acra-poisonrecordmaker/acra-poisonrecordmaker.go
+++ b/cmd/acra-poisonrecordmaker/acra-poisonrecordmaker.go
@@ -79,7 +79,7 @@ func main() {
 func openKeyStoreV1(keysDir string) keystore.PoisonKeyStore {
 	masterKey, err := keystore.GetMasterKeyFromEnvironment()
 	if err != nil {
-		log.WithError(err).Errorln("can't load master key")
+		log.WithError(err).Errorln("Cannot load master key")
 		os.Exit(1)
 	}
 	scellEncryptor, err := keystore.NewSCellKeyEncryptor(masterKey)
@@ -98,7 +98,7 @@ func openKeyStoreV1(keysDir string) keystore.PoisonKeyStore {
 func openKeyStoreV2(keyDirPath string) keystore.PoisonKeyStore {
 	encryption, signature, err := keystoreV2.GetMasterKeysFromEnvironment()
 	if err != nil {
-		log.WithError(err).Error("cannot read master keys from environment")
+		log.WithError(err).Errorln("Cannot load master key")
 		os.Exit(1)
 	}
 	suite, err := keystoreV2.NewSCellSuite(encryption, signature)

--- a/cmd/acra-rollback/acra-rollback.go
+++ b/cmd/acra-rollback/acra-rollback.go
@@ -305,7 +305,7 @@ func main() {
 func openKeyStoreV1(keysDir string) keystore.DecryptionKeyStore {
 	masterKey, err := keystore.GetMasterKeyFromEnvironment()
 	if err != nil {
-		log.WithError(err).Errorln("Can't load master key")
+		log.WithError(err).Errorln("Cannot load master key")
 		os.Exit(1)
 	}
 	scellEncryptor, err := keystore.NewSCellKeyEncryptor(masterKey)
@@ -324,7 +324,7 @@ func openKeyStoreV1(keysDir string) keystore.DecryptionKeyStore {
 func openKeyStoreV2(keyDirPath string) keystore.DecryptionKeyStore {
 	encryption, signature, err := keystoreV2.GetMasterKeysFromEnvironment()
 	if err != nil {
-		log.WithError(err).Error("cannot read master keys from environment")
+		log.WithError(err).Errorln("Cannot load master key")
 		os.Exit(1)
 	}
 	suite, err := keystoreV2.NewSCellSuite(encryption, signature)

--- a/cmd/acra-rotate/acra-rotate.go
+++ b/cmd/acra-rotate/acra-rotate.go
@@ -45,7 +45,7 @@ var (
 func openKeyStoreV1(dirPath string) keystore.RotateStorageKeyStore {
 	masterKey, err := keystore.GetMasterKeyFromEnvironment()
 	if err != nil {
-		log.WithError(err).Errorln("Can't load master key")
+		log.WithError(err).Errorln("Cannot load master key")
 		os.Exit(1)
 	}
 	scellEncryptor, err := keystore.NewSCellKeyEncryptor(masterKey)
@@ -64,7 +64,7 @@ func openKeyStoreV1(dirPath string) keystore.RotateStorageKeyStore {
 func openKeyStoreV2(keyDirPath string) keystore.RotateStorageKeyStore {
 	encryption, signature, err := keystoreV2.GetMasterKeysFromEnvironment()
 	if err != nil {
-		log.WithError(err).Error("cannot read master keys from environment")
+		log.WithError(err).Errorln("Cannot load master key")
 		os.Exit(1)
 	}
 	suite, err := keystoreV2.NewSCellSuite(encryption, signature)

--- a/cmd/acra-server/acra-server.go
+++ b/cmd/acra-server/acra-server.go
@@ -449,7 +449,7 @@ func main() {
 func openKeyStoreV1(keysDir string, cacheSize int) keystore.ServerKeyStore {
 	masterKey, err := keystore.GetMasterKeyFromEnvironment()
 	if err != nil {
-		log.WithError(err).Errorln("Can't load master key")
+		log.WithError(err).Errorln("Cannot load master key")
 		os.Exit(1)
 	}
 	scellEncryptor, err := keystore.NewSCellKeyEncryptor(masterKey)
@@ -470,7 +470,7 @@ func openKeyStoreV1(keysDir string, cacheSize int) keystore.ServerKeyStore {
 func openKeyStoreV2(keyDirPath string) keystore.ServerKeyStore {
 	encryption, signature, err := keystoreV2.GetMasterKeysFromEnvironment()
 	if err != nil {
-		log.WithError(err).Error("cannot read master keys from environment")
+		log.WithError(err).Errorln("Cannot load master key")
 		os.Exit(1)
 	}
 	suite, err := keystoreV2.NewSCellSuite(encryption, signature)

--- a/cmd/acra-translator/acra-translator.go
+++ b/cmd/acra-translator/acra-translator.go
@@ -199,7 +199,7 @@ func openKeyStoreV1(keysDir string, cacheSize int) keystore.TranslationKeyStore 
 	if err != nil {
 		log.WithError(err).
 			WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantLoadMasterKey).
-			Errorln("Can't load master key")
+			Errorln("Cannot load master key")
 		os.Exit(1)
 	}
 	scellEncryptor, err := keystore.NewSCellKeyEncryptor(masterKey)
@@ -224,7 +224,7 @@ func openKeyStoreV2(keyDirPath string) keystore.TranslationKeyStore {
 	if err != nil {
 		log.WithError(err).
 			WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantLoadMasterKey).
-			Error("cannot read master keys from environment")
+			Errorln("Cannot load master key")
 		os.Exit(1)
 	}
 	suite, err := keystoreV2.NewSCellSuite(encryption, signature)

--- a/keystore/keystore.go
+++ b/keystore/keystore.go
@@ -91,7 +91,12 @@ func ValidateMasterKey(key []byte) error {
 
 // GetMasterKeyFromEnvironment return master key from environment variable with name AcraMasterKeyVarName
 func GetMasterKeyFromEnvironment() (key []byte, err error) {
-	b64value := os.Getenv(AcraMasterKeyVarName)
+	return GetMasterKeyFromEnvironmentVariable(AcraMasterKeyVarName)
+}
+
+// GetMasterKeyFromEnvironmentVariable return master key from specified environment variable.
+func GetMasterKeyFromEnvironmentVariable(varname string) (key []byte, err error) {
+	b64value := os.Getenv(varname)
 	if len(b64value) == 0 {
 		return nil, ErrEmptyMasterKey
 	}

--- a/keystore/keystore.go
+++ b/keystore/keystore.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/cossacklabs/themis/gothemis/cell"
 	"github.com/cossacklabs/themis/gothemis/keys"
+	log "github.com/sirupsen/logrus"
 )
 
 // KeyStore-related constants.
@@ -95,19 +96,22 @@ func GetMasterKeyFromEnvironment() (key []byte, err error) {
 }
 
 // GetMasterKeyFromEnvironmentVariable return master key from specified environment variable.
-func GetMasterKeyFromEnvironmentVariable(varname string) (key []byte, err error) {
+func GetMasterKeyFromEnvironmentVariable(varname string) ([]byte, error) {
 	b64value := os.Getenv(varname)
 	if len(b64value) == 0 {
+		log.Warnf("%v environment variable is not set", varname)
 		return nil, ErrEmptyMasterKey
 	}
-	key, err = base64.StdEncoding.DecodeString(b64value)
+	key, err := base64.StdEncoding.DecodeString(b64value)
 	if err != nil {
-		return
+		log.WithError(err).Warnf("Failed to decode %s", varname)
+		return nil, err
 	}
-	if err = ValidateMasterKey(key); err != nil {
-		return
+	if err := ValidateMasterKey(key); err != nil {
+		log.WithError(err).Warnf("Failed to validate %s", varname)
+		return nil, err
 	}
-	return
+	return key, nil
 }
 
 // KeyEncryptor describes Encrypt and Decrypt interfaces.

--- a/keystore/v2/keystore/crypto.go
+++ b/keystore/v2/keystore/crypto.go
@@ -19,6 +19,7 @@ package keystore
 import (
 	"crypto/subtle"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"os"
 
@@ -37,6 +38,35 @@ const (
 var (
 	ErrEqualMasterKeys = errors.New("encryption and signature master keys are equal")
 )
+
+// SerializedKeys is the serialized form of master keys.
+type SerializedKeys struct {
+	Encryption []byte `json:"encryption"`
+	Signature  []byte `json:"signature"`
+}
+
+// NewMasterKeys generates a new set of master keys.
+func NewMasterKeys() (*SerializedKeys, error) {
+	encryptionKey, err := keystoreV1.GenerateSymmetricKey()
+	if err != nil {
+		return nil, err
+	}
+	signatureKey, err := keystoreV1.GenerateSymmetricKey()
+	if err != nil {
+		return nil, err
+	}
+	return &SerializedKeys{Encryption: encryptionKey, Signature: signatureKey}, nil
+}
+
+// Marshal serializes master key into a byte buffer.
+func (k *SerializedKeys) Marshal() ([]byte, error) {
+	return json.Marshal(k)
+}
+
+// Unmarshal deserializes master keys from a byte buffer.
+func (k *SerializedKeys) Unmarshal(buffer []byte) error {
+	return json.Unmarshal(buffer, k)
+}
 
 // GetMasterKeysFromEnvironment reads master keys from default environment variables.
 // Returns encryption key, signature key, error.

--- a/keystore/v2/keystore/crypto.go
+++ b/keystore/v2/keystore/crypto.go
@@ -75,12 +75,18 @@ func (k *SerializedKeys) Unmarshal(buffer []byte) error {
 	return json.Unmarshal(buffer, k)
 }
 
-// GetMasterKeysFromEnvironment reads master keys from default environment variables.
+// GetMasterKeysFromEnvironment reads master keys from default environment variable.
 // Returns encryption key, signature key, error.
 func GetMasterKeysFromEnvironment() ([]byte, []byte, error) {
-	keys, err := getMasterKeysFromEnvironment()
+	return GetMasterKeysFromEnvironmentVariable(keystoreV1.AcraMasterKeyVarName)
+}
+
+// GetMasterKeysFromEnvironmentVariable reads master keys from specified environment variable.
+// Returns encryption key, signature key, error.
+func GetMasterKeysFromEnvironmentVariable(varname string) ([]byte, []byte, error) {
+	keys, err := getMasterKeysFromEnvironment(varname)
 	if err != nil {
-		log.WithError(err).Warnf("Cannot read %v", keystoreV1.AcraMasterKeyVarName)
+		log.WithError(err).Warnf("Cannot read %v", varname)
 		return nil, nil, err
 	}
 
@@ -103,8 +109,8 @@ func GetMasterKeysFromEnvironment() ([]byte, []byte, error) {
 	return keys.Encryption, keys.Signature, nil
 }
 
-func getMasterKeysFromEnvironment() (*SerializedKeys, error) {
-	base64value := os.Getenv(keystoreV1.AcraMasterKeyVarName)
+func getMasterKeysFromEnvironment(varname string) (*SerializedKeys, error) {
+	base64value := os.Getenv(varname)
 	if len(base64value) == 0 {
 		return nil, keystoreV1.ErrEmptyMasterKey
 	}

--- a/tests/test.py
+++ b/tests/test.py
@@ -2459,7 +2459,7 @@ class TestKeyStoreMigration(BaseTestCase):
                 '--dst_keystore={}'.format(new_version),
             ],
             env={'SRC_ACRA_MASTER_KEY': self.get_master_key(self.keystore_version),
-                 'DST_ACRA_MASTER_KEY': self.get_master_key(new_version)}
+                 'DST_ACRA_MASTER_KEY': self.get_master_key(new_version)},
             timeout=PROCESS_CALL_TIMEOUT)
 
         # Finalize the migration, replacing old key store with the new one.


### PR DESCRIPTION
One key to rule them all,
　one key to sign them,
One key to crypt them all
　and to the env vars bind them. 
<sub>I'm sorry. I could not resist the temptation.</sub>

So... Key store v2 requires two separate master keys: one for encryption of key material and another one for signing the key store metadata. The original idea was to naturally use two separate environment variables to supply the key values. While it is easy to code, it is not really easy for the users to use. They have to generate two separate keys, store them separately, set them up separately, while conceptually they are still just one “Acra master key”.

### What do we do with that

Instead of using two separate variables for key store v2, use the same ACRA_MASTER_KEY as key store v1 uses. However, instead of expecting base64-encoded key bytes there, we expect a base64-encoded JSON object with base64-encoded keys in it. This is the key format which can be generated with

    acra-keymaker --keystore=v2 --generate_master_key master.key

in one go, and then read in using

    export ACRA_MASTER_KEY=$(cat master.key | base64)

### Yo dawg, we heard you like base64?

While double-wrapping base64 may sound silly and wasteful, it simplifies setup flow for the users: always pass the key file to base64 before setting the ACRA_MASTER_KEY variable. There is no need to special case key store v2 just because it's already readable JSON inside.

For example, with key store v1 the master is simply 32 random bytes, encoded in base64 for the environment:

    5Tl/mehY/QhswVMn13QUvSu9MdSsm+JvRefWGF/zBsA=

while for key store v2 the key consists of two sets of 32 random bytes, wrapped into a JSON object:

    {
      "encryption":"dN6qtsv+yi1YeCCnKrHuGyn9vOdLVTkAd4/p7pfYIVk=",
      "signature":"lI4ziBwzWGIz5z7JUsKZgPfPeBHCquaxOaBl5ZMJnEo="
    }

which is then encoded in base64 again for ACRA_MASTER_KEY variable:

    eyJlbmNyeXB0aW9uIjoiZE42cXRzdit5aTFZZUNDbktySHVHeW45dk9kTFZUa0FkNC9wN3BmWUlWaz0iLCJzaWduYXR1cmUiOiJsSTR6aUJ3eldHSXo1ejdKVXNLWmdQZlBlQkhDcXVheE9hQmw1Wk1KbkVvPSJ9

While admittedly wasteful, this greatly simplifies the setup flow:

    acra-keymaker --keystore=v1 --generate_master_key master-key.v1
    export ACRA_MASTER_KEY=$(cat master-key.v1 | base64)

or s/v1/v2/g for key store v2.

### What are those other commits

#### Require --keystore version when generating master keys

Previously the `--generate_master_key` option did not require the user to specify the key store version. It always outputs a single symmetric key, and for key store v2 the user was supposed to generate two keys separately.

However, this is going to change. `acra-keymaker` will output a suitable master key in one call, even for key store v2. For this it will need to know which format to generate.

Make the `--keystore` option **required** when using `--generate_master_key` even if a master key for key store v1 is requested. This is a breaking change because from now on it will not be possible to use

    acra-keymaker --generate_master_key path/to/master.key

for key store v1 keys.

#### Use different variables for acra-migrate-keys

`acra-migrate-keys` deals with two separate key stores which may have different master keys. Instead of accepting master keys via the same `ACRA_MASTER_KEY` variable, use distinct `SRC_ACRA_MASTER_KEY` and `DST_ACRA_MASTER_KEY`, similar to how the command-line options use the same prefix.

Testing this is a bit move involved since previously migration tests expected that all variables are already configured and unchanged. Now this is not the case and we have to pass them explicitly, after generating a new set of master keys.