### PR TITLE
Spell "keystore" as a single word

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,14 +60,14 @@ jobs:
       - run: python3 tests/generate_random_data.py
       # each iteration pass to test different ports for forks to avoid problems with TCP TIME WAIT between tests
       - run:
-          name: Integration tests (key store v1)
+          name: Integration tests (keystore v1)
           environment:
             TEST_KEYSTORE: v1
           command: |
             .circleci/integration.sh
             if [ -f  $FILEPATH_ERROR_FLAG ]; then cat "$FILEPATH_ERROR_FLAG"; rm "$FILEPATH_ERROR_FLAG"; exit 1; fi
       - run:
-          name: Integration tests (key store v2)
+          name: Integration tests (keystore v2)
           environment:
             TEST_KEYSTORE: v2
           command: |
@@ -108,14 +108,14 @@ jobs:
       - run: python3 tests/generate_random_data.py
       # each iteration pass to test different ports for forks to avoid problems with TCP TIME WAIT between tests
       - run:
-          name: Integration tests (key store v1)
+          name: Integration tests (keystore v1)
           environment:
             TEST_KEYSTORE: v1
           command: |
             .circleci/integration.sh
             if [ -f  $FILEPATH_ERROR_FLAG ]; then cat "$FILEPATH_ERROR_FLAG"; rm "$FILEPATH_ERROR_FLAG"; exit 1; fi
       - run:
-          name: Integration tests (key store v2)
+          name: Integration tests (keystore v2)
           environment:
             TEST_KEYSTORE: v2
           command: |
@@ -161,14 +161,14 @@ jobs:
     - run: python3 tests/generate_random_data.py
     # each iteration pass to test different ports for forks to avoid problems with TCP TIME WAIT between tests
     - run:
-        name: Integration tests (key store v1)
+        name: Integration tests (keystore v1)
         environment:
           TEST_KEYSTORE: v1
         command: |
           .circleci/integration.sh
           if [ -f  $FILEPATH_ERROR_FLAG ]; then cat "$FILEPATH_ERROR_FLAG"; rm "$FILEPATH_ERROR_FLAG"; exit 1; fi
     - run:
-        name: Integration tests (key store v2)
+        name: Integration tests (keystore v2)
         environment:
           TEST_KEYSTORE: v2
         command: |
@@ -214,14 +214,14 @@ jobs:
       - run: python3 tests/generate_random_data.py
       # each iteration pass to test different ports for forks to avoid problems with TCP TIME WAIT between tests
       - run:
-          name: Integration tests (key store v1)
+          name: Integration tests (keystore v1)
           environment:
             TEST_KEYSTORE: v1
           command: |
             .circleci/integration.sh
             if [ -f  $FILEPATH_ERROR_FLAG ]; then cat "$FILEPATH_ERROR_FLAG"; rm "$FILEPATH_ERROR_FLAG"; exit 1; fi
       - run:
-          name: Integration tests (key store v2)
+          name: Integration tests (keystore v2)
           environment:
             TEST_KEYSTORE: v2
           command: |
@@ -267,14 +267,14 @@ jobs:
     - run: python3 tests/generate_random_data.py
     # each iteration pass to test different ports for forks to avoid problems with TCP TIME WAIT between tests
     - run:
-        name: Integration tests (key store v1)
+        name: Integration tests (keystore v1)
         environment:
           TEST_KEYSTORE: v1
         command: |
           .circleci/integration.sh
           if [ -f  $FILEPATH_ERROR_FLAG ]; then cat "$FILEPATH_ERROR_FLAG"; rm "$FILEPATH_ERROR_FLAG"; exit 1; fi
     - run:
-        name: Integration tests (key store v2)
+        name: Integration tests (keystore v2)
         environment:
           TEST_KEYSTORE: v2
         command: |
@@ -318,14 +318,14 @@ jobs:
       - run: python3 tests/generate_random_data.py
       # each iteration pass to test different ports for forks to avoid problems with TCP TIME WAIT between tests
       - run:
-          name: Integration tests (key store v1)
+          name: Integration tests (keystore v1)
           environment:
             TEST_KEYSTORE: v1
           command: |
             .circleci/integration.sh
             if [ -f  $FILEPATH_ERROR_FLAG ]; then cat "$FILEPATH_ERROR_FLAG"; rm "$FILEPATH_ERROR_FLAG"; exit 1; fi
       - run:
-          name: Integration tests (key store v2)
+          name: Integration tests (keystore v2)
           environment:
             TEST_KEYSTORE: v2
           command: |

--- a/cmd/acra-addzone/acra-addzone.go
+++ b/cmd/acra-addzone/acra-addzone.go
@@ -53,7 +53,7 @@ var (
 
 func main() {
 	outputDir := flag.String("keys_output_dir", keystore.DefaultKeyDirShort, "Folder where will be saved generated zone keys")
-	flag.Bool("fs_keystore_enable", true, "Use filesystem key store (deprecated, ignored)")
+	flag.Bool("fs_keystore_enable", true, "Use filesystem keystore (deprecated, ignored)")
 
 	logging.SetLogLevel(logging.LogVerbose)
 
@@ -97,7 +97,7 @@ func openKeyStoreV1(output string) keystore.StorageKeyCreation {
 	}
 	keyStore, err := filesystem.NewFilesystemKeyStore(output, scellEncryptor)
 	if err != nil {
-		log.WithError(err).Errorln("Can't init key store")
+		log.WithError(err).Errorln("Can't init keystore")
 		os.Exit(1)
 	}
 	return keyStore

--- a/cmd/acra-authmanager/acra_authmanager.go
+++ b/cmd/acra-authmanager/acra_authmanager.go
@@ -253,7 +253,7 @@ func openKeyStoreV1(keysDir string) keystore.WebConfigKeyStore {
 	}
 	keyStore, err := filesystem.NewFilesystemKeyStore(keysDir, encryptor)
 	if err != nil {
-		log.WithError(err).Errorln("Can't init key store")
+		log.WithError(err).Errorln("Can't init keystore")
 		os.Exit(1)
 	}
 	return keyStore

--- a/cmd/acra-keymaker/acra-keymaker.go
+++ b/cmd/acra-keymaker/acra-keymaker.go
@@ -92,7 +92,7 @@ func main() {
 	}
 
 	var store keystore.KeyMaking
-	// If the key store already exists, detect its version automatically and allow to not specify it.
+	// If the keystore already exists, detect its version automatically and allow to not specify it.
 	if *keystoreVersion == "" {
 		if filesystemV2.IsKeyDirectory(*outputDir) {
 			*keystoreVersion = "v2"

--- a/cmd/acra-keymaker/acra-keymaker.go
+++ b/cmd/acra-keymaker/acra-keymaker.go
@@ -53,7 +53,7 @@ func main() {
 	outputDir := flag.String("keys_output_dir", keystore.DefaultKeyDirShort, "Folder where will be saved keys")
 	outputPublicKey := flag.String("keys_public_output_dir", keystore.DefaultKeyDirShort, "Folder where will be saved public key")
 	masterKey := flag.String("generate_master_key", "", "Generate new random master key and save to file")
-	keystoreVersion := flag.String("keystore", "", "set key store format: v1 (current), v2 (new)")
+	keystoreVersion := flag.String("keystore", "", "set keystore format: v1 (current), v2 (new)")
 
 	logging.SetLogLevel(logging.LogVerbose)
 
@@ -74,7 +74,7 @@ func main() {
 		case "v2":
 			newKey, err = keystoreV2.NewSerializedMasterKeys()
 		case "":
-			log.Errorf("Key store version is required: --keystore={v1|v2}")
+			log.Errorf("Keystore version is required: --keystore={v1|v2}")
 			os.Exit(1)
 		default:
 			log.Errorf("Unknown --keystore option: %v", *keystoreVersion)
@@ -106,7 +106,7 @@ func main() {
 	case "v2":
 		store = openKeyStoreV2(*outputDir)
 	case "":
-		log.Errorf("Key store version is required: --keystore={v1|v2}")
+		log.Errorf("Keystore version is required: --keystore={v1|v2}")
 		os.Exit(1)
 	default:
 		log.Errorf("Unknown --keystore option: %v", *keystoreVersion)
@@ -184,7 +184,7 @@ func openKeyStoreV1(outputDir, outputPublicKey string) keystore.KeyMaking {
 		store, err = filesystem.NewFilesystemKeyStore(outputDir, scellEncryptor)
 	}
 	if err != nil {
-		log.WithError(err).Errorln("Can't init key store")
+		log.WithError(err).Errorln("Can't init keystore")
 		os.Exit(1)
 	}
 	return store

--- a/cmd/acra-keys/acra-keys.go
+++ b/cmd/acra-keys/acra-keys.go
@@ -16,12 +16,12 @@
 
 // Package main is entry point for `acra-keys` utility.
 //
-// It can access and maniplulate key stores:
+// It can access and maniplulate keystores:
 //
 //   - list keys
 //   - export keys
 //   - import keys
-//   - migrate key stores
+//   - migrate keystores
 //   - read key data
 //   - destroy keys
 package main

--- a/cmd/acra-keys/keys/acra-keys.go
+++ b/cmd/acra-keys/keys/acra-keys.go
@@ -28,8 +28,8 @@ import (
 )
 
 func warnKeystoreV2Only(command string) {
-	log.Error(fmt.Sprintf("\"%s\" is not implemented for key store v1", command))
-	log.Info("You can convert key store v1 into v2 with \"acra-keys migrate\"")
+	log.Error(fmt.Sprintf("\"%s\" is not implemented for keystore v1", command))
+	log.Info("You can convert keystore v1 into v2 with \"acra-keys migrate\"")
 	// TODO(ilammy, 2020-05-19): production documentation does not describe migration yet
 	log.Info("Read more: https://docs.cossacklabs.com/pages/documentation-acra/#key-management")
 }
@@ -71,7 +71,7 @@ func ExportKeysCommand(params ExportKeysParams, keyStore api.KeyStore) {
 	log.Infof("Exported key data is encrypted and saved here: %s", params.ExportDataFile())
 	log.Infof("New encryption keys for import generated here: %s", params.ExportKeysFile())
 	log.Infof("DO NOT transport or store these files together")
-	log.Infof("Import the keys into another key store like this:\n\tacra-keys import --key_bundle_file \"%s\" --key_bundle_secret \"%s\"", params.ExportDataFile(), params.ExportKeysFile())
+	log.Infof("Import the keys into another keystore like this:\n\tacra-keys import --key_bundle_file \"%s\" --key_bundle_secret \"%s\"", params.ExportDataFile(), params.ExportKeysFile())
 }
 
 // ImportKeysCommand implements the "import" command.

--- a/cmd/acra-keys/keys/destroy-key.go
+++ b/cmd/acra-keys/keys/destroy-key.go
@@ -104,7 +104,7 @@ func (p *DestroyKeySubcommand) Parse(arguments []string) error {
 func (p *DestroyKeySubcommand) Execute() {
 	keyStore, err := OpenKeyStoreForWriting(p)
 	if err != nil {
-		log.WithError(err).Fatal("Failed to open key store")
+		log.WithError(err).Fatal("Failed to open keystore")
 	}
 	DestroyKeyCommand(p, keyStore)
 }

--- a/cmd/acra-keys/keys/export.go
+++ b/cmd/acra-keys/keys/export.go
@@ -62,7 +62,7 @@ func (p *CommonExportImportParameters) ExportDataFile() string {
 	return p.exportDataFile
 }
 
-// Register registers key store flags with the given flag set.
+// Register registers keystore flags with the given flag set.
 func (p *CommonExportImportParameters) Register(flags *flag.FlagSet, filePurspose string) {
 	// The purpose is either "output" or "output". This is not very localizable, but we don't care about it at this point.
 	flags.StringVar(&p.exportDataFile, "key_bundle_file", "", "path to "+filePurspose+" file for exported key bundle")

--- a/cmd/acra-keys/keys/export.go
+++ b/cmd/acra-keys/keys/export.go
@@ -119,7 +119,7 @@ func (p *ExportKeysSubcommand) RegisterFlags() {
 	p.FlagSet.BoolVar(&p.exportAll, "all", false, "export all keys")
 	p.FlagSet.BoolVar(&p.exportPrivate, "private_keys", false, "export private key data")
 	p.FlagSet.Usage = func() {
-		fmt.Fprintf(os.Stderr, "Command \"%s\": export keys from the key store\n", CmdExportKeys)
+		fmt.Fprintf(os.Stderr, "Command \"%s\": export keys from the keystore\n", CmdExportKeys)
 		fmt.Fprintf(os.Stderr, "\n\t%s %s [options...] --key_bundle_file <file> --key_bundle_secret <file> <key-ID...>\n", os.Args[0], CmdExportKeys)
 		fmt.Fprintf(os.Stderr, "\nOptions:\n")
 		cmd.PrintFlags(p.FlagSet)
@@ -153,7 +153,7 @@ func (p *ExportKeysSubcommand) Execute() {
 		if err == ErrNotImplementedV1 {
 			warnKeystoreV2Only(CmdExportKeys)
 		}
-		log.WithError(err).Fatal("Failed to open key store")
+		log.WithError(err).Fatal("Failed to open keystore")
 	}
 	ExportKeysCommand(p, keyStore)
 }
@@ -204,7 +204,7 @@ func (p *ImportKeysSubcommand) RegisterFlags() {
 	p.CommonExportImportParameters.Register(p.FlagSet, "input")
 	p.CommonKeyListingParameters.Register(p.FlagSet)
 	p.FlagSet.Usage = func() {
-		fmt.Fprintf(os.Stderr, "Command \"%s\": import keys into the key store\n", CmdImportKeys)
+		fmt.Fprintf(os.Stderr, "Command \"%s\": import keys into the keystore\n", CmdImportKeys)
 		fmt.Fprintf(os.Stderr, "\n\t%s %s [options...] --key_bundle_file <file> --key_bundle_secret <file>\n", os.Args[0], CmdImportKeys)
 		fmt.Fprintf(os.Stderr, "\nOptions:\n")
 		cmd.PrintFlags(p.FlagSet)
@@ -231,7 +231,7 @@ func (p *ImportKeysSubcommand) Execute() {
 		if err == ErrNotImplementedV1 {
 			warnKeystoreV2Only(CmdExportKeys)
 		}
-		log.WithError(err).Fatal("Failed to open key store")
+		log.WithError(err).Fatal("Failed to open keystore")
 	}
 	ImportKeysCommand(p, keyStore)
 }

--- a/cmd/acra-keys/keys/keystore.go
+++ b/cmd/acra-keys/keys/keystore.go
@@ -31,7 +31,7 @@ import (
 
 // KeyStoreFactory should return one of those errors when it is not able to construct requested key store.
 var (
-	ErrNotImplementedV1 = errors.New("not implemented for key store v1")
+	ErrNotImplementedV1 = errors.New("not implemented for keystore v1")
 )
 
 // KeyStoreParameters are parameters for DefaultKeyStoreFactory.

--- a/cmd/acra-keys/keys/keystore.go
+++ b/cmd/acra-keys/keys/keystore.go
@@ -29,7 +29,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// KeyStoreFactory should return one of those errors when it is not able to construct requested key store.
+// KeyStoreFactory should return one of those errors when it is not able to construct requested keystore.
 var (
 	ErrNotImplementedV1 = errors.New("not implemented for keystore v1")
 )
@@ -40,7 +40,7 @@ type KeyStoreParameters interface {
 	KeyDirPublic() string
 }
 
-// CommonKeyStoreParameters is a mix-in of command line parameters for key store construction.
+// CommonKeyStoreParameters is a mix-in of command line parameters for keystore construction.
 type CommonKeyStoreParameters struct {
 	keyDir       string
 	keyDirPublic string
@@ -59,12 +59,12 @@ func (p *CommonKeyStoreParameters) KeyDirPublic() string {
 	return p.keyDirPublic
 }
 
-// Register registers key store flags with the given flag set.
+// Register registers keystore flags with the given flag set.
 func (p *CommonKeyStoreParameters) Register(flags *flag.FlagSet) {
 	p.RegisterPrefixed(flags, DefaultKeyDirectory, "", "")
 }
 
-// RegisterPrefixed registers key store flags with the given flag set, using given prefix and description.
+// RegisterPrefixed registers keystore flags with the given flag set, using given prefix and description.
 func (p *CommonKeyStoreParameters) RegisterPrefixed(flags *flag.FlagSet, defaultKeysDir, flagPrefix, descriptionSuffix string) {
 	if descriptionSuffix != "" {
 		descriptionSuffix = " " + descriptionSuffix
@@ -73,7 +73,7 @@ func (p *CommonKeyStoreParameters) RegisterPrefixed(flags *flag.FlagSet, default
 	flags.StringVar(&p.keyDirPublic, flagPrefix+"keys_dir_public", "", "path to key directory for public keys"+descriptionSuffix)
 }
 
-// OpenKeyStoreForReading opens a key store suitable for reading keys.
+// OpenKeyStoreForReading opens a keystore suitable for reading keys.
 func OpenKeyStoreForReading(params KeyStoreParameters) (keystore.ServerKeyStore, error) {
 	if filesystemV2.IsKeyDirectory(params.KeyDir()) {
 		return openKeyStoreV2(params)
@@ -81,7 +81,7 @@ func OpenKeyStoreForReading(params KeyStoreParameters) (keystore.ServerKeyStore,
 	return openKeyStoreV1(params)
 }
 
-// OpenKeyStoreForWriting opens a key store suitable for modifications.
+// OpenKeyStoreForWriting opens a keystore suitable for modifications.
 func OpenKeyStoreForWriting(params KeyStoreParameters) (keystore.KeyMaking, error) {
 	if filesystemV2.IsKeyDirectory(params.KeyDir()) {
 		return openKeyStoreV2(params)
@@ -89,7 +89,7 @@ func OpenKeyStoreForWriting(params KeyStoreParameters) (keystore.KeyMaking, erro
 	return openKeyStoreV1(params)
 }
 
-// OpenKeyStoreForExport opens a key store suitable for export operations.
+// OpenKeyStoreForExport opens a keystore suitable for export operations.
 func OpenKeyStoreForExport(params KeyStoreParameters) (api.KeyStore, error) {
 	if filesystemV2.IsKeyDirectory(params.KeyDir()) {
 		return openKeyStoreV2(params)
@@ -98,7 +98,7 @@ func OpenKeyStoreForExport(params KeyStoreParameters) (api.KeyStore, error) {
 	return nil, ErrNotImplementedV1
 }
 
-// OpenKeyStoreForImport opens a key store suitable for import operations.
+// OpenKeyStoreForImport opens a keystore suitable for import operations.
 func OpenKeyStoreForImport(params KeyStoreParameters) (api.MutableKeyStore, error) {
 	if filesystemV2.IsKeyDirectory(params.KeyDir()) {
 		return openKeyStoreV2(params)

--- a/cmd/acra-keys/keys/list-keys.go
+++ b/cmd/acra-keys/keys/list-keys.go
@@ -34,7 +34,7 @@ type ListKeysParams interface {
 	UseJSON() bool
 }
 
-// CommonKeyListingParameters is a mix-in of command line parameters for key store listing.
+// CommonKeyListingParameters is a mix-in of command line parameters for keystore listing.
 type CommonKeyListingParameters struct {
 	useJSON bool
 }

--- a/cmd/acra-keys/keys/list-keys.go
+++ b/cmd/acra-keys/keys/list-keys.go
@@ -72,7 +72,7 @@ func (p *ListKeySubcommand) RegisterFlags() {
 	p.CommonKeyStoreParameters.Register(p.FlagSet)
 	p.CommonKeyListingParameters.Register(p.FlagSet)
 	p.FlagSet.Usage = func() {
-		fmt.Fprintf(os.Stderr, "Command \"%s\": list available keys in the key store\n", CmdListKeys)
+		fmt.Fprintf(os.Stderr, "Command \"%s\": list available keys in the keystore\n", CmdListKeys)
 		fmt.Fprintf(os.Stderr, "\n\t%s %s [options...]\n", os.Args[0], CmdListKeys)
 		fmt.Fprintf(os.Stderr, "\nOptions:\n")
 		cmd.PrintFlags(p.FlagSet)
@@ -88,7 +88,7 @@ func (p *ListKeySubcommand) Parse(arguments []string) error {
 func (p *ListKeySubcommand) Execute() {
 	keyStore, err := OpenKeyStoreForReading(p)
 	if err != nil {
-		log.WithError(err).Fatal("Failed to open key store")
+		log.WithError(err).Fatal("Failed to open keystore")
 	}
 	ListKeysCommand(p, keyStore)
 }

--- a/cmd/acra-keys/keys/migrate-keys.go
+++ b/cmd/acra-keys/keys/migrate-keys.go
@@ -59,8 +59,8 @@ const (
 
 // Command-line errors for "acra-keys migrate":
 var (
-	ErrMissingFormat = errors.New("key store format not specified")
-	ErrMissingKeyDir = errors.New("key directory not specified")
+	ErrMissingFormat = errors.New("keystore format not specified")
+	ErrMissingKeyDir = errors.New("keys directory not specified")
 )
 
 // SrcKeyStoreVersion returns source key store version.
@@ -106,14 +106,14 @@ func (m *MigrateKeysSubcommand) GetFlagSet() *flag.FlagSet {
 // RegisterFlags registers command-line flags of "acra-keys migrate".
 func (m *MigrateKeysSubcommand) RegisterFlags() {
 	m.flagSet = flag.NewFlagSet(CmdMigrateKeys, flag.ContinueOnError)
-	m.src.RegisterPrefixed(m.flagSet, "", "src_", "(old key store, source)")
-	m.dst.RegisterPrefixed(m.flagSet, "", "dst_", "(new key store, destination)")
-	m.flagSet.StringVar(&m.srcVersion, "src_keystore", "", "key store format to use: v1 (current), v2 (new)")
-	m.flagSet.StringVar(&m.dstVersion, "dst_keystore", "", "key store format to use: v1 (current), v2 (new)")
-	m.flagSet.BoolVar(&m.dryRun, "dry_run", false, "try migration without writing to the output key store")
-	m.flagSet.BoolVar(&m.force, "force", false, "write to output key store even if it exists")
+	m.src.RegisterPrefixed(m.flagSet, "", "src_", "(old keystore, source)")
+	m.dst.RegisterPrefixed(m.flagSet, "", "dst_", "(new keystore, destination)")
+	m.flagSet.StringVar(&m.srcVersion, "src_keystore", "", "keystore format to use: v1 (current), v2 (new)")
+	m.flagSet.StringVar(&m.dstVersion, "dst_keystore", "", "keystore format to use: v1 (current), v2 (new)")
+	m.flagSet.BoolVar(&m.dryRun, "dry_run", false, "try migration without writing to the output keystore")
+	m.flagSet.BoolVar(&m.force, "force", false, "write to output keystore even if it exists")
 	m.flagSet.Usage = func() {
-		fmt.Fprintf(os.Stderr, "Command \"%s\": migrate key store to a different format\n", CmdMigrateKeys)
+		fmt.Fprintf(os.Stderr, "Command \"%s\": migrate keystore to a different format\n", CmdMigrateKeys)
 		fmt.Fprintf(os.Stderr, "\n\t%s %s [options...] \\\n"+
 			"\t\t--src_keystore <src-version> --src_keys_dir <.acrakeys-src> \\\n"+
 			"\t\t--dst_keystore <dst-version> --dst_keys_dir <.acrakeys-dst>\n",
@@ -176,8 +176,8 @@ func (m *MigrateKeysSubcommand) Execute() {
 			log.WithError(err).Fatal("Migration failed")
 		}
 		log.Infof("Migration complete")
-		log.Infof("Old key store: %s", m.SrcKeyStoreParams().KeyDir())
-		log.Infof("New key store: %s", m.DstKeyStoreParams().KeyDir())
+		log.Infof("Old keystore: %s", m.SrcKeyStoreParams().KeyDir())
+		log.Infof("New keystore: %s", m.DstKeyStoreParams().KeyDir())
 		if m.DryRun() {
 			log.Infof("Run without --dry_run to actually write key data")
 		}
@@ -185,7 +185,7 @@ func (m *MigrateKeysSubcommand) Execute() {
 	}
 
 	log.WithFields(log.Fields{"src": m.SrcKeyStoreVersion(), "dst": m.DstKeyStoreVersion()}).
-		Fatal("Key store conversion not supported")
+		Fatal("Keystore conversion not supported")
 }
 
 // MigrateV1toV2 transfers keys from key store v1 to v2.
@@ -244,7 +244,7 @@ func (m *MigrateKeysSubcommand) openKeyStoreV1(keyVarName string, params KeyStor
 		keyStore, err = filesystemV1.NewFilesystemKeyStore(keyDir, encryptor)
 	}
 	if err != nil {
-		log.WithError(err).Error("Cannot init key store")
+		log.WithError(err).Error("Cannot init keystore")
 		return nil, err
 	}
 	return keyStore, nil
@@ -271,7 +271,7 @@ func (m *MigrateKeysSubcommand) openKeyStoreV2(keyVarName string, params KeyStor
 	if m.DryRun() {
 		keyDir, err = filesystemV2.NewInMemory(suite)
 		if err != nil {
-			log.WithError(err).Error("Cannot create in-memory key store")
+			log.WithError(err).Error("Cannot create in-memory keystore")
 			return nil, err
 		}
 	} else {

--- a/cmd/acra-keys/keys/migrate-keys.go
+++ b/cmd/acra-keys/keys/migrate-keys.go
@@ -63,22 +63,22 @@ var (
 	ErrMissingKeyDir = errors.New("keys directory not specified")
 )
 
-// SrcKeyStoreVersion returns source key store version.
+// SrcKeyStoreVersion returns source keystore version.
 func (m *MigrateKeysSubcommand) SrcKeyStoreVersion() string {
 	return m.srcVersion
 }
 
-// SrcKeyStoreParams returns parameters of the source key store.
+// SrcKeyStoreParams returns parameters of the source keystore.
 func (m *MigrateKeysSubcommand) SrcKeyStoreParams() KeyStoreParameters {
 	return &m.src
 }
 
-// DstKeyStoreVersion returns destination key store version.
+// DstKeyStoreVersion returns destination keystore version.
 func (m *MigrateKeysSubcommand) DstKeyStoreVersion() string {
 	return m.dstVersion
 }
 
-// DstKeyStoreParams returns parameters of the destination key store.
+// DstKeyStoreParams returns parameters of the destination keystore.
 func (m *MigrateKeysSubcommand) DstKeyStoreParams() KeyStoreParameters {
 	return &m.dst
 }
@@ -88,7 +88,7 @@ func (m *MigrateKeysSubcommand) DryRun() bool {
 	return m.dryRun
 }
 
-// ForceWrite returns true if migration is allowed to overwrite existing destination key store.
+// ForceWrite returns true if migration is allowed to overwrite existing destination keystore.
 func (m *MigrateKeysSubcommand) ForceWrite() bool {
 	return m.force
 }
@@ -188,7 +188,7 @@ func (m *MigrateKeysSubcommand) Execute() {
 		Fatal("Keystore conversion not supported")
 }
 
-// MigrateV1toV2 transfers keys from key store v1 to v2.
+// MigrateV1toV2 transfers keys from keystore v1 to v2.
 func MigrateV1toV2(srcV1 filesystemV1.KeyExport, dstV2 keystoreV2.KeyFileImportV1) error {
 	log.Trace("Enumerating keys for export")
 	keys, err := filesystemV1.EnumerateExportedKeys(srcV1)

--- a/cmd/acra-keys/keys/read-key.go
+++ b/cmd/acra-keys/keys/read-key.go
@@ -128,7 +128,7 @@ func (p *ReadKeySubcommand) Parse(arguments []string) error {
 func (p *ReadKeySubcommand) Execute() {
 	keyStore, err := OpenKeyStoreForReading(p)
 	if err != nil {
-		log.WithError(err).Fatal("Failed to open key store")
+		log.WithError(err).Fatal("Failed to open keystore")
 	}
 	PrintKeyCommand(p, keyStore)
 }

--- a/cmd/acra-poisonrecordmaker/acra-poisonrecordmaker.go
+++ b/cmd/acra-poisonrecordmaker/acra-poisonrecordmaker.go
@@ -89,7 +89,7 @@ func openKeyStoreV1(keysDir string) keystore.PoisonKeyStore {
 	}
 	store, err := filesystem.NewFilesystemKeyStore(keysDir, scellEncryptor)
 	if err != nil {
-		log.WithError(err).Errorln("can't initialize key store")
+		log.WithError(err).Errorln("can't initialize keystore")
 		os.Exit(1)
 	}
 	return store

--- a/cmd/acra-rollback/acra-rollback.go
+++ b/cmd/acra-rollback/acra-rollback.go
@@ -315,7 +315,7 @@ func openKeyStoreV1(keysDir string) keystore.DecryptionKeyStore {
 	}
 	keystorage, err := filesystem.NewFilesystemKeyStore(keysDir, scellEncryptor)
 	if err != nil {
-		log.WithError(err).Errorln("Can't initialize key store")
+		log.WithError(err).Errorln("Can't initialize keystore")
 		os.Exit(1)
 	}
 	return keystorage

--- a/cmd/acra-rotate/acra-rotate.go
+++ b/cmd/acra-rotate/acra-rotate.go
@@ -55,7 +55,7 @@ func openKeyStoreV1(dirPath string) keystore.RotateStorageKeyStore {
 	}
 	keystorage, err := filesystem.NewFilesystemKeyStore(dirPath, scellEncryptor)
 	if err != nil {
-		log.WithError(err).Errorln("can't initialize key store")
+		log.WithError(err).Errorln("can't initialize keystore")
 		os.Exit(1)
 	}
 	return keystorage

--- a/configs/acra-addzone.yaml
+++ b/configs/acra-addzone.yaml
@@ -5,7 +5,7 @@ config_file:
 # dump config
 dump_config: false
 
-# Use filesystem key store (deprecated, ignored)
+# Use filesystem keystore (deprecated, ignored)
 fs_keystore_enable: true
 
 # Generate with yaml config markdown text file with descriptions of all args

--- a/configs/acra-keymaker.yaml
+++ b/configs/acra-keymaker.yaml
@@ -35,6 +35,6 @@ keys_output_dir: .acrakeys
 # Folder where will be saved public key
 keys_public_output_dir: .acrakeys
 
-# set key store format: v1 (current), v2 (new)
+# set keystore format: v1 (current), v2 (new)
 keystore: 
 

--- a/configs/acra-keys.yaml
+++ b/configs/acra-keys.yaml
@@ -29,28 +29,28 @@ key_bundle_secret:
 # export private key data
 private_keys: false
 
-# try migration without writing to the output key store
+# try migration without writing to the output keystore
 dry_run: false
 
-# path to key directory (new key store, destination)
+# path to key directory (new keystore, destination)
 dst_keys_dir: 
 
-# path to key directory for public keys (new key store, destination)
+# path to key directory for public keys (new keystore, destination)
 dst_keys_dir_public: 
 
-# key store format to use: v1 (current), v2 (new)
+# keystore format to use: v1 (current), v2 (new)
 dst_keystore: 
 
-# write to output key store even if it exists
+# write to output keystore even if it exists
 force: false
 
-# path to key directory (old key store, source)
+# path to key directory (old keystore, source)
 src_keys_dir: 
 
-# path to key directory for public keys (old key store, source)
+# path to key directory for public keys (old keystore, source)
 src_keys_dir_public: 
 
-# key store format to use: v1 (current), v2 (new)
+# keystore format to use: v1 (current), v2 (new)
 src_keystore: 
 
 # client ID for which to retrieve key

--- a/decryptor/base/decryptor.go
+++ b/decryptor/base/decryptor.go
@@ -109,7 +109,7 @@ type DataDecryptor interface {
 type Decryptor interface {
 	DataDecryptor
 	DecryptionSubscriber
-	// register key store that will be used for retrieving private keys
+	// register keystore that will be used for retrieving private keys
 	SetKeyStore(keystore.DecryptionKeyStore)
 	// Return private keys for current connected client used to decrypt
 	// symmetric keys embedded in AcraStructs

--- a/decryptor/base/proxy.go
+++ b/decryptor/base/proxy.go
@@ -63,7 +63,7 @@ func (p *proxySetting) TableSchemaStore() config.TableSchemaStore {
 	return p.tableSchemaStore
 }
 
-// KeyStore return key store
+// KeyStore return keystore
 func (p *proxySetting) KeyStore() keystore.DecryptionKeyStore {
 	return p.keystore
 }

--- a/keystore/filesystem/connector_keystore.go
+++ b/keystore/filesystem/connector_keystore.go
@@ -34,7 +34,7 @@ type ConnectorFileSystemKeyStore struct {
 	connectorMode connector_mode.ConnectorMode
 }
 
-// ConnectorFileSystemKeyStoreBuilder allows to build a custom key store.
+// ConnectorFileSystemKeyStoreBuilder allows to build a custom keystore.
 type ConnectorFileSystemKeyStoreBuilder struct {
 	directory     string
 	clientID      []byte
@@ -43,7 +43,7 @@ type ConnectorFileSystemKeyStoreBuilder struct {
 	connectorMode connector_mode.ConnectorMode
 }
 
-// NewCustomConnectorFileSystemKeyStore allows to customize a translator key store.
+// NewCustomConnectorFileSystemKeyStore allows to customize a translator keystore.
 func NewCustomConnectorFileSystemKeyStore() *ConnectorFileSystemKeyStoreBuilder {
 	return &ConnectorFileSystemKeyStoreBuilder{
 		storage: &DummyStorage{},
@@ -85,7 +85,7 @@ func (b *ConnectorFileSystemKeyStoreBuilder) ConnectorMode(connectorMode connect
 	return b
 }
 
-// Build a key store.
+// Build a keystore.
 func (b *ConnectorFileSystemKeyStoreBuilder) Build() (*ConnectorFileSystemKeyStore, error) {
 	if b.directory == "" {
 		return nil, errNoPrivateKeyDir

--- a/keystore/filesystem/key_export.go
+++ b/keystore/filesystem/key_export.go
@@ -48,7 +48,7 @@ type KeyFileClassifier interface {
 	ClassifyExportedKey(path string) *ExportedKey
 }
 
-// ExportedKey describes a key that can be exported from key store.
+// ExportedKey describes a key that can be exported from keystore.
 //
 // `Purpose` describes the purpose of this key.
 // This is one of the `Purpose...` constants exported by this module.
@@ -181,7 +181,7 @@ func EnumerateExportedKeysByClass(enumerator KeyExportEnumerator, classifier Key
 	return exportedKeys, nil
 }
 
-// EnumerateExportedKeyPaths returns a list of key paths that can be exported from this key store.
+// EnumerateExportedKeyPaths returns a list of key paths that can be exported from this keystore.
 func (store *KeyStore) EnumerateExportedKeyPaths() ([]string, error) {
 	paths := make([]string, 0)
 

--- a/keystore/filesystem/server_keystore.go
+++ b/keystore/filesystem/server_keystore.go
@@ -75,7 +75,7 @@ func NewFilesystemKeyStoreTwoPath(privateKeyFolder, publicKeyFolder string, encr
 	return NewCustomFilesystemKeyStore().KeyDirectories(privateKeyFolder, publicKeyFolder).Encryptor(encryptor).Build()
 }
 
-// KeyStoreBuilder allows to build a custom key store.
+// KeyStoreBuilder allows to build a custom keystore.
 type KeyStoreBuilder struct {
 	privateKeyDir string
 	publicKeyDir  string
@@ -145,10 +145,10 @@ func (b *KeyStoreBuilder) Build() (*KeyStore, error) {
 	return newFilesystemKeyStore(b.privateKeyDir, b.publicKeyDir, b.storage, b.encryptor, b.cacheSize)
 }
 
-// IsKeyDirectory checks if the local directory contains a key store.
+// IsKeyDirectory checks if the local directory contains a keystore.
 // This is a conservative check.
-// That is, positive return value does not mean that the directory contains *a valid* key store.
-// However, false value means that the directory definitely is not a valid key store.
+// That is, positive return value does not mean that the directory contains *a valid* keystore.
+// However, false value means that the directory definitely is not a valid keystore.
 // In particular, false is returned if the directory does not exists or cannot be opened.
 func IsKeyDirectory(keyDirectory string) bool {
 	fi, err := os.Stat(keyDirectory)
@@ -631,9 +631,9 @@ func (store *KeyStore) GenerateDataEncryptionKeys(id []byte) error {
 	return nil
 }
 
-// ListKeys enumerates keys present in the key store.
+// ListKeys enumerates keys present in the keystore.
 func (store *KeyStore) ListKeys() ([]keystore.KeyDescription, error) {
-	// In Acra CE this method is implemented only for key store v2.
+	// In Acra CE this method is implemented only for keystore v2.
 	return nil, keystore.ErrNotImplemented
 }
 
@@ -738,7 +738,7 @@ func (store *KeyStore) destroyKeyWithFilename(filename string) error {
 	store.cache.Add(filename, nil)
 
 	// Remove key files. It's okay if they are already removed (or never existed).
-	// Key store v1 does not differentiate between 'destroying' and 'removing' keys
+	// Keystore v1 does not differentiate between 'destroying' and 'removing' keys
 	// because multiple functinons depend on the key file to be absent, not empty.
 	err := store.fs.Remove(store.GetPrivateKeyFilePath(filename))
 	if err != nil && !os.IsNotExist(err) {

--- a/keystore/filesystem/server_keystore.go
+++ b/keystore/filesystem/server_keystore.go
@@ -180,8 +180,8 @@ func newFilesystemKeyStore(privateKeyFolder, publicKeyFolder string, storage Sto
 	if !os.IsNotExist(err) {
 		const expectedPermission = "-rwx------"
 		if runtime.GOOS == "linux" && fi.Mode().Perm().String() != expectedPermission {
-			log.Errorf("Key store folder has an incorrect permissions %s, expected: %s", fi.Mode().Perm().String(), expectedPermission)
-			return nil, errors.New("key store folder has an incorrect permissions")
+			log.Errorf("Keystore folder has an incorrect permissions %s, expected: %s", fi.Mode().Perm().String(), expectedPermission)
+			return nil, errors.New("keystore folder has an incorrect permissions")
 		}
 	}
 	_, err = storage.Stat(publicKeyFolder)

--- a/keystore/filesystem/server_keystore_test.go
+++ b/keystore/filesystem/server_keystore_test.go
@@ -456,7 +456,7 @@ func TestFilesystemKeyStoreExport(t *testing.T) {
 	publicKeys := filepath.Join(keyDirectory, "public")
 	privateKeys := filepath.Join(keyDirectory, "private")
 
-	// Prepare key store
+	// Prepare keystore
 	encryptor, err := keystore.NewSCellKeyEncryptor([]byte("test key"))
 	if err != nil {
 		t.Fatalf("failed to initialize encryptor: %v", err)
@@ -493,7 +493,7 @@ func TestFilesystemKeyStoreExport(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetZonePrivateKey() failed: %v", err)
 	}
-	// Since we cannot access all generated key pairs via AcraServer key store,
+	// Since we cannot access all generated key pairs via AcraServer keystore,
 	// we generate them here and use Save... API
 	connectorKeyPair, err := keys.New(keys.TypeEC)
 	err = keyStore.SaveConnectorKeypair(clientID, connectorKeyPair)

--- a/keystore/filesystem/server_keystore_test.go
+++ b/keystore/filesystem/server_keystore_test.go
@@ -463,7 +463,7 @@ func TestFilesystemKeyStoreExport(t *testing.T) {
 	}
 	keyStore, err := NewFilesystemKeyStoreTwoPath(privateKeys, publicKeys, encryptor)
 	if err != nil {
-		t.Fatalf("failed to initialize key store: %v", err)
+		t.Fatalf("failed to initialize keystore: %v", err)
 	}
 
 	// Prepare various keys for testing.

--- a/keystore/filesystem/translator_keystore.go
+++ b/keystore/filesystem/translator_keystore.go
@@ -30,14 +30,14 @@ type TranslatorFileSystemKeyStore struct {
 	encryptor keystore.KeyEncryptor
 }
 
-// TranslatorFileSystemKeyStoreBuilder allows to build a custom key store.
+// TranslatorFileSystemKeyStoreBuilder allows to build a custom keystore.
 type TranslatorFileSystemKeyStoreBuilder struct {
 	keyStoreBuilder *KeyStoreBuilder
 	directory       string
 	encryptor       keystore.KeyEncryptor
 }
 
-// NewCustomTranslatorFileSystemKeyStore allows to customize a translator key store.
+// NewCustomTranslatorFileSystemKeyStore allows to customize a translator keystore.
 func NewCustomTranslatorFileSystemKeyStore() *TranslatorFileSystemKeyStoreBuilder {
 	return &TranslatorFileSystemKeyStoreBuilder{
 		keyStoreBuilder: NewCustomFilesystemKeyStore(),
@@ -64,7 +64,7 @@ func (b *TranslatorFileSystemKeyStoreBuilder) Storage(storage Storage) *Translat
 	return b
 }
 
-// Build a key store.
+// Build a keystore.
 func (b *TranslatorFileSystemKeyStoreBuilder) Build() (*TranslatorFileSystemKeyStore, error) {
 	if b.directory == "" {
 		return nil, errNoPrivateKeyDir

--- a/keystore/keystore.go
+++ b/keystore/keystore.go
@@ -207,7 +207,7 @@ type DecryptionKeyStore interface {
 	PoisonKeyStore
 }
 
-// KeyMaking enables key store initialization. It is used by acra-keymaker tool.
+// KeyMaking enables keystore initialization. It is used by acra-keymaker tool.
 type KeyMaking interface {
 	StorageKeyCreation
 	TransportKeyCreation
@@ -238,9 +238,9 @@ type ServerKeyStore interface {
 	Reset()
 }
 
-// KeyDescription describes a key in the key store.
+// KeyDescription describes a key in the keystore.
 //
-// "ID" is unique string that can be used to identify this key set in the key store.
+// "ID" is unique string that can be used to identify this key set in the keystore.
 // "Purpose" is short human-readable description of the key purpose.
 // "ClientID" and "ZoneID" are filled in where relevant.
 type KeyDescription struct {

--- a/keystore/v2/keystore/api/keyRing.go
+++ b/keystore/v2/keystore/api/keyRing.go
@@ -79,7 +79,7 @@ type KeyDescription struct {
 	Data       []KeyData
 }
 
-// KeyData contains plaintext key data to be added to key store.
+// KeyData contains plaintext key data to be added to keystore.
 // Only relevant fields are stored. They must be filled according to the format.
 type KeyData struct {
 	Format       KeyFormat

--- a/keystore/v2/keystore/api/keyStore.go
+++ b/keystore/v2/keystore/api/keyStore.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-// Package api describes API of Acra Key Store version 2.
+// Package api describes API of Acra Keystore version 2.
 package api
 
 import (
@@ -32,12 +32,12 @@ type KeyStore interface {
 	// This generally renders opened KeyRings unusable.
 	Close() error
 
-	// ListKeyRings enumerates all key rings present in this key store.
+	// ListKeyRings enumerates all key rings present in this keystore.
 	ListKeyRings() ([]string, error)
 
 	// ExportKeyRings packages specified key rings for export.
 	// Key ring data is encrypted and signed using given cryptosuite.
-	// Resulting container can be imported into existing or different key store with ImportKeyRings().
+	// Resulting container can be imported into existing or different keystore with ImportKeyRings().
 	ExportKeyRings(paths []string, cryptosuite *crypto.KeyStoreSuite, mode ExportMode) ([]byte, error)
 
 	// DescribeKeyRing describes key ring by its purpose path.

--- a/keystore/v2/keystore/api/tests/keyRing.go
+++ b/keystore/v2/keystore/api/tests/keyRing.go
@@ -264,7 +264,7 @@ func testKeyRingDestroyingKeys(t *testing.T, newKeyStore NewKeyStore) {
 
 	var keyData []byte
 
-	// Do a health check on the key store. Make sure it keeps the data right now.
+	// Do a health check on the keystore. Make sure it keeps the data right now.
 	keyData, err = ring.PrivateKey(keyV1, api.ThemisKeyPairFormat)
 	if err != nil {
 		t.Fatalf("failed to get private key v1 data: %v", err)

--- a/keystore/v2/keystore/api/tests/keyStore.go
+++ b/keystore/v2/keystore/api/tests/keyStore.go
@@ -557,7 +557,7 @@ func testKeyStoreListing(t *testing.T, newKeyStore NewKeyStore) {
 	}
 
 	if len(keyRingsBefore) != 0 {
-		t.Errorf("key store is not empty initially")
+		t.Errorf("keystore is not empty initially")
 	}
 
 	if len(keyRingsAfter) != 3 {

--- a/keystore/v2/keystore/asn1/asn1.go
+++ b/keystore/v2/keystore/asn1/asn1.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-// Package asn1 contains descriptions of ASN.1 data structures used by Key Store.
+// Package asn1 contains descriptions of ASN.1 data structures used by Keystore.
 package asn1
 
 import (
@@ -34,7 +34,7 @@ var (
 	Sha256OID = asn1.ObjectIdentifier([]int{2, 16, 840, 1, 101, 3, 4, 2, 1})
 )
 
-// SignedContainer for a signed object. Every exported object of the key store
+// SignedContainer for a signed object. Every exported object of the keystore
 // is packed into a SignedContainer for storage. For example, file-based key
 // store keeps a file for each key directory. Every file contains a SignedContainer
 // with "ContentType" equal to 'TypeKeyDirectory' and a KeyDirectory stored
@@ -113,7 +113,7 @@ const (
 // Signature for SignedContainer. A container can have multiple signatures
 // made with different algorithms, enabling future-proofing, extensibility,
 // and collision resistance. Signatures are computed for the "Payload" of
-// SignedContainer, usually with HMAC keyed by the key store master key.
+// SignedContainer, usually with HMAC keyed by the keystore master key.
 // The signing algorithm is indicated by the "Algorithm" field.
 type Signature struct {
 	Algorithm asn1.ObjectIdentifier
@@ -231,7 +231,7 @@ func (r *KeyRing) KeyWithSeqnum(seqnum int) (*Key, int) {
 	return nil, NoKey
 }
 
-// Key stored in the key store. The key is identified by its content and can have
+// Key stored in the keystore. The key is identified by its content and can have
 // multiple representations. It also has some metadata pertaining to its usage
 // restrictions.
 type Key struct {

--- a/keystore/v2/keystore/asn1/keyStoreFormat.asn1
+++ b/keystore/v2/keystore/asn1/keyStoreFormat.asn1
@@ -12,9 +12,9 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
--- ASN.1 grammar defining format of Acra Key Store, version 2.
+-- ASN.1 grammar defining format of Acra Keystore, version 2.
 --
--- Version 2 key stores are represented as hierarchy of key directories
+-- Version 2 keystores are represented as hierarchy of key directories
 -- usually stored in DER encoding as filsystem hierarchies.
 --
 -- Version 1 uses flat list of binary files to store each key individually.
@@ -22,9 +22,9 @@
 -- each of them stores a single Themis private key.
 AcraKeyStoreV2 DEFINITIONS IMPLICIT TAGS ::= BEGIN
 
--- Container for a signed object. Every exported object of the key store
+-- Container for a signed object. Every exported object of the keystore
 -- is packed into a SignedContainer for storage. For example, file-based
--- key store keeps a file for each key directory. Every file contains
+-- keystore keeps a file for each key directory. Every file contains
 -- a SignedContainer with "contentType" equal to 'typeKeyDirectory'
 -- and a KeyDirectory stored in its "data" field.
 SignedContainer ::= SEQUENCE {
@@ -49,7 +49,7 @@ ContentType ::= ENUMERATED {
 -- Signature for SignedContainer. A container can have multiple signatures
 -- made with different algorithms, enabling future-proofing, extensibility,
 -- and collision resistance. Signatures are computed for the "payload" of
--- SignedContainer, usually with HMAC keyed by the key store master key.
+-- SignedContainer, usually with HMAC keyed by the keystore master key.
 -- The signing algorithm is indicated by the "algorithm" field.
 Signature ::= SEQUENCE {
     algorithm   OBJECT IDENTIFIER,  -- signature algorithm
@@ -108,7 +108,7 @@ KeyRing ::= SEQUENCE {
     current     INTEGER             -- seqnum of current key (-1 if none)
 }
 
--- Cryptographic key stored in the key store. The key is identified by its
+-- Cryptographic key stored in the keystore. The key is identified by its
 -- content and can have multiple representations. It also has some metadata
 -- pertaining to its usage restrictions.
 Key ::= SEQUENCE {

--- a/keystore/v2/keystore/crypto.go
+++ b/keystore/v2/keystore/crypto.go
@@ -130,7 +130,7 @@ func getMasterKeysFromEnvironment(varname string) (*SerializedKeys, error) {
 
 // NewSCellSuite creates default cryptography suite for KeyStore:
 // - keys are encrypted by Themis Secure Cell in Seal mode
-// - key store is signed with HMAC-SHA-256
+// - keystore is signed with HMAC-SHA-256
 func NewSCellSuite(encryptionKey, signatureKey []byte) (*crypto.KeyStoreSuite, error) {
 	return crypto.NewSCellSuite(encryptionKey, signatureKey)
 }

--- a/keystore/v2/keystore/crypto/crypto.go
+++ b/keystore/v2/keystore/crypto/crypto.go
@@ -33,7 +33,7 @@ type KeyStoreSuite struct {
 
 // NewSCellSuite creates default cryptography suite for KeyStore:
 // - keys are encrypted by Themis Secure Cell in Seal mode
-// - key store is signed with HMAC-SHA-256
+// - keystore is signed with HMAC-SHA-256
 func NewSCellSuite(encryptionKey, signatureKey []byte) (*KeyStoreSuite, error) {
 	encryptor, err := keystoreV1.NewSCellKeyEncryptor(encryptionKey)
 	if err != nil {

--- a/keystore/v2/keystore/filesystem/backend/filesystem.go
+++ b/keystore/v2/keystore/filesystem/backend/filesystem.go
@@ -415,7 +415,7 @@ func (b *DirectoryBackend) doRenameNX(oldpath, newpath string) error {
 	// Not all filesystems support "exclusive" rename and "os" API does not export
 	// a function for such rename. We do not make atomicity promises in Backend,
 	// but do our best to avoid race conditions here. Hard links should succeed
-	// because key store should be located entirely on the same filesystem.
+	// because keystore should be located entirely on the same filesystem.
 	err := os.Link(oldpath, newpath)
 	if err != nil {
 		return err

--- a/keystore/v2/keystore/filesystem/backend/filesystem.go
+++ b/keystore/v2/keystore/filesystem/backend/filesystem.go
@@ -42,7 +42,7 @@ const (
 var (
 	ErrNotDirectory       = errors.New("root key directory is not a directory")
 	ErrInvalidPermissions = errors.New("invalid key directory access permissions")
-	ErrInvalidVersion     = errors.New("invalid key store version file content")
+	ErrInvalidVersion     = errors.New("invalid keystore version file content")
 )
 
 // DirectoryBackend keeps data in filesystem directory hierarchy.
@@ -138,7 +138,7 @@ func OpenDirectoryBackend(root string) (*DirectoryBackend, error) {
 	}
 	err = CheckDirectoryVersion(root)
 	if err != nil {
-		errLog.WithError(err).Debug("not a key store")
+		errLog.WithError(err).Debug("not a keystore")
 		return nil, err
 	}
 	lock, err := newFileLock(filepath.Join(root, lockFile))

--- a/keystore/v2/keystore/filesystem/backend/filesystem.go
+++ b/keystore/v2/keystore/filesystem/backend/filesystem.go
@@ -55,7 +55,7 @@ type DirectoryBackend struct {
 const (
 	lockFile      = ".lock"
 	versionFile   = "version"
-	versionString = "Acra Key Store v2"
+	versionString = "Acra Keystore v2"
 )
 
 // CreateDirectoryBackend opens a directory backend at given root path.

--- a/keystore/v2/keystore/filesystem/export.go
+++ b/keystore/v2/keystore/filesystem/export.go
@@ -74,7 +74,7 @@ func (s *KeyStore) importKeyRing(newRingData *asn1.KeyRing, delegate api.KeyRing
 	err := s.readKeyRing(keyRing)
 	switch err {
 	case nil:
-		// If the key store successfuly returned an existing key ring with the same name,
+		// If the keystore successfuly returned an existing key ring with the same name,
 		// we have to resolve this conflict somehow. Present both current and new versions
 		// to the delegate and let it decide how to proceed.
 		decision, err := delegate.DecideKeyRingOverwrite(keyRing.data, newRingData)
@@ -106,7 +106,7 @@ func (s *KeyStore) importKeyRing(newRingData *asn1.KeyRing, delegate api.KeyRing
 		return nil
 
 	default:
-		// Otherwise, this is some unexpected error from the key store. Abort import and get out.
+		// Otherwise, this is some unexpected error from the keystore. Abort import and get out.
 		return err
 	}
 }

--- a/keystore/v2/keystore/filesystem/keyRingTX.go
+++ b/keystore/v2/keystore/filesystem/keyRingTX.go
@@ -32,7 +32,7 @@ type keyRingTX interface {
 
 // Errors returned by transactions:
 var (
-	errTxConcurrentModification = errors.New("concurrent key store modification")
+	errTxConcurrentModification = errors.New("concurrent keystore modification")
 	errTxKeyNotFound            = errors.New("no key with such seqnum in key ring")
 	errTxKeyExists              = errors.New("duplicate key with seqnum in key ring")
 )

--- a/keystore/v2/keystore/filesystem/keyStore.go
+++ b/keystore/v2/keystore/filesystem/keyStore.go
@@ -33,12 +33,12 @@ import (
 
 const serviceName = "keystore"
 
-// Errors returned by basuc key store.
+// Errors returned by basic keystore.
 var (
 	ErrNotImplemented = errors.New("not implemented")
 )
 
-// KeyStore is a filesystem-like key store which keeps key rings in files.
+// KeyStore is a filesystem-like keystore which keeps key rings in files.
 //
 // What exactly is the underlying filesystem is somewhat flexible and controlled by filesystem.Backend.
 // Normally this is an actual filesystem but there are alternative implementations.
@@ -49,7 +49,7 @@ type KeyStore struct {
 	fs        backend.Backend
 }
 
-// OpenDirectory opens a read-only key store located in given directory.
+// OpenDirectory opens a read-only keystore located in given directory.
 func OpenDirectory(rootDir string, cryptosuite *crypto.KeyStoreSuite) (api.KeyStore, error) {
 	backend, err := backend.OpenDirectoryBackend(rootDir)
 	if err != nil {
@@ -58,7 +58,7 @@ func OpenDirectory(rootDir string, cryptosuite *crypto.KeyStoreSuite) (api.KeySt
 	return CustomKeyStore(backend, cryptosuite)
 }
 
-// OpenDirectoryRW opens a key store located in given directory.
+// OpenDirectoryRW opens a keystore located in given directory.
 // If the directory does not exist it will be created.
 func OpenDirectoryRW(rootDir string, cryptosuite *crypto.KeyStoreSuite) (api.MutableKeyStore, error) {
 	backend, err := backend.CreateDirectoryBackend(rootDir)
@@ -68,26 +68,26 @@ func OpenDirectoryRW(rootDir string, cryptosuite *crypto.KeyStoreSuite) (api.Mut
 	return CustomKeyStore(backend, cryptosuite)
 }
 
-// IsKeyDirectory checks if the directory contains a key store.
+// IsKeyDirectory checks if the directory contains a keystore.
 // This is a conservative check.
-// That is, positive return value does not mean that the directory contains *a valid* key store.
-// However, false value means that the directory definitely is not a valid key store.
+// That is, positive return value does not mean that the directory contains *a valid* keystore.
+// However, false value means that the directory definitely is not a valid keystore.
 // In particular, false is returned if the directory does not exists or cannot be opened.
 func IsKeyDirectory(rootDir string) bool {
 	return backend.CheckDirectoryVersion(rootDir) == nil
 }
 
-// NewInMemory returns a new, empty in-memory key store.
+// NewInMemory returns a new, empty in-memory keystore.
 // This is mostly useful for testing.
 func NewInMemory(cryptosuite *crypto.KeyStoreSuite) (api.MutableKeyStore, error) {
 	return CustomKeyStore(backend.NewInMemory(), cryptosuite)
 }
 
-// CustomKeyStore returns a configurable filesystem-based key store.
+// CustomKeyStore returns a configurable filesystem-based keystore.
 // This constructor is useful if you want to provide a custom filesystem backend.
 //
-// The backend will be closed when this key store is closed,
-// so a backend instance generally cannot be shared between key stores.
+// The backend will be closed when this keystore is closed,
+// so a backend instance generally cannot be shared between keystores.
 func CustomKeyStore(backend backend.Backend, cryptosuite *crypto.KeyStoreSuite) (api.MutableKeyStore, error) {
 	notary, err := signature.NewNotary(cryptosuite.SignatureAlgorithms)
 	if err != nil {
@@ -145,7 +145,7 @@ func (s *KeyStore) OpenKeyRingRW(path string) (api.MutableKeyRing, error) {
 	return ring, nil
 }
 
-// ListKeyRings enumerates all key rings present in this key store.
+// ListKeyRings enumerates all key rings present in this keystore.
 func (s *KeyStore) ListKeyRings() (rings []string, err error) {
 	err = s.fs.RLock()
 	if err != nil {
@@ -175,14 +175,14 @@ func (s *KeyStore) ListKeyRings() (rings []string, err error) {
 
 // DescribeKeyRing describes key ring by its purpose path.
 func (s *KeyStore) DescribeKeyRing(path string) (*keystoreV1.KeyDescription, error) {
-	// This is basic key store which does not define any particular key rings.
-	// This method will be overridden by actual key store implementation.
+	// This is basic keystore which does not define any particular key rings.
+	// This method will be overridden by actual keystore implementation.
 	return nil, ErrNotImplemented
 }
 
 // ExportKeyRings packages specified key rings for export.
 // Key ring data is encrypted and signed using given cryptosuite.
-// Resulting container can be imported into existing or different key store with ImportKeyRings().
+// Resulting container can be imported into existing or different keystore with ImportKeyRings().
 func (s *KeyStore) ExportKeyRings(paths []string, cryptosuite *crypto.KeyStoreSuite, mode api.ExportMode) ([]byte, error) {
 	keyRings, err := s.exportKeyRings(paths, mode)
 	if err != nil {

--- a/keystore/v2/keystore/filesystem/keyStore_test.go
+++ b/keystore/v2/keystore/filesystem/keyStore_test.go
@@ -63,7 +63,7 @@ func testFilesystemKeyStore(t *testing.T) (func(t *testing.T) api.MutableKeyStor
 		}
 		store, err := OpenDirectoryRW(testDir, testKeyStoreSuite(t))
 		if err != nil {
-			t.Fatalf("failed to create key store: %v", err)
+			t.Fatalf("failed to create keystore: %v", err)
 		}
 		return store
 	}
@@ -85,7 +85,7 @@ func TestKeyStoreOpeningDir(t *testing.T) {
 
 	_, err = OpenDirectory(rootPath, testKeyStoreSuite(t))
 	if err != backendAPI.ErrNotExist {
-		t.Errorf("opened non-existant key store: %v", err)
+		t.Errorf("opened non-existant keystore: %v", err)
 	}
 
 	if IsKeyDirectory(rootPath) {
@@ -94,7 +94,7 @@ func TestKeyStoreOpeningDir(t *testing.T) {
 
 	_, err = OpenDirectoryRW(rootPath, testKeyStoreSuite(t))
 	if err != nil {
-		t.Fatalf("failed to create key store: %v", err)
+		t.Fatalf("failed to create keystore: %v", err)
 	}
 
 	fi, err := os.Stat(rootPath)
@@ -176,7 +176,7 @@ func TestKeyStorePersistence(t *testing.T) {
 
 	s1, err := OpenDirectoryRW(testDir, testKeyStoreSuite(t))
 	if err != nil {
-		t.Fatalf("failed to open key store: %v", err)
+		t.Fatalf("failed to open keystore: %v", err)
 	}
 	s1.OpenKeyRingRW("my-keyring")
 	if err != nil {
@@ -185,7 +185,7 @@ func TestKeyStorePersistence(t *testing.T) {
 
 	s2, err := OpenDirectory(testDir, testKeyStoreSuite(t))
 	if err != nil {
-		t.Fatalf("failed to open key store (read-only): %v", err)
+		t.Fatalf("failed to open keystore (read-only): %v", err)
 	}
 	s2.OpenKeyRing("my-keyring")
 	if err != nil {

--- a/keystore/v2/keystore/importV1.go
+++ b/keystore/v2/keystore/importV1.go
@@ -28,7 +28,7 @@ var (
 	ErrUnknownPurpose = errors.New("unknown key purpose")
 )
 
-// KeyFileImportV1 defines how filesystem key store v1 keys are imported.
+// KeyFileImportV1 defines how filesystem keystore v1 keys are imported.
 type KeyFileImportV1 interface {
 	ImportKeyFileV1(oldKeyStore filesystemV1.KeyExport, key filesystemV1.ExportedKey) error
 }

--- a/keystore/v2/keystore/importV1_test.go
+++ b/keystore/v2/keystore/importV1_test.go
@@ -54,7 +54,7 @@ func TestImportKeyStoreV1(t *testing.T) {
 	}
 	keyStoreV1, err := filesystemV1.NewFilesystemKeyStore(keyDirV1, encryptor)
 	if err != nil {
-		t.Fatalf("failed to initialize key store v1: %v", err)
+		t.Fatalf("failed to initialize keystore v1: %v", err)
 	}
 
 	clientID := []byte("Tweedledee and Tweedledum")
@@ -66,7 +66,7 @@ func TestImportKeyStoreV1(t *testing.T) {
 	}
 	keyDirectoryV2, err := filesystemV2.OpenDirectoryRW(keyDirV2, suite)
 	if err != nil {
-		t.Fatalf("failed to initialize key store v2: %v", err)
+		t.Fatalf("failed to initialize keystore v2: %v", err)
 	}
 	keyStoreV2 := NewServerKeyStore(keyDirectoryV2)
 	keyStoreV2connectorServer := NewConnectorKeyStore(keyDirectoryV2, clientID, connectorMode.AcraServerMode)

--- a/keystore/v2/keystore/importV1_test.go
+++ b/keystore/v2/keystore/importV1_test.go
@@ -38,7 +38,7 @@ var (
 )
 
 func TestImportKeyStoreV1(t *testing.T) {
-	// Prepare root key store directory (for both versions)
+	// Prepare root keystore directory (for both versions)
 	rootDirectory, err := ioutil.TempDir(os.TempDir(), "import_test")
 	if err != nil {
 		t.Fatalf("failed to create key directory: %v", err)
@@ -47,7 +47,7 @@ func TestImportKeyStoreV1(t *testing.T) {
 	keyDirV1 := filepath.Join(rootDirectory, "v1")
 	keyDirV2 := filepath.Join(rootDirectory, "v2")
 
-	// Prepare key store v1
+	// Prepare keystore v1
 	encryptor, err := keystoreV1.NewSCellKeyEncryptor(testMasterKey)
 	if err != nil {
 		t.Fatalf("failed to initialize encryptor: %v", err)
@@ -59,7 +59,7 @@ func TestImportKeyStoreV1(t *testing.T) {
 
 	clientID := []byte("Tweedledee and Tweedledum")
 
-	// Prepare key store v2
+	// Prepare keystore v2
 	suite, err := cryptoV2.NewSCellSuite(testEncryptionKey, testSignatureKey)
 	if err != nil {
 		t.Fatalf("failed to initialize cryptosuite: %v", err)
@@ -98,7 +98,7 @@ func TestImportKeyStoreV1(t *testing.T) {
 	if err != nil {
 		t.Errorf("GetZonePrivateKey() failed: %v", err)
 	}
-	// Since we cannot access all generated key pairs via AcraServer key store,
+	// Since we cannot access all generated key pairs via AcraServer keystore,
 	// we generate them here and use Save... API
 	connectorKeyPairV1, err := keys.New(keys.TypeEC)
 	err = keyStoreV1.SaveConnectorKeypair(clientID, connectorKeyPairV1)
@@ -153,7 +153,7 @@ func TestImportKeyStoreV1(t *testing.T) {
 		t.Errorf("poison record key pair corrupted")
 	}
 	// Pay close attention here, transport keys are a bit complicated.
-	// They cannot be all accessed via server key store alone.
+	// They cannot be all accessed via server keystore alone.
 	serverPeerPublicKeyV2, err := keyStoreV2.GetPeerPublicKey(clientID)
 	if err != nil {
 		t.Errorf("GetPeerPublicKey() failed: %v", err)

--- a/keystore/v2/keystore/keyStore.go
+++ b/keystore/v2/keystore/keyStore.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-// Package keystore implements Acra Key Store version 2.
+// Package keystore implements Acra Keystore version 2.
 package keystore
 
 import (
@@ -30,7 +30,7 @@ import (
 
 const serviceName = "keystore"
 
-// Errors in key store listing and export.
+// Errors in keystore listing and export.
 var (
 	ErrUnrecognizedKeyPurpose = errors.New("key purpose not recognized")
 )
@@ -46,7 +46,7 @@ const (
 	PurposeTransportTranslator = "AcraTranslator transport key"
 )
 
-// ServerKeyStore provides full access to Acra Key Store.
+// ServerKeyStore provides full access to Acra Keystore.
 //
 // It is intended to be used by AcraServer components and uses server transport keys.
 type ServerKeyStore struct {
@@ -54,7 +54,7 @@ type ServerKeyStore struct {
 	log *log.Entry
 }
 
-// ConnectorKeyStore provides access to Acra Key Store for AcraConnector.
+// ConnectorKeyStore provides access to Acra Keystore for AcraConnector.
 //
 // This is the same as ServerKeyStore, but with AcraConnector transport keys.
 type ConnectorKeyStore struct {
@@ -63,20 +63,20 @@ type ConnectorKeyStore struct {
 	mode     connector_mode.ConnectorMode
 }
 
-// TranslatorKeyStore provides access to Acra Key Store for AcraTranslator.
+// TranslatorKeyStore provides access to Acra Keystore for AcraTranslator.
 //
 // This is the same as ServerKeyStore, but with AcraTranslator transport keys.
 type TranslatorKeyStore struct {
 	ServerKeyStore
 }
 
-// NewServerKeyStore configures key store for AcraServer.
+// NewServerKeyStore configures keystore for AcraServer.
 func NewServerKeyStore(keyStore api.MutableKeyStore) *ServerKeyStore {
 	return &ServerKeyStore{keyStore, log.WithField("service", serviceName)}
 }
 
-// NewConnectorKeyStore configures key store for AcraConnector.
-// Aside from key store you need to provide connecting clientID and connection mode.
+// NewConnectorKeyStore configures keystore for AcraConnector.
+// Aside from keystore you need to provide connecting clientID and connection mode.
 func NewConnectorKeyStore(keyStore api.MutableKeyStore, clientID []byte, mode connector_mode.ConnectorMode) *ConnectorKeyStore {
 	return &ConnectorKeyStore{
 		ServerKeyStore: ServerKeyStore{keyStore, log.WithField("service", serviceName)},
@@ -85,14 +85,14 @@ func NewConnectorKeyStore(keyStore api.MutableKeyStore, clientID []byte, mode co
 	}
 }
 
-// NewTranslatorKeyStore configures key store for AcraTranslator
+// NewTranslatorKeyStore configures keystore for AcraTranslator
 func NewTranslatorKeyStore(keyStore api.MutableKeyStore) *TranslatorKeyStore {
 	return &TranslatorKeyStore{
 		ServerKeyStore{keyStore, log.WithField("service", serviceName)},
 	}
 }
 
-// ListKeys enumerates keys present in the key store.
+// ListKeys enumerates keys present in the keystore.
 func (s *ServerKeyStore) ListKeys() ([]keystore.KeyDescription, error) {
 	keyRings, err := s.ListKeyRings()
 	if err != nil {

--- a/tests/test.py
+++ b/tests/test.py
@@ -787,7 +787,7 @@ class KeyMakerTest(unittest.TestCase):
                 }
                 value = json.dumps(keys).encode('ascii')
             else:
-                self.fail("key store version not supported")
+                self.fail("keystore version not supported")
 
             return {ACRA_MASTER_KEY_VAR_NAME: b64encode(value)}
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -317,7 +317,7 @@ def create_client_keypair(name, only_server=False, only_connector=False, only_st
 
 def exchange_client_public_keys(client, server_keys_dir, connector_keys_dir):
     if KEYSTORE_VERSION == 'v1':
-        # Older key stores expect the administrator to manually copy
+        # Older keystores expect the administrator to manually copy
         # the following public key files. They are not encrypted or
         # authenticated in any way.
         connector_key = '{}.pub'.format(client)
@@ -331,7 +331,7 @@ def exchange_client_public_keys(client, server_keys_dir, connector_keys_dir):
         shutil.copy(os.path.join(connector_keys_dir, connector_key),
                     server_keys_dir)
     else:
-        # Newer key stores have a bit more involved key transfer process.
+        # Newer keystores have a bit more involved key transfer process.
         with tempfile.TemporaryDirectory() as tmp_dir:
             bundle = os.path.join(tmp_dir, 'key-bundle')
             secret = os.path.join(tmp_dir, 'key-bundle-secret')
@@ -775,10 +775,10 @@ class KeyMakerTest(unittest.TestCase):
 
         def random_keys(size):
             if KEYSTORE_VERSION == 'v1':
-                # Key store v1 uses simple binary data for keys
+                # Keystore v1 uses simple binary data for keys
                 value = os.urandom(size)
             elif KEYSTORE_VERSION == 'v2':
-                # Key store v2 uses more complex JSON format
+                # Keystore v2 uses more complex JSON format
                 encryption = os.urandom(size)
                 signature = os.urandom(size)
                 keys = {
@@ -2374,9 +2374,9 @@ class TestKeyStorageClearing(BaseTestCase):
 class TestKeyStoreMigration(BaseTestCase):
     """Test "acra-keys migrate" utility."""
 
-    # We need to test different key store formats so we can't touch
+    # We need to test different keystore formats so we can't touch
     # the global KEYS_FOLDER. We need to launch service instances
-    # with particular key store configuration. Ignore the usual
+    # with particular keystore configuration. Ignore the usual
     # setup and teardown routines that start Acra services.
 
     def setUp(self):
@@ -2415,7 +2415,7 @@ class TestKeyStoreMigration(BaseTestCase):
 
 
     def create_key_store(self, version):
-        """Create new key store of given version."""
+        """Create new keystore of given version."""
         # Start with service transport keys and client storage keys.
         self.client_id = 'test-client-please-ignore'
         subprocess.check_call([
@@ -2445,8 +2445,8 @@ class TestKeyStoreMigration(BaseTestCase):
         self.keystore_version = version
 
     def migrate_key_store(self, new_version):
-        """Migrate key store from current to given new version."""
-        # Run the migration tool. New key store is in a new directory.
+        """Migrate keystore from current to given new version."""
+        # Run the migration tool. New keystore is in a new directory.
         subprocess.check_call([
                 './acra-keys', 'migrate',
                 '--src_keys_dir={}'.format(self.current_key_store_path()),
@@ -2460,21 +2460,21 @@ class TestKeyStoreMigration(BaseTestCase):
                  'DST_ACRA_MASTER_KEY': self.get_master_key(new_version)},
             timeout=PROCESS_CALL_TIMEOUT)
 
-        # Finalize the migration, replacing old key store with the new one.
+        # Finalize the migration, replacing old keystore with the new one.
         # We assume the services to be not running at this moment.
         os.rename(self.current_key_store_path(), self.old_key_store_path())
         os.rename(self.new_key_store_path(), self.current_key_store_path())
         self.keystore_version = new_version
 
     def change_key_store_path(self):
-        """Change the absolute path of the key store directory."""
+        """Change the absolute path of the keystore directory."""
         # Swap the whole testing directory for a new one.
         old_key_store_path = self.current_key_store_path()
         old_test_dir = self.test_dir
         new_test_dir = tempfile.TemporaryDirectory()
         self.test_dir = new_test_dir
         new_key_store_path = self.current_key_store_path()
-        # Move the key store to the new location.
+        # Move the keystore to the new location.
         os.rename(old_key_store_path, new_key_store_path)
         # Remove the old, now unneeded directory.
         old_test_dir.cleanup()
@@ -2584,7 +2584,7 @@ class TestKeyStoreMigration(BaseTestCase):
     # Now we can proceed with the tests...
 
     def test_migrate_v1_to_v2(self):
-        """Verify v1 -> v2 key store migration."""
+        """Verify v1 -> v2 keystore migration."""
         data_1 = get_pregenerated_random_data()
         data_2 = get_pregenerated_random_data()
 
@@ -2657,7 +2657,7 @@ class TestKeyStoreMigration(BaseTestCase):
             self.assertEquals(selected['raw_data'], data_2)
 
     def test_moved_key_store(self):
-        """Verify that key store can be moved to a different absolute path."""
+        """Verify that keystore can be moved to a different absolute path."""
         self.create_key_store(KEYSTORE_VERSION)
 
         # Save some data, do a sanity check.
@@ -2667,11 +2667,11 @@ class TestKeyStoreMigration(BaseTestCase):
             selected = self.select_via_connector(row_id)
             self.assertEquals(selected['data'], data.encode('ascii'))
 
-        # Move the key store to a different (still temporary) location.
+        # Move the keystore to a different (still temporary) location.
         self.change_key_store_path()
 
-        # Check that key store path is not included into encryption context.
-        # We should still be able to access the data with the same key store
+        # Check that keystore path is not included into encryption context.
+        # We should still be able to access the data with the same keystore
         # but located at different path.
         with self.running_services():
             selected = self.select_via_connector(row_id)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -105,7 +105,7 @@ def load_default_config(service_name):
 
 
 def read_key(kind, client_id=None, zone_id=None, keys_dir='.acrakeys'):
-    """Reads key from Key Store with acra-keys."""
+    """Reads key from keystore with acra-keys."""
     args = ['./acra-keys', 'read', '--keys_dir={}'.format(keys_dir)]
     if client_id is not None:
         args.append('--client_id={}'.format(client_id))
@@ -116,7 +116,7 @@ def read_key(kind, client_id=None, zone_id=None, keys_dir='.acrakeys'):
 
 
 def destroy_key(kind, client_id=None, keys_dir='.acrakeys'):
-    """Destroys key in the Key Store with acra-keys."""
+    """Destroys key in the keystore with acra-keys."""
     args = ['./acra-keys', 'destroy', '--keys_dir={}'.format(keys_dir)]
     if client_id:
         args.append('--client_id={}'.format(client_id))


### PR DESCRIPTION
As requested by @vixentael in #400, use a single-word spelling consistently.

This is preferable since that's how Go modules are called, how the command-line operations are named, and in general to convey the unitary meaning without sounding like a place where they sell keys.

Note that the code also has a lot of CamelCase `KeyStore` which suggests separate words, but we don't change that to avoid breaking stuff. Only human-visible strings are changed.

Update comments as well to avoid suggesting that this is alternate spelling. Otherwise developers may read a lot of comments and write new code using the undesirable spelling.

This change is somewhat important since it changes key store format (version identification string). However, we can still make this change for consistency as key store v2 has not yet been available to the users.