### PR TITLE
Generate keys with "acra-keys generate"

### DIFF
--- a/cmd/acra-keys/acra-keys.go
+++ b/cmd/acra-keys/acra-keys.go
@@ -24,6 +24,7 @@
 //   - migrate keystores
 //   - read key data
 //   - destroy keys
+//   - generate keys
 package main
 
 import (
@@ -38,6 +39,7 @@ func main() {
 		&keys.MigrateKeysSubcommand{},
 		&keys.ReadKeySubcommand{},
 		&keys.DestroyKeySubcommand{},
+		&keys.GenerateKeySubcommand{},
 	}
 	subcommand := keys.ParseParameters(subcommands)
 	if subcommand != nil {

--- a/cmd/acra-keys/keys/command-line.go
+++ b/cmd/acra-keys/keys/command-line.go
@@ -41,6 +41,7 @@ var DefaultConfigPath = utils.GetConfigPathByName("acra-keys")
 
 // Sub-command names:
 const (
+	CmdGenerate    = "generate"
 	CmdListKeys    = "list"
 	CmdExportKeys  = "export"
 	CmdImportKeys  = "import"

--- a/cmd/acra-keys/keys/generate.go
+++ b/cmd/acra-keys/keys/generate.go
@@ -50,6 +50,8 @@ type GenerateKeyParams interface {
 	ZoneID() []byte
 	GenerateNewZone() bool
 	GenerateZoneKeys() bool
+
+	SpecificKeysRequested() bool
 }
 
 // Key generation errors:
@@ -133,6 +135,12 @@ func (g *GenerateKeySubcommand) GenerateNewZone() bool {
 // GenerateZoneKeys returns true if a new key for a zone was requested.
 func (g *GenerateKeySubcommand) GenerateZoneKeys() bool {
 	return g.rotateZone
+}
+
+// SpecificKeysRequested returns true if the user has requested any key specifically.
+// It returns false if no keys were requested.
+func (g *GenerateKeySubcommand) SpecificKeysRequested() bool {
+	return g.acraConnector || g.acraServer || g.acraTranslator || g.acraWriter || g.acraWebConfig || g.newZone || g.rotateZone
 }
 
 // Name returns the same of this subcommand.
@@ -324,7 +332,7 @@ func GenerateAcraKeys(params GenerateKeyParams, keystore keystore.KeyMaking, def
 	switch defaultKeys {
 	case GenerateOnInitialize:
 		firstGeneration := params.KeystoreVersion() != ""
-		explictKeys := generateAcraConnector || generateAcraServer || generateAcraTranslator || generateAcraWriter
+		explictKeys := params.SpecificKeysRequested()
 		clientIDKnown := len(params.ClientID()) != 0
 		overrideDefaultSet = firstGeneration && !explictKeys && clientIDKnown
 	case GenerateDefaultsOverride:

--- a/cmd/acra-keys/keys/generate.go
+++ b/cmd/acra-keys/keys/generate.go
@@ -166,7 +166,7 @@ func (g *GenerateKeySubcommand) RegisterFlags() {
 	g.flagSet.BoolVar(&g.acraTranslator, "acratranslator_transport_key", false, "Generate transport keypair for AcraTranslator")
 	g.flagSet.BoolVar(&g.acraWriter, "client_storage_key", false, "Generate keypair for data encryption/decryption (for a client)")
 	g.flagSet.BoolVar(&g.acraWebConfig, "acrawebconfig_symmetric_key", false, "Generate symmetric key for AcraWebconfig's basic auth DB")
-	g.flagSet.BoolVar(&g.newZone, "new_zone", false, "Generate new Acra storage zone")
+	g.flagSet.BoolVar(&g.newZone, "zone", false, "Generate new Acra storage zone")
 	g.flagSet.BoolVar(&g.rotateZone, "zone_storage_key", false, "Rotate existing Acra zone storagae keypair")
 	g.flagSet.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Command \"%s\": generate new keys\n", CmdGenerate)

--- a/cmd/acra-keys/keys/generate.go
+++ b/cmd/acra-keys/keys/generate.go
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020, Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package keys
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/cossacklabs/acra/cmd"
+)
+
+// GenerateKeyParams are parameters of "acra-keys generate" subcommand.
+type GenerateKeyParams interface {
+}
+
+// GenerateKeySubcommand is the "acra-keys generate" subcommand.
+type GenerateKeySubcommand struct {
+	flagSet *flag.FlagSet
+}
+
+// Name returns the same of this subcommand.
+func (g *GenerateKeySubcommand) Name() string {
+	return CmdGenerate
+}
+
+// GetFlagSet returns flag set of this subcommand.
+func (g *GenerateKeySubcommand) GetFlagSet() *flag.FlagSet {
+	return g.flagSet
+}
+
+// RegisterFlags registers command-line flags of "acra-keys generate".
+func (g *GenerateKeySubcommand) RegisterFlags() {
+	g.flagSet = flag.NewFlagSet(CmdGenerate, flag.ContinueOnError)
+	g.flagSet.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Command \"%s\": generate new keys\n", CmdGenerate)
+		fmt.Fprintf(os.Stderr, "\n\t%s %s [options...]\n", os.Args[0], CmdGenerate)
+		fmt.Fprintf(os.Stderr, "\nOptions:\n")
+		cmd.PrintFlags(g.flagSet)
+	}
+}
+
+// Parse command-line parameters of the subcommand.
+func (g *GenerateKeySubcommand) Parse(arguments []string) error {
+	err := cmd.ParseFlagsWithConfig(g.flagSet, arguments, DefaultConfigPath, ServiceName)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Execute this subcommand.
+func (g *GenerateKeySubcommand) Execute() {
+}

--- a/cmd/acra-keys/keys/generate.go
+++ b/cmd/acra-keys/keys/generate.go
@@ -22,15 +22,81 @@ import (
 	"os"
 
 	"github.com/cossacklabs/acra/cmd"
+	log "github.com/sirupsen/logrus"
 )
 
 // GenerateKeyParams are parameters of "acra-keys generate" subcommand.
 type GenerateKeyParams interface {
+	KeyStoreParameters
+	KeyStoreVersion() string
+
+	GenerateMasterKeyFile() string
+
+	ClientID() []byte
+	GenerateAcraConnector() bool
+	GenerateAcraServer() bool
+	GenerateAcraTranslator() bool
+	GenerateAcraWriter() bool
+	GenerateAcraWebConfig() bool
 }
 
 // GenerateKeySubcommand is the "acra-keys generate" subcommand.
 type GenerateKeySubcommand struct {
 	flagSet *flag.FlagSet
+
+	CommonKeyStoreParameters
+	keyStoreVersion string
+
+	outKeyDir       string
+	outKeyDirPublic string
+	clientID        string
+	masterKeyFile   string
+	acraConnector   bool
+	acraServer      bool
+	acraTranslator  bool
+	acraWriter      bool
+	acraWebConfig   bool
+}
+
+// KeyStoreVersion returns requested key store version.
+func (g *GenerateKeySubcommand) KeyStoreVersion() string {
+	return g.keyStoreVersion
+}
+
+// ClientID returns client ID.
+func (g *GenerateKeySubcommand) ClientID() []byte {
+	return []byte(g.clientID)
+}
+
+// GenerateMasterKeyFile returns path to output file for master key.
+// Returns empty string if master key has not been requested.
+func (g *GenerateKeySubcommand) GenerateMasterKeyFile() string {
+	return g.masterKeyFile
+}
+
+// GenerateAcraConnector returns true if new AcraConnector key was requested.
+func (g *GenerateKeySubcommand) GenerateAcraConnector() bool {
+	return g.acraConnector
+}
+
+// GenerateAcraServer returns true if new AcraServer key was requested.
+func (g *GenerateKeySubcommand) GenerateAcraServer() bool {
+	return g.acraServer
+}
+
+// GenerateAcraTranslator returns true if new AcraTranslator key was requested.
+func (g *GenerateKeySubcommand) GenerateAcraTranslator() bool {
+	return g.acraTranslator
+}
+
+// GenerateAcraWriter returns true if new AcraWriter key was requested.
+func (g *GenerateKeySubcommand) GenerateAcraWriter() bool {
+	return g.acraWriter
+}
+
+// GenerateAcraWebConfig returns true if new AcraWebConfig key was requested.
+func (g *GenerateKeySubcommand) GenerateAcraWebConfig() bool {
+	return g.acraWebConfig
 }
 
 // Name returns the same of this subcommand.
@@ -46,6 +112,15 @@ func (g *GenerateKeySubcommand) GetFlagSet() *flag.FlagSet {
 // RegisterFlags registers command-line flags of "acra-keys generate".
 func (g *GenerateKeySubcommand) RegisterFlags() {
 	g.flagSet = flag.NewFlagSet(CmdGenerate, flag.ContinueOnError)
+	g.CommonKeyStoreParameters.Register(g.flagSet)
+	g.flagSet.StringVar(&g.keyStoreVersion, "keystore", "", "Key store format: v1 (current), v2 (new)")
+	g.flagSet.StringVar(&g.clientID, "client_id", "", "Client ID")
+	g.flagSet.StringVar(&g.masterKeyFile, "master_key_path", "", "Generate new random master key and save to file")
+	g.flagSet.BoolVar(&g.acraConnector, "acraconnector_transport_key", false, "Generate transport keypair for AcraConnector")
+	g.flagSet.BoolVar(&g.acraServer, "acraserver_transport_key", false, "Generate transport keypair for AcraServer")
+	g.flagSet.BoolVar(&g.acraTranslator, "acratranslator_transport_key", false, "Generate transport keypair for AcraTranslator")
+	g.flagSet.BoolVar(&g.acraWriter, "client_storage_key", false, "Generate keypair for data encryption/decryption (for a client)")
+	g.flagSet.BoolVar(&g.acraWebConfig, "acrawebconfig_symmetric_key", false, "Generate symmetric key for AcraWebconfig's basic auth DB")
 	g.flagSet.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Command \"%s\": generate new keys\n", CmdGenerate)
 		fmt.Fprintf(os.Stderr, "\n\t%s %s [options...]\n", os.Args[0], CmdGenerate)
@@ -59,6 +134,29 @@ func (g *GenerateKeySubcommand) Parse(arguments []string) error {
 	err := cmd.ParseFlagsWithConfig(g.flagSet, arguments, DefaultConfigPath, ServiceName)
 	if err != nil {
 		return err
+	}
+	err = ValidateClientID(g)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// ValidateClientID checks that client ID is specified correctly.
+func ValidateClientID(params GenerateKeyParams) error {
+	clientID := params.ClientID()
+	// If the client ID is specified then it must be a valid one.
+	if len(clientID) != 0 {
+		cmd.ValidateClientID(string(clientID))
+	} else {
+		// Client ID is required to generate some of the keys.
+		// (Which are always generated on first launch, when --keystore is specified.)
+		firstGeneration := params.KeyStoreVersion() != ""
+		requestedClientKeys := params.GenerateAcraConnector() || params.GenerateAcraServer() || params.GenerateAcraTranslator() || params.GenerateAcraWriter()
+		if firstGeneration || requestedClientKeys {
+			log.Error("--client_id is required to generate keys")
+			return ErrMissingClientID
+		}
 	}
 	return nil
 }

--- a/configs/acra-keys.yaml
+++ b/configs/acra-keys.yaml
@@ -59,3 +59,24 @@ client_id:
 # zone ID for which to retrieve key
 zone_id: 
 
+# Generate transport keypair for AcraConnector
+acraconnector_transport_key: false
+
+# Generate transport keypair for AcraServer
+acraserver_transport_key: false
+
+# Generate transport keypair for AcraTranslator
+acratranslator_transport_key: false
+
+# Generate symmetric key for AcraWebconfig's basic auth DB
+acrawebconfig_symmetric_key: false
+
+# Generate keypair for data encryption/decryption (for a client)
+client_storage_key: false
+
+# Key store format: v1 (current), v2 (new)
+keystore: 
+
+# Generate new random master key and save to file
+master_key_path: 
+

--- a/configs/acra-keys.yaml
+++ b/configs/acra-keys.yaml
@@ -74,14 +74,14 @@ acrawebconfig_symmetric_key: false
 # Generate keypair for data encryption/decryption (for a client)
 client_storage_key: false
 
-# Key store format: v1 (current), v2 (new)
+# Keystore format: v1 (current), v2 (new)
 keystore: 
 
 # Generate new random master key and save to file
 master_key_path: 
 
 # Generate new Acra storage zone
-new_zone: false
+zone: false
 
 # Rotate existing Acra zone storagae keypair
 zone_storage_key: false

--- a/configs/acra-keys.yaml
+++ b/configs/acra-keys.yaml
@@ -80,3 +80,9 @@ keystore:
 # Generate new random master key and save to file
 master_key_path: 
 
+# Generate new Acra storage zone
+new_zone: false
+
+# Rotate existing Acra zone storagae keypair
+zone_storage_key: false
+

--- a/keystore/filesystem/server_keystore.go
+++ b/keystore/filesystem/server_keystore.go
@@ -670,7 +670,7 @@ func (store *KeyStore) GetPoisonKeyPair() (*keys.Keypair, error) {
 		}
 		return &keys.Keypair{Public: public, Private: private}, nil
 	}
-	log.Infoln("Generate poison key pair")
+	log.Debug("Generate poison key pair")
 	return store.generateKeyPair(PoisonKeyFilename, []byte(PoisonKeyFilename))
 }
 
@@ -692,7 +692,7 @@ func (store *KeyStore) GetAuthKey(remove bool) ([]byte, error) {
 		}
 		return key, nil
 	}
-	log.Infof("Generate basic auth key for AcraWebconfig to %v", keyPath)
+	log.Debugf("Generate basic auth key for AcraWebconfig to %v", keyPath)
 	return store.generateKey(BasicAuthKeyFilename, keystore.BasicAuthKeyLength)
 }
 

--- a/keystore/v2/keystore/poison.go
+++ b/keystore/v2/keystore/poison.go
@@ -38,7 +38,7 @@ func (s *ServerKeyStore) GetPoisonKeyPair() (*keys.Keypair, error) {
 	}
 	keypair, err := s.currentKeyPair(ring)
 	if err == api.ErrNoCurrentKey {
-		s.log.Info("generate poison record key pair")
+		s.log.Debug("Generate poison record key pair")
 		return s.newCurrentKeyPair(ring)
 	}
 	if err != nil {

--- a/keystore/v2/keystore/webConfig.go
+++ b/keystore/v2/keystore/webConfig.go
@@ -36,12 +36,12 @@ func (s *ServerKeyStore) GetAuthKey(remove bool) ([]byte, error) {
 		return nil, err
 	}
 	if remove {
-		s.log.Info("new authentication key for AcraWebconfig requested")
+		s.log.Debug("New authentication key for AcraWebconfig requested")
 		return s.newCurrentSymmetricKey(ring)
 	}
 	key, err := s.currentSymmetricKey(ring)
 	if err == api.ErrNoCurrentKey {
-		s.log.Info("generate authentication key for AcraWebconfig")
+		s.log.Debug("Generate authentication key for AcraWebconfig")
 		return s.newCurrentSymmetricKey(ring)
 	}
 	if err != nil {


### PR DESCRIPTION
Add a new subcommand for key generation. This is a replacement for `acra-keymaker` and other tools like `acra-addzone`.

### Generating master keys

The first step is to generate a master key:

```
acra-keys generate --master_key_path=master.key --keystore=v2
```

The `--keystore` option is required since the format of master keys is different for keystore versions.

The resulting master key is placed into the specified file. It needs to be set in the environment:

```
ACRA_MASTER_KEY=$(cat master.key | base64)
```

### Generating initial keystore

After you have a master key, generate the initial keystore:

```
acra-keys generate --keystore=v2 --client_id=ACME
```

The `--keystore` option is required here as well since we need to know which format to use. When the keystore is already initialized, this option is not necessary as `acra-keys` can see the format for itself.

The `--client_id` option is now **required** as well. This is different from `acra-keymaker` which uses client ID `client` when it is not specified explicitly.

`acra-keys` will generate a default set of keys:

  - transport keys for AcraConnector, AcraServer, AcraTranslator
  - storage key for AcraWriter to use

It is also possible to initialize the keystore with only some of the keys. For example, if you need only the storage key without the transport keys, initialize the keystore like this:

```
acra-keys generate --keystore=v2 --client_id=ACME --client_storage_key
```

Note that key options are **different** from the ones used by `acra-keymaker`.

| Option | Key |
| -- | -- |
| `--acraconnector_transport_key` | transport keypair for AcraConnector |
| `--acraserver_transport_key` | transport keypair for AcraServer |
| `--acratranslator_transport_key` | transport keypair for AcraTranslator |
| `--client_storage_key` |  encryption keypair for AcraWriter |
| `--acrawebconfig_symmetric_key` | encryption key for AcraWebConfig |

The keystore will be initialized in the default directory: `.acrakeys` in the current directory. You can change this with `--keys_dir` (and `--keys_dir_public` for v1). Note that these option names are **different** from `acra-keymaker` which uses `--keys_output_dir`. This is to be consistent with other `acra-keys` subcommands.

### Rotating existing keys

`acra-keys generate` can be used to rotate keys in the existing keystore. Just run it again and specify the keys you need to rotate:

```
acra-keys generate --client_id=ACME --acraserver_transport_key
```

This will generate a new key for the `ACME` client to use on AcraConnector when connecting to AcraServer.

### New features for zones

`acra-keys generate` can also be used instead of `acra-addzone` to generate new zones:

```
$ acra-keys generate --zone
{"id":"DDDDDDDDtapktGNSfSnodqtv","public_key":"VUVDMgAAAC1UemR1A1qdHwVPp4iFTZKnHFNOMQqHmUc04SFGxwUk3wnmY0ut"}
INFO[0000] Generated new Acra zone
```

JSON output format is the same as `acra-addzone`.

You can also use it to rotate existing zone keys (previously this was impossible to do):

```
$ acra-keys generate --zone_id=DDDDDDDDtapktGNSfSnodqtv --zone_storage_key
{"id":"DDDDDDDDtapktGNSfSnodqtv","public_key":"VUVDMgAAAC0cIjpMAoXUNFamoZqCDaY9wAHAT/tXhfWOqTAYDqPp5PZAXtwB"}
INFO[0000] Generated zone storage key               
```

### Compatibility with `acra-keymaker` and its replacement

Note that the command-line is different and not compatible with `acra-keymaker`. The plan is to eventually deprecate `acra-keymaker` in favor of `acra-keys`. We could possible reimplement `acra-keymaker` and `acra-addzone` using the shared code from `acra-tools` to reduce maintenance burden. For now, both `acra-keymaker` and `acra-keys generate` will be supported, with the latter being the preferred way to generate keys.

### Pending tasks

- [x] Review by @Lagovas
- [x] Review by @shad
- [x] Review by @vixentael 
- [x] Adjust this PR for Acra EE
- [x] Rename `--new_zone` => `--zone`