### PR TITLE
RegisterWithContext for signal handlers

### DIFF
--- a/cmd/acra-translator/server/server.go
+++ b/cmd/acra-translator/server/server.go
@@ -40,10 +40,6 @@ import (
 	"google.golang.org/grpc"
 )
 
-// defaultWaitGroupTimeoutDuration specifies how long should we wait
-// for background goroutines finishing while ReaderServer shutdown
-const defaultWaitGroupTimeoutDuration = time.Second
-
 // ReaderServer represents AcraTranslator server, connects with KeyStorage, configuration file,
 // gRPC and HTTP request parsers.
 type ReaderServer struct {
@@ -318,7 +314,7 @@ func (server *ReaderServer) Start(parentContext context.Context) {
 
 	// global 'cancel' has been called. Now we should wait (not more than specified duration) until all
 	// background goroutines spawned by readerServer will finish their execution
-	if utils.WaitWithTimeout(&server.waitGroup, defaultWaitGroupTimeoutDuration) {
+	if utils.WaitWithTimeout(&server.waitGroup, utils.DefaultWaitGroupTimeoutDuration) {
 		log.Errorf("Couldn't stop all background goroutines spawned by readerServer. Exited by timeout")
 	}
 	return

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -198,6 +198,10 @@ func GetConfigPathByName(name string) string {
 	return fmt.Sprintf("configs/%s.yaml", name)
 }
 
+// defaultWaitGroupTimeoutDuration specifies how long should we wait
+// for background goroutines finishing while ReaderServer shutdown
+const DefaultWaitGroupTimeoutDuration = time.Second
+
 // WaitWithTimeout waits for the waitgroup for the specified max timeout.
 // Returns true if waiting timed out.
 func WaitWithTimeout(wg *sync.WaitGroup, timeout time.Duration) bool {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -198,7 +198,7 @@ func GetConfigPathByName(name string) string {
 	return fmt.Sprintf("configs/%s.yaml", name)
 }
 
-// defaultWaitGroupTimeoutDuration specifies how long should we wait
+// DefaultWaitGroupTimeoutDuration specifies how long should we wait
 // for background goroutines finishing while ReaderServer shutdown
 const DefaultWaitGroupTimeoutDuration = time.Second
 


### PR DESCRIPTION
This PR is a technical one. It is needed for EE.

Basically it moves `DefaultWaitGroupTimeoutDuration` constant (and makes it exportable in order to reuse in other packages) to common `utils` package. Additionally it adds new `RegisterWithContext` function to signal handler utility component that actually behaves like usual `Register` but avoids `os.Exit` and allows passing global context for better controlling of background goroutine that runs it.