### PR TITLE
Use interfaces instead of structs for encryptor configuration

### DIFF
--- a/cmd/acra-server/config.go
+++ b/cmd/acra-server/config.go
@@ -49,7 +49,7 @@ type Config struct {
 	censor                  acracensor.AcraCensorInterface
 	withConnector           bool
 	TraceToLog              bool
-	tableSchema             *encryptorConfig.MapTableSchemaStore
+	tableSchema             encryptorConfig.TableSchemaStore
 	dataEncryptor           encryptor.DataEncryptor
 	keystore                keystore.KeyStore
 	traceOptions            []trace.StartOption

--- a/decryptor/mysql/proxy_test.go
+++ b/decryptor/mysql/proxy_test.go
@@ -15,7 +15,7 @@ func (*decryptorFactory) New(clientID []byte) (base.Decryptor, error) {
 
 type tableSchemaStore struct{ empty bool }
 
-func (*tableSchemaStore) GetTableSchema(tableName string) *config.TableSchema {
+func (*tableSchemaStore) GetTableSchema(tableName string) config.TableSchema {
 	panic("implement me")
 }
 

--- a/decryptor/postgresql/proxy_test.go
+++ b/decryptor/postgresql/proxy_test.go
@@ -154,7 +154,7 @@ func (*decryptorFactory) New(clientID []byte) (base.Decryptor, error) {
 
 type tableSchemaStore struct{ empty bool }
 
-func (*tableSchemaStore) GetTableSchema(tableName string) *config.TableSchema {
+func (*tableSchemaStore) GetTableSchema(tableName string) config.TableSchema {
 	panic("implement me")
 }
 

--- a/encryptor/dataEncryptor.go
+++ b/encryptor/dataEncryptor.go
@@ -17,26 +17,18 @@ limitations under the License.
 package encryptor
 
 import (
-	"github.com/cossacklabs/acra/acra-writer"
+	acrawriter "github.com/cossacklabs/acra/acra-writer"
 	"github.com/cossacklabs/acra/decryptor/base"
+	"github.com/cossacklabs/acra/encryptor/config"
 	"github.com/cossacklabs/acra/keystore"
 )
-
-// EncryptionSetting provide interface to fetch data about encryption settings
-type EncryptionSetting interface {
-	IsSearchable() bool
-	GetMaskingPattern() string
-	GetPartialPlaintextLen() int
-	IsEndMasking() bool
-	IsConsistentTokenization() bool
-}
 
 // DataEncryptor replace raw data in queries with encrypted
 type DataEncryptor interface {
 	// EncryptWithZoneID encrypt with explicit zone id
-	EncryptWithZoneID(zoneID, data []byte, setting EncryptionSetting) ([]byte, error)
+	EncryptWithZoneID(zoneID, data []byte, setting config.ColumnEncryptionSetting) ([]byte, error)
 	// EncryptWithClientID encrypt with explicit client id
-	EncryptWithClientID(clientID, data []byte, setting EncryptionSetting) ([]byte, error)
+	EncryptWithClientID(clientID, data []byte, setting config.ColumnEncryptionSetting) ([]byte, error)
 }
 
 // AcrawriterDataEncryptor implement DataEncryptor and encrypt data with AcraStructs
@@ -50,7 +42,7 @@ func NewAcrawriterDataEncryptor(keystore keystore.PublicKeyStore) (*AcrawriterDa
 }
 
 // EncryptWithZoneID encrypt with explicit zone id
-func (encryptor *AcrawriterDataEncryptor) EncryptWithZoneID(zoneID, data []byte, setting EncryptionSetting) ([]byte, error) {
+func (encryptor *AcrawriterDataEncryptor) EncryptWithZoneID(zoneID, data []byte, setting config.ColumnEncryptionSetting) ([]byte, error) {
 	if err := base.ValidateAcraStructLength(data); err == nil {
 		return data, nil
 	}
@@ -62,7 +54,7 @@ func (encryptor *AcrawriterDataEncryptor) EncryptWithZoneID(zoneID, data []byte,
 }
 
 // EncryptWithClientID encrypt with explicit client id
-func (encryptor *AcrawriterDataEncryptor) EncryptWithClientID(clientID, data []byte, setting EncryptionSetting) ([]byte, error) {
+func (encryptor *AcrawriterDataEncryptor) EncryptWithClientID(clientID, data []byte, setting config.ColumnEncryptionSetting) ([]byte, error) {
 	if err := base.ValidateAcraStructLength(data); err == nil {
 		return data, nil
 	}

--- a/encryptor/dataEncryptor_test.go
+++ b/encryptor/dataEncryptor_test.go
@@ -18,8 +18,10 @@ package encryptor
 
 import (
 	"bytes"
-	"github.com/cossacklabs/themis/gothemis/keys"
 	"testing"
+
+	"github.com/cossacklabs/acra/encryptor/config"
+	"github.com/cossacklabs/themis/gothemis/keys"
 )
 
 type keyStore struct {
@@ -40,7 +42,27 @@ func (ks *keyStore) GetClientIDEncryptionPublicKey(clientID []byte) (*keys.Publi
 
 type emptyEncryptionSetting struct{}
 
+func (*emptyEncryptionSetting) ColumnName() string {
+	panic("implement me")
+}
+
+func (*emptyEncryptionSetting) ClientID() []byte {
+	panic("implement me")
+}
+
+func (*emptyEncryptionSetting) ZoneID() []byte {
+	panic("implement me")
+}
+
+func (*emptyEncryptionSetting) IsTokenized() bool {
+	return false
+}
+
 func (*emptyEncryptionSetting) IsConsistentTokenization() bool {
+	panic("implement me")
+}
+
+func (*emptyEncryptionSetting) GetTokenType() config.TokenType {
 	panic("implement me")
 }
 

--- a/encryptor/queryDataEncryptor.go
+++ b/encryptor/queryDataEncryptor.go
@@ -28,13 +28,8 @@ import (
 	"reflect"
 )
 
-// QueryEncryptionState interface to access to encryption state for query
-type QueryEncryptionState interface {
-	GetColumnEncryptionSetting(index int) *config.ColumnEncryptionSetting
-}
-
 type querySelectSetting struct {
-	setting     *config.ColumnEncryptionSetting
+	setting     config.ColumnEncryptionSetting
 	tableName   string
 	columnName  string
 	columnAlias string
@@ -75,8 +70,8 @@ func (encryptor *QueryDataEncryptor) encryptInsertQuery(insert *sqlparser.Insert
 		for _, col := range insert.Columns {
 			columnsName = append(columnsName, col.String())
 		}
-	} else if len(schema.Columns()) > 0 {
-		columnsName = schema.Columns()
+	} else if cols := schema.Columns(); len(cols) > 0 {
+		columnsName = cols
 	}
 
 	changed := false
@@ -313,21 +308,21 @@ func (encryptor *QueryDataEncryptor) OnQuery(query base.OnQueryObject) (base.OnQ
 	return query, false, nil
 }
 
-// encryptWithColumnSettings encrypt data and use ZoneId or ClientID from ColumnEncryptionSettings if not empty otherwise static ClientID that passed to parser
-func (encryptor *QueryDataEncryptor) encryptWithColumnSettings(columnSetting *config.ColumnEncryptionSetting, data []byte) ([]byte, error) {
-	logger := logrus.WithFields(logrus.Fields{"column": columnSetting.Name})
+// encryptWithColumnSettings encrypt data and use ZoneId or ClientID from ColumnEncryptionSetting if not empty otherwise static ClientID that passed to parser
+func (encryptor *QueryDataEncryptor) encryptWithColumnSettings(columnSetting config.ColumnEncryptionSetting, data []byte) ([]byte, error) {
+	logger := logrus.WithFields(logrus.Fields{"column": columnSetting.ColumnName()})
 	logger.Debugln("QueryDataEncryptor.encryptWithColumnSettings")
-	if len(columnSetting.ZoneID) > 0 {
-		logger.WithField("zone_id", string(columnSetting.ZoneID)).Debugln("Encrypt with specific ZoneID for column")
-		return encryptor.encryptor.EncryptWithZoneID([]byte(columnSetting.ZoneID), data, columnSetting)
+	zoneID := columnSetting.ZoneID()
+	if len(zoneID) > 0 {
+		logger.WithField("zone_id", string(zoneID)).Debugln("Encrypt with specific ZoneID for column")
+		return encryptor.encryptor.EncryptWithZoneID(zoneID, data, columnSetting)
 	}
-	var id []byte
-	if len(columnSetting.ClientID) > 0 {
-		logger.WithField("client_id", string(columnSetting.ClientID)).Debugln("Encrypt with specific ClientID for column")
-		id = []byte(columnSetting.ClientID)
+	clientID := columnSetting.ClientID()
+	if len(clientID) > 0 {
+		logger.WithField("client_id", string(clientID)).Debugln("Encrypt with specific ClientID for column")
 	} else {
 		logger.WithField("client_id", string(encryptor.clientID)).Debugln("Encrypt with ClientID from connection")
-		id = encryptor.clientID
+		clientID = encryptor.clientID
 	}
-	return encryptor.encryptor.EncryptWithClientID(id, data, columnSetting)
+	return encryptor.encryptor.EncryptWithClientID(clientID, data, columnSetting)
 }

--- a/encryptor/queryDataEncryptor.go
+++ b/encryptor/queryDataEncryptor.go
@@ -75,8 +75,8 @@ func (encryptor *QueryDataEncryptor) encryptInsertQuery(insert *sqlparser.Insert
 		for _, col := range insert.Columns {
 			columnsName = append(columnsName, col.String())
 		}
-	} else if len(schema.Columns) > 0 {
-		columnsName = schema.Columns
+	} else if len(schema.Columns()) > 0 {
+		columnsName = schema.Columns()
 	}
 
 	changed := false
@@ -148,7 +148,7 @@ func UpdateExpressionValue(expr sqlparser.Expr, coder DBDataCoder, updateFunc fu
 }
 
 // encryptExpression check that expr is SQLVal and has Hexval then try to encrypt
-func (encryptor *QueryDataEncryptor) encryptExpression(expr sqlparser.Expr, schema *config.TableSchema, columnName string) (bool, error) {
+func (encryptor *QueryDataEncryptor) encryptExpression(expr sqlparser.Expr, schema config.TableSchema, columnName string) (bool, error) {
 	if schema.NeedToEncrypt(columnName) {
 		err := UpdateExpressionValue(expr, encryptor.dataCoder, func(data []byte) ([]byte, error) {
 			if len(data) == 0 {
@@ -212,7 +212,7 @@ func (encryptor *QueryDataEncryptor) hasTablesToEncrypt(tables []*AliasedTableNa
 
 // encryptUpdateExpressions try to encrypt all supported exprs. Use firstTable if column has not explicit table name because it's implicitly used in DBMSs
 func (encryptor *QueryDataEncryptor) encryptUpdateExpressions(exprs sqlparser.UpdateExprs, firstTable sqlparser.TableName, qualifierMap AliasToTableMap) (bool, error) {
-	var schema *config.TableSchema
+	var schema config.TableSchema
 	changed := false
 	for _, expr := range exprs {
 		// recognize table name of column

--- a/encryptor/queryDataEncryptor_test.go
+++ b/encryptor/queryDataEncryptor_test.go
@@ -38,7 +38,7 @@ type testEncryptor struct {
 	fetchedIDs [][]byte
 }
 
-func (e *testEncryptor) EncryptWithZoneID(zoneIDdata, data []byte, setting EncryptionSetting) ([]byte, error) {
+func (e *testEncryptor) EncryptWithZoneID(zoneIDdata, data []byte, setting config.ColumnEncryptionSetting) ([]byte, error) {
 	if base.ValidateAcraStructLength(data) == nil {
 		return data, nil
 	}
@@ -49,7 +49,7 @@ func (e *testEncryptor) reset() {
 	e.fetchedIDs = [][]byte{}
 }
 
-func (e *testEncryptor) EncryptWithClientID(clientID, data []byte, setting EncryptionSetting) ([]byte, error) {
+func (e *testEncryptor) EncryptWithClientID(clientID, data []byte, setting config.ColumnEncryptionSetting) ([]byte, error) {
 	if base.ValidateAcraStructLength(data) == nil {
 		return data, nil
 	}


### PR DESCRIPTION
Currently, Acra CE's `ColumnEncryptionSetting` exposes Acra EE configuration variables too. Moreover, despite `EncryptionSetting` being used by encryptors, Acra EE code still depends on `ColumnEncryptionSetting`-the-`struct` directly in several places. This makes it hard to add new extensions to Acra EE.

Replace structures with interfaces, making it possible for Acra EE to provide is own extended implementations without duplicating the API and surrounding code too much. Read commit messages for more technical details.

This PR only introduces the interfaces. Acra CE still exposes Acra EE configuration bits. This requires more coordination with Acra EE. A separate future PR will move Acra EE configuration to Acra EE, once it is adapted to this new interface.