### PR TITLE
Improve Acra Go Report scores

### DIFF
--- a/acra-censor/common/matching_logic.go
+++ b/acra-censor/common/matching_logic.go
@@ -71,7 +71,7 @@ func checkSinglePatternMatch(query, pattern sqlparser.Statement) bool {
 
 //SQL statemnent handlers
 func handleUnionStatement(query, pattern sqlparser.Statement) bool {
-	match := false
+	var match bool
 	queryUnionNode, ok := query.(*sqlparser.Union)
 	if !ok {
 		return false
@@ -110,7 +110,7 @@ func handleUnionStatement(query, pattern sqlparser.Statement) bool {
 	return true
 }
 func handleSelectStatement(query, pattern sqlparser.Statement) bool {
-	match := false
+	var match bool
 	querySelectNode, ok := query.(*sqlparser.Select)
 	if !ok {
 		return false
@@ -187,7 +187,7 @@ func handleStreamStatement(query, pattern sqlparser.Statement) bool {
 	return false
 }
 func handleInsertStatement(query, pattern sqlparser.Statement) bool {
-	match := false
+	var match bool
 	queryInsertNode, ok := query.(*sqlparser.Insert)
 	if !ok {
 		return false
@@ -237,7 +237,7 @@ func handleInsertStatement(query, pattern sqlparser.Statement) bool {
 	return false
 }
 func handleUpdateStatement(query, pattern sqlparser.Statement) bool {
-	match := false
+	var match bool
 	queryUpdateNode, ok := query.(*sqlparser.Update)
 	if !ok {
 		return false
@@ -279,7 +279,7 @@ func handleUpdateStatement(query, pattern sqlparser.Statement) bool {
 	return true
 }
 func handleDeleteStatement(query, pattern sqlparser.Statement) bool {
-	match := false
+	var match bool
 	queryDeleteNode, ok := query.(*sqlparser.Delete)
 	if !ok {
 		return false

--- a/acra-censor/common/matching_logic_test.go
+++ b/acra-censor/common/matching_logic_test.go
@@ -124,7 +124,7 @@ func TestHandleRangeCondition(t *testing.T) {
 	}
 	notMatchableQueries := [][]string{
 		// left side value placeholder
-		[]string{
+		{
 			"select 1 from t where param between 'value placeholder' and 3",
 			"select 1 from t where param between 'value placeholder' and 'qwe'",
 			"select 1 from t where param between 'value placeholder' and TRUE",
@@ -132,7 +132,7 @@ func TestHandleRangeCondition(t *testing.T) {
 			"select 1 from t where param between (select 1) and 2",
 		},
 		// right side value placeholder
-		[]string{
+		{
 			"select 1 from t where param between 2 and 'value placeholder'",
 			"select 1 from t where param between 'qwe' and 'value placeholder'",
 			"select 1 from t where param between TRUE and 'value placeholder'",
@@ -140,13 +140,13 @@ func TestHandleRangeCondition(t *testing.T) {
 			"select 1 from t where param between (select 1) and 'value placeholder'",
 		},
 		// two sides placeholder
-		[]string{
+		{
 			// incorrect column name
 			"select 1 from t where incorrect_column between NULL and 'value placeholder'",
 			"select 1 from t where param between (select 1) and (select 1)",
 		}, // all queries should match
 		// two explicit int values
-		[]string{
+		{
 			"select 1 from t where param between 1 and 3",
 			"select 1 from t where param between 2 and 2",
 			"select 1 from t where param between 1 and True",
@@ -155,32 +155,32 @@ func TestHandleRangeCondition(t *testing.T) {
 			"select 1 from t where param between 2 and 1",
 		},
 		// two explicit str values
-		[]string{
+		{
 			"select 1 from t where param between 'qwe' and 1",
 			"select 1 from t where param between 2 and 'asd'",
 			"select 1 from t where param between True and 'asd'",
 			"select 1 from t where param between 'qwe' and NULL",
 		},
 		// subqueries
-		[]string{
+		{
 			"select 1 from t where param between (select 1) and (select 1)",
 			"select 1 from t where param between (select 2) and (select 2)",
 		},
 		// subqueries with %%SUBQUERY%% placeholder
-		[]string{
+		{
 			"select 1 from t where param between 1 and (select 1)",
 			"select 1 from t where param between (select 1) and 1",
 			"select 1 from t where param between (select 1) and someFunc()",
 		},
 		// subqueries with %%SUBQUERY%% and %%VALUE%% placeholders
-		[]string{
+		{
 			"select 1 from t where param between 'some value' and (select 'some query')",
 			"select 1 from t where param between someFunc() and 'some value'",
 		},
 	}
 	matchableQueries := [][]string{
 		// left side value placeholder
-		[]string{
+		{
 			"SELECT 1 FROM t WHERE param BETWEEN 1 AND 2",
 			"SELECT 1 FROM t WHERE param BETWEEN 'qwe' AND 2",
 			"SELECT 1 FROM t WHERE param BETWEEN TRUE AND 2",
@@ -188,7 +188,7 @@ func TestHandleRangeCondition(t *testing.T) {
 			"SELECT 1 FROM t WHERE param BETWEEN NULL AND 2",
 		},
 		// right side value placeholder
-		[]string{
+		{
 			"SELECT 1 FROM t WHERE param BETWEEN 1 AND 2",
 			"SELECT 1 FROM t WHERE param BETWEEN 1 AND 'qwe'",
 			"SELECT 1 FROM t WHERE param BETWEEN 1 AND TRUE",
@@ -196,31 +196,31 @@ func TestHandleRangeCondition(t *testing.T) {
 			"SELECT 1 FROM t WHERE param BETWEEN 1 AND NULL",
 		},
 		// two sides placeholder
-		[]string{
+		{
 			"SELECT 1 FROM t WHERE param BETWEEN 1 AND 2",
 			"SELECT 1 FROM t WHERE param BETWEEN NULL AND 'qwe'",
 			"SELECT 1 FROM t WHERE param BETWEEN 'qwe' AND TRUE",
 			"SELECT 1 FROM t WHERE param BETWEEN FALSE AND NULL",
 		},
 		// two explicit int values
-		[]string{
+		{
 			"SELECT 1 FROM t WHERE param BETWEEN 1 AND 2",
 		},
 		// two explicit str values
-		[]string{
+		{
 			"SELECT 1 FROM t WHERE param BETWEEN 'qwe' and 'asd'",
 		},
 		// explicit subqueries
-		[]string{
+		{
 			"select 1 from t where param between (select 1) and (select 2)",
 		},
 		// subqueries with %%SUBQUERY%% placeholder
-		[]string{
+		{
 			"select 1 from t where param between (select 1) and (select 1)",
 			"select 1 from t where param between (select 1) and (select 1 from table1 union select 2 from table2)",
 		},
 		// subqueries with %%SUBQUERY%% and %%VALUE%% placeholders
-		[]string{
+		{
 			"select 1 from t where param between (select 'some query') and 'some value'",
 			"select 1 from t where param between (select 'some query') and 123",
 			"select 1 from t where param between (select 'some query') and FALSE",
@@ -331,14 +331,14 @@ func TestPatternsInWhereClauses(t *testing.T) {
 	}
 	notMatchableQueries := [][]string{
 		// left side value placeholder
-		[]string{
+		{
 			"select 1 from t where param between 'value placeholder' and 3",
 			"select 1 from t where param between 'value placeholder' and 'qwe'",
 			"select 1 from t where param between 'value placeholder' and TRUE",
 			"select 1 from t where param between 'value placeholder' and NULL",
 		},
 		// left side value placeholder with other conditions
-		[]string{
+		{
 			// incorrect param1
 			"select 1 from t where param1 = 1 and param between 'value placeholder' and 2 or param3='qwe'",
 			// incorrect right value
@@ -347,14 +347,14 @@ func TestPatternsInWhereClauses(t *testing.T) {
 			"select 1 from t where param1 = 2 and param between 'value placeholder' and 2 or param3='incorrect'",
 		},
 		// right side value placeholder
-		[]string{
+		{
 			"select 1 from t where param between 2 and 'value placeholder'",
 			"select 1 from t where param between 'qwe' and 'value placeholder'",
 			"select 1 from t where param between TRUE and 'value placeholder'",
 			"select 1 from t where param between NULL and 'value placeholder'",
 		},
 		// right side value placeholder with other conditions
-		[]string{
+		{
 			// incorrect param1
 			"select 1 from t where param1 = 1 and param between 1 and 1 or param1 = TRUE",
 			// incorrect param1
@@ -364,16 +364,16 @@ func TestPatternsInWhereClauses(t *testing.T) {
 		},
 
 		// two sides placeholder
-		[]string{}, // all queries should match
+		{}, // all queries should match
 		// two sides placeholder with other conditions
-		[]string{
+		{
 			// incorrect param1
 			"select 1 from t where param1 = 1 and param between 'asd' and 1 or param1 = TRUE",
 			// incorrect param1
 			"select 1 from t where param1 = 2 and param between 1 and 'qwe' or param1 = FALSE",
 		},
 		// two explicit int values
-		[]string{
+		{
 			"select 1 from t where param between 1 and 3",
 			"select 1 from t where param between 2 and 2",
 			"select 1 from t where param between 1 and 'qwe'",
@@ -381,7 +381,7 @@ func TestPatternsInWhereClauses(t *testing.T) {
 			"select 1 from t where param between 1 and TRUE",
 		},
 		// two explicit int values with other conditions
-		[]string{
+		{
 			// incorrect right condition
 			"select 1 from t where b=2 and param between 1 and 3 and True",
 			// incorrect left condition
@@ -392,7 +392,7 @@ func TestPatternsInWhereClauses(t *testing.T) {
 			"select 1 from t where b=1 and param between 1 and 2 and True",
 		},
 		// two explicit str values
-		[]string{
+		{
 			// incorrect right condition
 			"select 1 from t where param between 'qwe' and 'incorrect'",
 			// incorrect left condition
@@ -403,7 +403,7 @@ func TestPatternsInWhereClauses(t *testing.T) {
 			"select 1 from t where param between 1 and 'asd'",
 		},
 		// two explicit str values with other conditions
-		[]string{
+		{
 			// "select 1 from t where b='qwe' and param between 'qwe' and 'asd' and t in (1,2,3)",
 			// incorrect t in ()
 			"select 1 from t where b='qwe' and param between 'qwe' and 'asd' and t in (1,2,2)",
@@ -417,7 +417,7 @@ func TestPatternsInWhereClauses(t *testing.T) {
 			"select 1 from t where b='qwe' and incorrect_column between 'qwe' and 'asd' and t in (1,2,3)",
 		},
 		// IN clause with %%VALUE%% placeholders
-		[]string{
+		{
 			// incorrect specific value
 			"select 1 from t where b='qwe' and t IN (1, 'qwe', 2)",
 			// subquery instead value
@@ -426,9 +426,9 @@ func TestPatternsInWhereClauses(t *testing.T) {
 			"select 1 from t where b='qwe' and t IN (1, 2, 1, 1)",
 		},
 		// IN clause with %%LIST_OF_VALUES%% placeholders
-		[]string{}, // any length of list is acceptable
+		{}, // any length of list is acceptable
 		// IN clause with %%VALUE%% and %%LIST_OF_VALUES%% placeholders
-		[]string{
+		{
 			// incorrect specific value
 			"select 1 from t where b='qwe' and t IN (1, 2, 1)",
 			// subquery as value
@@ -438,30 +438,30 @@ func TestPatternsInWhereClauses(t *testing.T) {
 		},
 
 		// column IN (%%SUBQUERY%%)
-		[]string{
+		{
 			// anything except subquery
 			"select 1 from t where b='qwe' and t IN (1)",
 		},
 
 		// column IN (%%VALUE, %%SUBQUERY%%, 1, %%LIST_OF_VALUES%%)
-		[]string{
+		{
 			// anything except subquery on subquery placeholder
 			"select 1 from t where b='qwe' and t IN (1, 2, 1, 3)",
 		},
 		// age = (%%SUBQUERY%%)
-		[]string{
+		{
 			// not subquery
 			"select 1 from t where b='qwe' and a=1",
 			// func instead subquery
 			"select 1 from t where b='qwe' and a=someFunc(2)",
 		},
 		// exists without patterns
-		[]string{
+		{
 			// different query in exists
 			"select 1 from t where exists(select 2) and a=2",
 		},
 		// exists with %%SUBQUERY%%
-		[]string{
+		{
 			// func instead exists
 			"select 1 from t where someFunc(1) and a=2",
 			// another value in second param
@@ -470,28 +470,28 @@ func TestPatternsInWhereClauses(t *testing.T) {
 	}
 	matchableQueries := [][]string{
 		// left side value placeholder
-		[]string{
+		{
 			"SELECT 1 FROM t WHERE param BETWEEN 1 AND 2",
 			"SELECT 1 FROM t WHERE param BETWEEN 'qwe' AND 2",
 			"SELECT 1 FROM t WHERE param BETWEEN TRUE AND 2",
 			"SELECT 1 FROM t WHERE param BETWEEN NULL AND 2",
 		},
 		// left side value placeholder with other conditions
-		[]string{
+		{
 			"select 1 from t where param1 = 2 and param between 1 and 2 or param3='qwe'",
 			"select 1 from t where param1 = 2 and param between 'qwe' and 2 or param3='qwe'",
 			"select 1 from t where param1 = 2 and param between TRUE and 2 or param3='qwe'",
 			"select 1 from t where param1 = 2 and param between NULL and 2 or param3='qwe'",
 		},
 		// right side value placeholder
-		[]string{
+		{
 			"SELECT 1 FROM t WHERE param BETWEEN 1 AND 2",
 			"SELECT 1 FROM t WHERE param BETWEEN 1 AND 'qwe'",
 			"SELECT 1 FROM t WHERE param BETWEEN 1 AND TRUE",
 			"SELECT 1 FROM t WHERE param BETWEEN 1 AND NULL",
 		},
 		// right side value placeholder with other conditions
-		[]string{
+		{
 			// incorrect param1
 			"select 1 from t where param1 = 2 and param between 1 and 1 or param1 = TRUE",
 			// incorrect param1
@@ -500,44 +500,44 @@ func TestPatternsInWhereClauses(t *testing.T) {
 			"select 1 from t where param1 = 2 and param between 1 and TRUE or param1 = TRUE",
 		},
 		// two sides placeholder
-		[]string{
+		{
 			"select 1 from t where param between TRUE and 1",
 			"select 1 from t where param between TRUE and 'qwe'",
 			"select 1 from t where param between NULL and FALSE",
 			"select 1 from t where param between 'qwe' and 2",
 		},
 		// two sides placeholder with other conditions
-		[]string{
+		{
 			"select 1 from t where param1 = 2 and param between TRUE and 1 or param2 is NULL",
 			"select 1 from t where param1 = 2 and param between TRUE and 'qwe' or param2 is NULL",
 			"select 1 from t where param1 = 2 and param between NULL and FALSE or param2 is NULL",
 			"select 1 from t where param1 = 2 and param between 'qwe' and 2 or param2 is NULL",
 		},
 		// two explicit int values
-		[]string{
+		{
 			"SELECT 1 FROM t WHERE param BETWEEN 1 AND 2",
 		},
 		// two explicit int values with other conditions
-		[]string{
+		{
 			"select 1 from t where b=2 and param between 1 and 2 and True",
 		},
 		// two explicit str values
-		[]string{
+		{
 			"select 1 from t where param between 'qwe' and 'asd'",
 		},
 		// two explicit str values with other conditions
-		[]string{
+		{
 			"select 1 from t where b='qwe' and param between 'qwe' and 'asd' and t in (1,2,3)",
 		},
 		// IN clause with %%VALUE%% placeholders
-		[]string{
+		{
 			// int, str
 			"select 1 from t where b='qwe' and t IN (1, 'qwe', 1)",
 			// boolean, nullable
 			"select 1 from t where b='qwe' and t IN (FALSE, NULL, 1)",
 		},
 		// IN clause with %%LIST_OF_VALUES%% placeholders
-		[]string{
+		{
 			// one value
 			"select 1 from t where b='qwe' and t IN (1)",
 			// many values
@@ -545,7 +545,7 @@ func TestPatternsInWhereClauses(t *testing.T) {
 		},
 
 		// IN clause with %%VALUE%% and %%LIST_OF_VALUES%% placeholders
-		[]string{
+		{
 			// one value as list of values
 			"select 1 from t where b='qwe' and t IN ('qwe', 1, 1)",
 			// many values as list of values
@@ -553,30 +553,30 @@ func TestPatternsInWhereClauses(t *testing.T) {
 		},
 
 		// column IN (%%SUBQUERY%%)
-		[]string{
+		{
 			"select 1 from t where b='qwe' and t IN ((select 1))",
 			"select 1 from t where b='qwe' and t IN ((select 1 from table1))",
 			"select 1 from t where b='qwe' and t IN ((select column1 from table1 where a=1 union select column1 from table2 where b=1))",
 		},
 
 		// column IN (%%VALUE, %%SUBQUERY%%, 1, %%LIST_OF_VALUES%%)
-		[]string{
+		{
 			"select 1 from t where b='qwe' and t IN (1, (select 1), 1, 1, 2)",
 			"select 1 from t where b='qwe' and t IN (1, (select 1 from table1), 1, 1, 2)",
 			"select 1 from t where b='qwe' and t IN (1, (select column1 from table1 where a=1 union select column1 from table2 where b=1), 1, 1, 2)",
 		},
 		// age = (%%SUBQUERY%%)
-		[]string{
+		{
 			"select 1 from t where b='qwe' and a=(select 1)",
 			"select 1 from t where b='qwe' and a=(select 1 from table1 union select 2 from table2)",
 		},
 		// exists without patterns
-		[]string{
+		{
 			// different query in exists
 			"select 1 from t where exists(select 1) and a=2",
 		},
 		// exists with %%SUBQUERY%%
-		[]string{
+		{
 			// simple query
 			"select 1 from t where exists(select 1) and a=2",
 			// query with union
@@ -625,24 +625,24 @@ func TestGroupByWithColumnPattern(t *testing.T) {
 	}
 
 	matchableQueries := [][]string{
-		[]string{
+		{
 			"SELECT a1 FROM table1 GROUP BY column1",
 			"SELECT a1 FROM table1 GROUP BY 1",
 			"SELECT a1 FROM table1 GROUP BY (select priority from ordering o where o.val = e.name)",
 			"SELECT a1 FROM table1 GROUP BY Date()",
 			"SELECT a1 FROM table1 GROUP BY (case when f1 then 1 when f1 is null then 2 else 3 end)",
 		},
-		[]string{
+		{
 			"select a from b group by a, 2, 1, ABC",
 		},
 	}
 
 	notMatchableQueries := [][]string{
-		[]string{
+		{
 			// two columns
 			"SELECT a1 FROM table1 GROUP BY column1, column2",
 		},
-		[]string{
+		{
 			"SELECT a from b GROUP BY 1, abc, 1, abs",
 			"SELECT a from b GROUP BY a, abc, b, ABC",
 			"SELECT a from b GROUP BY a, abc, 1, ABC, ABC",
@@ -693,16 +693,16 @@ func TestHavingWithColumnAndValueMatch(t *testing.T) {
 	}
 
 	matchableQueries := [][]string{
-		[]string{
+		{
 			"SELECT a1 FROM table1 GROUP BY a2 HAVING COUNT(a) > 100",
 			"SELECT a1 FROM table1 GROUP BY a2 HAVING COUNT(*) > 100",
 		},
-		[]string{
+		{
 			"SELECT a1 FROM table1 GROUP BY a2 HAVING COUNT(a3) > 100",
 			"SELECT a1 FROM table1 GROUP BY a2 HAVING COUNT(a3) > 200.0",
 			"SELECT a1 FROM table1 GROUP BY a2 HAVING COUNT(a3) > NULL",
 		},
-		[]string{
+		{
 			"SELECT a1 FROM table1 GROUP BY a2 HAVING COUNT(a3) > 0",
 			"SELECT a1 FROM table1 GROUP BY a2 HAVING COUNT(a2) > 1000",
 			"SELECT a1 FROM table1 GROUP BY a2 HAVING COUNT(a1) > TRUE",
@@ -710,13 +710,13 @@ func TestHavingWithColumnAndValueMatch(t *testing.T) {
 	}
 
 	notMatchableQueries := [][]string{
-		[]string{
+		{
 			// GroupBy not match
 			"SELECT a1 FROM table1 GROUP BY a3 HAVING COUNT(a) > 100",
 			// Comparison inside Having not match
 			"SELECT a1 FROM table1 GROUP BY a2 HAVING COUNT(a) < 100",
 		},
-		[]string{
+		{
 			// Wrong ColName inside FuncExpr of Having
 			"SELECT a1 FROM table1 GROUP BY a2 HAVING COUNT(a1) > 100",
 			// Wrong ComparisonExpr inside Having
@@ -726,7 +726,7 @@ func TestHavingWithColumnAndValueMatch(t *testing.T) {
 			// Subquery as value
 			"SELECT a1 FROM table1 GROUP BY a2 HAVING COUNT(a3) > (select 1)",
 		},
-		[]string{
+		{
 			// 2 columns inside FuncExpr
 			"SELECT a1 FROM table1 GROUP BY a2 HAVING COUNT(a1, a2) > 10",
 			// Wrong FuncExpr name

--- a/acra-censor/common/matching_logic_test.go
+++ b/acra-censor/common/matching_logic_test.go
@@ -69,7 +69,7 @@ func testSingleTopLevelPlaceholder(t *testing.T, pattern string, indexOfMatchedQ
 	if err != nil {
 		t.Fatal(err)
 	}
-	match := false
+
 	for index := range testQueries {
 
 		stmt, err := sqlparser.Parse(testQueries[index])
@@ -77,7 +77,7 @@ func testSingleTopLevelPlaceholder(t *testing.T, pattern string, indexOfMatchedQ
 			t.Fatal(err)
 		}
 
-		match = CheckPatternsMatching(parsedPatterns, stmt)
+		match := CheckPatternsMatching(parsedPatterns, stmt)
 		if contains(indexOfMatchedQuery, index) {
 			if !match {
 				t.Fatalf("Expected match in query <%s> with pattern <%s>", testQueries[index], pattern)

--- a/cmd/acra-keys/keys/list-keys_test.go
+++ b/cmd/acra-keys/keys/list-keys_test.go
@@ -27,12 +27,12 @@ import (
 
 func TestPrintKeysDefault(t *testing.T) {
 	keys := []keystore.KeyDescription{
-		keystore.KeyDescription{
+		{
 			ID:      "Test ID Please Ignore",
 			Purpose: "no particular",
 			ZoneID:  []byte("Area51"),
 		},
-		keystore.KeyDescription{
+		{
 			ID:      "Another ID",
 			Purpose: "testing",
 		},
@@ -57,12 +57,12 @@ testing       |                | Another ID
 
 func TestPrintKeysJSON(t *testing.T) {
 	keys := []keystore.KeyDescription{
-		keystore.KeyDescription{
+		{
 			ID:      "Test ID Please Ignore",
 			Purpose: "no particular",
 			ZoneID:  []byte("Area51"),
 		},
-		keystore.KeyDescription{
+		{
 			ID:      "Another ID",
 			Purpose: "testing",
 		},

--- a/cmd/acra-server/client_commands_session.go
+++ b/cmd/acra-server/client_commands_session.go
@@ -160,7 +160,7 @@ func (clientSession *ClientCommandsSession) HandleSession() {
 			logger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorGeneral).
 				Warningln("Can't convert config from incoming")
 			response = Response500Error
-			return
+			break
 		}
 		// set config values
 		flag.Set("db_host", configFromUI.DbHost)
@@ -176,7 +176,7 @@ func (clientSession *ClientCommandsSession) HandleSession() {
 			logger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantDumpConfig).
 				Errorln("DumpConfig failed")
 			response = Response500Error
-			return
+			break
 
 		}
 		logger.Infoln("Handled request correctly, restarting server")

--- a/decryptor/binary/binary_decryptor.go
+++ b/decryptor/binary/binary_decryptor.go
@@ -169,6 +169,8 @@ func (decryptor *Decryptor) ReadData(symmetricKey, zoneID []byte, reader io.Read
 
 	scell := cell.New(symmetricKey, cell.ModeSeal)
 	decrypted, err := scell.Unprotect(data, nil, zoneID)
+	utils.FillSlice(0, data)
+	data = nil
 
 	// fill zero symmetric_key
 	utils.FillSlice(byte(0), symmetricKey)

--- a/decryptor/binary/binary_decryptor.go
+++ b/decryptor/binary/binary_decryptor.go
@@ -169,7 +169,7 @@ func (decryptor *Decryptor) ReadData(symmetricKey, zoneID []byte, reader io.Read
 
 	scell := cell.New(symmetricKey, cell.ModeSeal)
 	decrypted, err := scell.Unprotect(data, nil, zoneID)
-	data = nil
+
 	// fill zero symmetric_key
 	utils.FillSlice(byte(0), symmetricKey)
 	if err != nil {

--- a/decryptor/mysql/response_proxy.go
+++ b/decryptor/mysql/response_proxy.go
@@ -644,6 +644,8 @@ func (handler *Handler) processFixedSizeNumberField(ctx context.Context, columnI
 		return nil, err
 	}
 
+	var intValue int64
+	var floatValue float64
 	// After processing, parse the value back and reencode it. Take care for the format to match.
 	// The result must have exact same format as it had. Overflows are unacceptable.
 	switch column.Type {
@@ -653,46 +655,46 @@ func (handler *Handler) processFixedSizeNumberField(ctx context.Context, columnI
 		}
 
 	case TypeTiny:
-		numericValue, err := strconv.ParseInt(string(value), 10, 8)
+		intValue, err = strconv.ParseInt(string(value), 10, 8)
 		if err != nil {
 			break
 		}
-		err = binary.Write(bytes.NewBuffer(encoded[:0]), binary.LittleEndian, int8(numericValue))
+		err = binary.Write(bytes.NewBuffer(encoded[:0]), binary.LittleEndian, int8(intValue))
 
 	case TypeShort, TypeYear:
-		numericValue, err := strconv.ParseInt(string(value), 10, 16)
+		intValue, err = strconv.ParseInt(string(value), 10, 16)
 		if err != nil {
 			break
 		}
-		err = binary.Write(bytes.NewBuffer(encoded[:0]), binary.LittleEndian, int16(numericValue))
+		err = binary.Write(bytes.NewBuffer(encoded[:0]), binary.LittleEndian, int16(intValue))
 
 	case TypeInt24, TypeLong:
-		numericValue, err := strconv.ParseInt(string(value), 10, 32)
+		intValue, err = strconv.ParseInt(string(value), 10, 32)
 		if err != nil {
 			break
 		}
-		err = binary.Write(bytes.NewBuffer(encoded[:0]), binary.LittleEndian, int32(numericValue))
+		err = binary.Write(bytes.NewBuffer(encoded[:0]), binary.LittleEndian, int32(intValue))
 
 	case TypeLongLong:
-		numericValue, err := strconv.ParseInt(string(value), 10, 64)
+		intValue, err = strconv.ParseInt(string(value), 10, 64)
 		if err != nil {
 			break
 		}
-		err = binary.Write(bytes.NewBuffer(encoded[:0]), binary.LittleEndian, int64(numericValue))
+		err = binary.Write(bytes.NewBuffer(encoded[:0]), binary.LittleEndian, int64(intValue))
 
 	case TypeFloat:
-		numericValue, err := strconv.ParseFloat(string(value), 32)
+		floatValue, err = strconv.ParseFloat(string(value), 32)
 		if err != nil {
 			break
 		}
-		err = binary.Write(bytes.NewBuffer(encoded[:0]), binary.LittleEndian, float32(numericValue))
+		err = binary.Write(bytes.NewBuffer(encoded[:0]), binary.LittleEndian, float32(floatValue))
 
 	case TypeDouble:
-		numericValue, err := strconv.ParseFloat(string(value), 64)
+		floatValue, err = strconv.ParseFloat(string(value), 64)
 		if err != nil {
 			break
 		}
-		err = binary.Write(bytes.NewBuffer(encoded[:0]), binary.LittleEndian, float64(numericValue))
+		err = binary.Write(bytes.NewBuffer(encoded[:0]), binary.LittleEndian, float64(floatValue))
 
 	default:
 		err = fmt.Errorf("MySQL field type not supported: <type=%d> <name=%s>", column.Type, column.Name)

--- a/decryptor/postgresql/packet_handler_test.go
+++ b/decryptor/postgresql/packet_handler_test.go
@@ -28,7 +28,7 @@ func TestClientUnknownCommand(t *testing.T) {
 	unknownMessageType := byte(1)
 	lengthBuf := []byte{0, 0, 0, 7}
 	dataBuf := []byte{1, 2, 3}
-	packet := bytes.Join([][]byte{[]byte{unknownMessageType}, lengthBuf, dataBuf}, []byte{})
+	packet := bytes.Join([][]byte{{unknownMessageType}, lengthBuf, dataBuf}, []byte{})
 	reader := bytes.NewReader(packet)
 	output := make([]byte, 8)
 	writer := bufio.NewWriter(bytes.NewBuffer(output[:0]))

--- a/decryptor/postgresql/pg_hex_decryptor.go
+++ b/decryptor/postgresql/pg_hex_decryptor.go
@@ -252,7 +252,7 @@ func (decryptor *PgHexDecryptor) ReadData(symmetricKey, zoneID []byte, reader io
 	scell := cell.New(symmetricKey, cell.ModeSeal)
 
 	decrypted, err := scell.Unprotect(data, nil, zoneID)
-	data = nil
+
 	// fill zero symmetric_key
 	utils.FillSlice(byte(0), symmetricKey)
 	if err != nil {
@@ -262,7 +262,7 @@ func (decryptor *PgHexDecryptor) ReadData(symmetricKey, zoneID []byte, reader io
 	outputLength := hexEncodedLen(uint64(len(decrypted)))
 	decryptor.checkBuf(&decryptor.output, outputLength)
 	hex.Encode(decryptor.output[:outputLength], decrypted)
-	decrypted = nil
+
 	return decryptor.output[:outputLength], nil
 }
 

--- a/decryptor/postgresql/pg_hex_decryptor.go
+++ b/decryptor/postgresql/pg_hex_decryptor.go
@@ -252,6 +252,8 @@ func (decryptor *PgHexDecryptor) ReadData(symmetricKey, zoneID []byte, reader io
 	scell := cell.New(symmetricKey, cell.ModeSeal)
 
 	decrypted, err := scell.Unprotect(data, nil, zoneID)
+	utils.FillSlice(0, data)
+	data = nil
 
 	// fill zero symmetric_key
 	utils.FillSlice(byte(0), symmetricKey)
@@ -262,6 +264,8 @@ func (decryptor *PgHexDecryptor) ReadData(symmetricKey, zoneID []byte, reader io
 	outputLength := hexEncodedLen(uint64(len(decrypted)))
 	decryptor.checkBuf(&decryptor.output, outputLength)
 	hex.Encode(decryptor.output[:outputLength], decrypted)
+	utils.FillSlice(0, decrypted)
+	decrypted = nil
 
 	return decryptor.output[:outputLength], nil
 }

--- a/encryptor/utils_test.go
+++ b/encryptor/utils_test.go
@@ -52,21 +52,21 @@ inner join table6 on table6.col1=t1.col1
 `
 	expectedValues := []columnInfo{
 		// column's alias is subquery alias with column and table without aliases in subquery
-		columnInfo{Alias: "t1", Table: "table1", Name: "col1"},
+		{Alias: "t1", Table: "table1", Name: "col1"},
 		// column's alias is subquery alias with column with AS expression and table without alias
-		columnInfo{Alias: "t1", Table: "table1", Name: "col22"},
+		{Alias: "t1", Table: "table1", Name: "col22"},
 		// column's alias is subquery alias and column name has alias in subquery to table with alias
-		columnInfo{Alias: "t2", Table: "table1", Name: "col1"},
+		{Alias: "t2", Table: "table1", Name: "col1"},
 		// column's alias is subquery alias and column name has alias in subquery to joined table with alias
-		columnInfo{Alias: "t2", Table: "table2", Name: "col3"},
+		{Alias: "t2", Table: "table2", Name: "col3"},
 		// column's alias is alias of joined table
-		columnInfo{Alias: "t3", Table: "table3", Name: "col1"},
+		{Alias: "t3", Table: "table3", Name: "col1"},
 		// column's alias is alias of joined table with AS expression
-		columnInfo{Alias: "t4", Table: "table4", Name: "col4"},
+		{Alias: "t4", Table: "table4", Name: "col4"},
 		// column without alias of table in FROM expression
-		columnInfo{Table: "table5", Name: "col5", Alias: "table5"},
+		{Table: "table5", Name: "col5", Alias: "table5"},
 		// column with alias as table name in FROM expression
-		columnInfo{Table: "table6", Name: "col6", Alias: "table6"},
+		{Table: "table6", Name: "col6", Alias: "table6"},
 	}
 	parsed, err := sqlparser.Parse(query)
 	if err != nil {

--- a/keystore/filesystem/server_keystore_test.go
+++ b/keystore/filesystem/server_keystore_test.go
@@ -495,17 +495,26 @@ func TestFilesystemKeyStoreExport(t *testing.T) {
 	}
 	// Since we cannot access all generated key pairs via AcraServer keystore,
 	// we generate them here and use Save... API
-	connectorKeyPair, _ := keys.New(keys.TypeEC)
+	connectorKeyPair, err := keys.New(keys.TypeEC)
+	if err != nil {
+		t.Fatalf("keys.New() failed: %v", err)
+	}
 	err = keyStore.SaveConnectorKeypair(clientID, connectorKeyPair)
 	if err != nil {
 		t.Fatalf("SaveConnectorKeypair() failed: %v", err)
 	}
-	serverKeyPair, _ := keys.New(keys.TypeEC)
+	serverKeyPair, err := keys.New(keys.TypeEC)
+	if err != nil {
+		t.Fatalf("keys.New() failed: %v", err)
+	}
 	err = keyStore.SaveServerKeypair(clientID, serverKeyPair)
 	if err != nil {
 		t.Fatalf("SaveServerKeypair() failed: %v", err)
 	}
-	translatorKeyPair, _ := keys.New(keys.TypeEC)
+	translatorKeyPair, err := keys.New(keys.TypeEC)
+	if err != nil {
+		t.Fatalf("keys.New() failed: %v", err)
+	}
 	err = keyStore.SaveTranslatorKeypair(clientID, translatorKeyPair)
 	if err != nil {
 		t.Fatalf("SaveTranslatorKeypair() failed: %v", err)

--- a/keystore/filesystem/server_keystore_test.go
+++ b/keystore/filesystem/server_keystore_test.go
@@ -495,17 +495,17 @@ func TestFilesystemKeyStoreExport(t *testing.T) {
 	}
 	// Since we cannot access all generated key pairs via AcraServer keystore,
 	// we generate them here and use Save... API
-	connectorKeyPair, err := keys.New(keys.TypeEC)
+	connectorKeyPair, _ := keys.New(keys.TypeEC)
 	err = keyStore.SaveConnectorKeypair(clientID, connectorKeyPair)
 	if err != nil {
 		t.Fatalf("SaveConnectorKeypair() failed: %v", err)
 	}
-	serverKeyPair, err := keys.New(keys.TypeEC)
+	serverKeyPair, _ := keys.New(keys.TypeEC)
 	err = keyStore.SaveServerKeypair(clientID, serverKeyPair)
 	if err != nil {
 		t.Fatalf("SaveServerKeypair() failed: %v", err)
 	}
-	translatorKeyPair, err := keys.New(keys.TypeEC)
+	translatorKeyPair, _ := keys.New(keys.TypeEC)
 	err = keyStore.SaveTranslatorKeypair(clientID, translatorKeyPair)
 	if err != nil {
 		t.Fatalf("SaveTranslatorKeypair() failed: %v", err)

--- a/keystore/filesystem/storage.go
+++ b/keystore/filesystem/storage.go
@@ -39,11 +39,11 @@ type Storage interface {
 	Rename(oldpath, newpath string) error
 	// TempFile creates a new temporary file with given name pattern and access permissions.
 	// Name of the newly created file is returned.
-	// Caller is responsibile for removing the file once they are done with it.
+	// Caller is responsible for removing the file once they are done with it.
 	TempFile(pattern string, perm os.FileMode) (string, error)
 	// TempDir creates a new temporary directory with given name pattern and access permissions.
 	// Name of the newly created directory is returned.
-	// Caller is responsibile for removing the directory and its contents once they are done with it.
+	// Caller is responsible for removing the directory and its contents once they are done with it.
 	TempDir(pattern string, perm os.FileMode) (string, error)
 	// Link creates a hard link at newpath which refers to the same path as oldpath.
 	// Not all file systems support hard links, and there may be restrictions on hard links between different directories.
@@ -52,7 +52,7 @@ type Storage interface {
 	// It is an error if dst already exists.
 	// dst is an independent copy of src with initially identical content.
 	Copy(src, dst string) error
-	// ReadFile reads entire content of the specifed file.
+	// ReadFile reads entire content of the specified file.
 	ReadFile(path string) ([]byte, error)
 	// WriteAll replaces entire content of the specified file, creating it with specified mode if it does not exist.
 	WriteFile(path string, data []byte, perm os.FileMode) error

--- a/keystore/v2/keystore/api/tests/key.go
+++ b/keystore/v2/keystore/api/tests/key.go
@@ -58,7 +58,7 @@ func testKeyInitialState(t *testing.T, newKeyStore NewKeyStore) {
 		ValidSince: validSince,
 		ValidUntil: validUntil,
 		Data: []api.KeyData{
-			api.KeyData{
+			{
 				Format:     api.ThemisKeyPairFormat,
 				PublicKey:  publicKey,
 				PrivateKey: privateKey,
@@ -124,7 +124,7 @@ func testKeyFormatLookup(t *testing.T, newKeyStore NewKeyStore) {
 		ValidSince: time.Now(),
 		ValidUntil: time.Now().Add(time.Hour),
 		Data: []api.KeyData{
-			api.KeyData{
+			{
 				Format:    api.ThemisKeyPairFormat,
 				PublicKey: []byte("my public key"),
 			},
@@ -178,7 +178,7 @@ func testKeyInvalidInputs(t *testing.T, newKeyStore NewKeyStore) {
 		ValidSince: time.Now(),
 		ValidUntil: time.Now().Add(time.Hour),
 		Data: []api.KeyData{
-			api.KeyData{
+			{
 				Format:       api.KeyFormat(9000),
 				SymmetricKey: []byte("secret"),
 			},
@@ -192,7 +192,7 @@ func testKeyInvalidInputs(t *testing.T, newKeyStore NewKeyStore) {
 		ValidSince: time.Now(),
 		ValidUntil: time.Now().Add(time.Hour),
 		Data: []api.KeyData{
-			api.KeyData{
+			{
 				Format: api.ThemisKeyPairFormat,
 			},
 		},
@@ -205,7 +205,7 @@ func testKeyInvalidInputs(t *testing.T, newKeyStore NewKeyStore) {
 		ValidSince: time.Now(),
 		ValidUntil: time.Now().Add(time.Hour),
 		Data: []api.KeyData{
-			api.KeyData{
+			{
 				Format:     api.ThemisKeyPairFormat,
 				PublicKey:  []byte{},
 				PrivateKey: []byte("asdasdas"),
@@ -220,7 +220,7 @@ func testKeyInvalidInputs(t *testing.T, newKeyStore NewKeyStore) {
 		ValidSince: time.Now(),
 		ValidUntil: time.Now().Add(time.Hour),
 		Data: []api.KeyData{
-			api.KeyData{
+			{
 				Format:    api.ThemisKeyPairFormat,
 				PublicKey: []byte("it's okay to have no private key"),
 			},
@@ -234,7 +234,7 @@ func testKeyInvalidInputs(t *testing.T, newKeyStore NewKeyStore) {
 		ValidSince: time.Now(),
 		ValidUntil: time.Now().Add(time.Hour),
 		Data: []api.KeyData{
-			api.KeyData{
+			{
 				Format:     api.ThemisSymmetricKeyFormat,
 				PrivateKey: []byte("should use SymmetricKey"),
 			},
@@ -248,11 +248,11 @@ func testKeyInvalidInputs(t *testing.T, newKeyStore NewKeyStore) {
 		ValidSince: time.Now(),
 		ValidUntil: time.Now().Add(time.Hour),
 		Data: []api.KeyData{
-			api.KeyData{
+			{
 				Format:       api.ThemisSymmetricKeyFormat,
 				SymmetricKey: []byte("secret"),
 			},
-			api.KeyData{
+			{
 				Format:       api.ThemisSymmetricKeyFormat,
 				SymmetricKey: []byte("more"),
 			},
@@ -276,7 +276,7 @@ func testKeyStateSwitching(t *testing.T, newKeyStore NewKeyStore) {
 		ValidSince: time.Now(),
 		ValidUntil: time.Now().Add(time.Hour),
 		Data: []api.KeyData{
-			api.KeyData{
+			{
 				Format:       api.ThemisSymmetricKeyFormat,
 				SymmetricKey: []byte("secret"),
 			},

--- a/keystore/v2/keystore/api/tests/keyRing.go
+++ b/keystore/v2/keystore/api/tests/keyRing.go
@@ -80,7 +80,7 @@ func testKeyRingAddingKeys(t *testing.T, newKeyStore NewKeyStore) {
 		ValidSince: time.Now(),
 		ValidUntil: time.Now().Add(time.Hour),
 		Data: []api.KeyData{
-			api.KeyData{
+			{
 				Format:       api.ThemisSymmetricKeyFormat,
 				SymmetricKey: []byte("data v1"),
 			},
@@ -93,7 +93,7 @@ func testKeyRingAddingKeys(t *testing.T, newKeyStore NewKeyStore) {
 		ValidSince: time.Now(),
 		ValidUntil: time.Now().Add(time.Hour),
 		Data: []api.KeyData{
-			api.KeyData{
+			{
 				Format:       api.ThemisSymmetricKeyFormat,
 				SymmetricKey: []byte("data v2"),
 			},
@@ -133,7 +133,7 @@ func testKeyRingCurrent(t *testing.T, newKeyStore NewKeyStore) {
 		ValidSince: time.Now(),
 		ValidUntil: time.Now().Add(time.Hour),
 		Data: []api.KeyData{
-			api.KeyData{
+			{
 				Format:       api.ThemisSymmetricKeyFormat,
 				SymmetricKey: []byte("data v1"),
 			},
@@ -166,7 +166,7 @@ func testKeyRingCurrent(t *testing.T, newKeyStore NewKeyStore) {
 		ValidSince: time.Now(),
 		ValidUntil: time.Now().Add(time.Hour),
 		Data: []api.KeyData{
-			api.KeyData{
+			{
 				Format:       api.ThemisSymmetricKeyFormat,
 				SymmetricKey: []byte("data v2"),
 			},
@@ -233,7 +233,7 @@ func testKeyRingDestroyingKeys(t *testing.T, newKeyStore NewKeyStore) {
 		ValidSince: time.Now(),
 		ValidUntil: time.Now().Add(time.Hour),
 		Data: []api.KeyData{
-			api.KeyData{
+			{
 				Format:     api.ThemisKeyPairFormat,
 				PublicKey:  []byte("public key v1"),
 				PrivateKey: []byte("private key v1"),
@@ -247,7 +247,7 @@ func testKeyRingDestroyingKeys(t *testing.T, newKeyStore NewKeyStore) {
 		ValidSince: time.Now(),
 		ValidUntil: time.Now().Add(time.Hour),
 		Data: []api.KeyData{
-			api.KeyData{
+			{
 				Format:     api.ThemisKeyPairFormat,
 				PublicKey:  []byte("public key v2"),
 				PrivateKey: []byte("private key v2"),

--- a/keystore/v2/keystore/api/tests/keyStore.go
+++ b/keystore/v2/keystore/api/tests/keyStore.go
@@ -93,7 +93,7 @@ func setupDemoKeyStore(s api.MutableKeyStore, t *testing.T) {
 		ValidSince: time.Now(),
 		ValidUntil: time.Now().Add(time.Hour),
 		Data: []api.KeyData{
-			api.KeyData{
+			{
 				Format:     api.ThemisKeyPairFormat,
 				PublicKey:  demoPublicKeyData,
 				PrivateKey: demoPrivateKeyData,
@@ -112,7 +112,7 @@ func setupDemoKeyStore(s api.MutableKeyStore, t *testing.T) {
 		ValidSince: time.Now(),
 		ValidUntil: time.Now().Add(time.Hour),
 		Data: []api.KeyData{
-			api.KeyData{
+			{
 				Format:    api.ThemisKeyPairFormat,
 				PublicKey: demoPublicKeyData,
 			},
@@ -130,7 +130,7 @@ func setupDemoKeyStore(s api.MutableKeyStore, t *testing.T) {
 		ValidSince: time.Now(),
 		ValidUntil: time.Now().Add(time.Hour),
 		Data: []api.KeyData{
-			api.KeyData{
+			{
 				Format:       api.ThemisSymmetricKeyFormat,
 				SymmetricKey: demoSymmetricKeyData,
 			},
@@ -486,7 +486,7 @@ func testKeyStoreDuplicateImportOverwrite(t *testing.T, newKeyStore NewKeyStore)
 		ValidSince: time.Now(),
 		ValidUntil: time.Now().Add(time.Hour),
 		Data: []api.KeyData{
-			api.KeyData{
+			{
 				Format:    api.ThemisKeyPairFormat,
 				PublicKey: []byte("another public key"),
 			},

--- a/keystore/v2/keystore/filesystem/export.go
+++ b/keystore/v2/keystore/filesystem/export.go
@@ -74,7 +74,7 @@ func (s *KeyStore) importKeyRing(newRingData *asn1.KeyRing, delegate api.KeyRing
 	err := s.readKeyRing(keyRing)
 	switch err {
 	case nil:
-		// If the keystore successfuly returned an existing key ring with the same name,
+		// If the keystore successfully returned an existing key ring with the same name,
 		// we have to resolve this conflict somehow. Present both current and new versions
 		// to the delegate and let it decide how to proceed.
 		decision, err := delegate.DecideKeyRingOverwrite(keyRing.data, newRingData)

--- a/keystore/v2/keystore/filesystem/keyStoreLoad.go
+++ b/keystore/v2/keystore/filesystem/keyStoreLoad.go
@@ -104,7 +104,7 @@ func (s *KeyStore) openKeyRing(ring *KeyRing) (err error) {
 
 	err = s.pullRingUpdates(ring)
 	if err != nil {
-		// If we tried to pull non-existant key ring, create a new empty one instead.
+		// If we tried to pull non-existent key ring, create a new empty one instead.
 		if err == backend.ErrNotExist {
 			return s.pushNewRingState(ring)
 		}

--- a/keystore/v2/keystore/filesystem/keyStore_test.go
+++ b/keystore/v2/keystore/filesystem/keyStore_test.go
@@ -85,7 +85,7 @@ func TestKeyStoreOpeningDir(t *testing.T) {
 
 	_, err = OpenDirectory(rootPath, testKeyStoreSuite(t))
 	if err != backendAPI.ErrNotExist {
-		t.Errorf("opened non-existant keystore: %v", err)
+		t.Errorf("opened non-existent keystore: %v", err)
 	}
 
 	if IsKeyDirectory(rootPath) {
@@ -153,7 +153,7 @@ func TestKeyStoreOpeningRings(t *testing.T) {
 
 	_, err = s.OpenKeyRing("some/keyring")
 	if err != backendAPI.ErrNotExist {
-		t.Errorf("opened non-existant key ring: %v", err)
+		t.Errorf("opened non-existent key ring: %v", err)
 	}
 
 	_, err = s.OpenKeyRingRW("some/keyring")

--- a/keystore/v2/keystore/importV1_test.go
+++ b/keystore/v2/keystore/importV1_test.go
@@ -100,17 +100,17 @@ func TestImportKeyStoreV1(t *testing.T) {
 	}
 	// Since we cannot access all generated key pairs via AcraServer keystore,
 	// we generate them here and use Save... API
-	connectorKeyPairV1, err := keys.New(keys.TypeEC)
+	connectorKeyPairV1, _ := keys.New(keys.TypeEC)
 	err = keyStoreV1.SaveConnectorKeypair(clientID, connectorKeyPairV1)
 	if err != nil {
 		t.Errorf("SaveConnectorKeypair() failed: %v", err)
 	}
-	serverKeyPairV1, err := keys.New(keys.TypeEC)
+	serverKeyPairV1, _ := keys.New(keys.TypeEC)
 	err = keyStoreV1.SaveServerKeypair(clientID, serverKeyPairV1)
 	if err != nil {
 		t.Errorf("SaveServerKeypair() failed: %v", err)
 	}
-	translatorKeyPairV1, err := keys.New(keys.TypeEC)
+	translatorKeyPairV1, _ := keys.New(keys.TypeEC)
 	err = keyStoreV1.SaveTranslatorKeypair(clientID, translatorKeyPairV1)
 	if err != nil {
 		t.Errorf("SaveTranslatorKeypair() failed: %v", err)

--- a/keystore/v2/keystore/importV1_test.go
+++ b/keystore/v2/keystore/importV1_test.go
@@ -100,17 +100,26 @@ func TestImportKeyStoreV1(t *testing.T) {
 	}
 	// Since we cannot access all generated key pairs via AcraServer keystore,
 	// we generate them here and use Save... API
-	connectorKeyPairV1, _ := keys.New(keys.TypeEC)
+	connectorKeyPairV1, err := keys.New(keys.TypeEC)
+	if err != nil {
+		t.Errorf("keys.New() failed: %v", err)
+	}
 	err = keyStoreV1.SaveConnectorKeypair(clientID, connectorKeyPairV1)
 	if err != nil {
 		t.Errorf("SaveConnectorKeypair() failed: %v", err)
 	}
-	serverKeyPairV1, _ := keys.New(keys.TypeEC)
+	serverKeyPairV1, err := keys.New(keys.TypeEC)
+	if err != nil {
+		t.Errorf("keys.New() failed: %v", err)
+	}
 	err = keyStoreV1.SaveServerKeypair(clientID, serverKeyPairV1)
 	if err != nil {
 		t.Errorf("SaveServerKeypair() failed: %v", err)
 	}
-	translatorKeyPairV1, _ := keys.New(keys.TypeEC)
+	translatorKeyPairV1, err := keys.New(keys.TypeEC)
+	if err != nil {
+		t.Errorf("keys.New() failed: %v", err)
+	}
 	err = keyStoreV1.SaveTranslatorKeypair(clientID, translatorKeyPairV1)
 	if err != nil {
 		t.Errorf("SaveTranslatorKeypair() failed: %v", err)

--- a/keystore/v2/keystore/keyRingUtils.go
+++ b/keystore/v2/keystore/keyRingUtils.go
@@ -126,7 +126,7 @@ func (s *ServerKeyStore) describeNewKeyPair(keypair *keys.Keypair) api.KeyDescri
 		ValidSince: time.Now(),
 		ValidUntil: time.Now().Add(defaultKeyCryptoperiod),
 		Data: []api.KeyData{
-			api.KeyData{
+			{
 				Format:     api.ThemisKeyPairFormat,
 				PublicKey:  keypair.Public.Value,
 				PrivateKey: keypair.Private.Value,
@@ -188,7 +188,7 @@ func (s *ServerKeyStore) describeNewSymmetricKey(key []byte) api.KeyDescription 
 		ValidSince: time.Now(),
 		ValidUntil: time.Now().Add(defaultKeyCryptoperiod),
 		Data: []api.KeyData{
-			api.KeyData{
+			{
 				Format:       api.ThemisSymmetricKeyFormat,
 				SymmetricKey: key,
 			},

--- a/keystore/v2/keystore/signature/notary_test.go
+++ b/keystore/v2/keystore/signature/notary_test.go
@@ -160,7 +160,7 @@ func TestUnknownSignature(t *testing.T) {
 		Payload: asn1.SignedPayload{
 			Data: 42,
 		},
-		Signatures: []asn1.Signature{asn1.Signature{
+		Signatures: []asn1.Signature{{
 			Algorithm: honestOID,
 			Signature: []byte("real thing, trust me"),
 		}},

--- a/logging/log_formatters.go
+++ b/logging/log_formatters.go
@@ -43,6 +43,7 @@ func TextFormatter() Formatter {
 	}
 }
 
+// JSONFormatter returns a default logrus.JSONFormatter with specific settings
 func JSONFormatter() Formatter {
 	return &AcraJSONFormatter{
 		Formatter: &logrus.JSONFormatter{
@@ -54,6 +55,7 @@ func JSONFormatter() Formatter {
 	}
 }
 
+// CEFFormatter returns a default CEFTextFormatter with specific settings
 func CEFFormatter() Formatter {
 	return &AcraCEFFormatter{
 		CEFTextFormatter: CEFTextFormatter{
@@ -106,14 +108,17 @@ type AcraTextFormatter struct {
 	Hooks []FormatterHook
 }
 
+// SetServiceName set service name
 func (f *AcraTextFormatter) SetServiceName(serviceName string) {
 	// service name is ignored by plaintext formatter, so just do nothing
 }
 
+// SetHooks set formatter hooks
 func (f *AcraTextFormatter) SetHooks(hooks []FormatterHook) {
 	f.Hooks = hooks
 }
 
+// GetHooks get formatter hooks
 func (f *AcraTextFormatter) GetHooks() []FormatterHook {
 	return f.Hooks
 }
@@ -132,6 +137,7 @@ type AcraJSONFormatter struct {
 	Hooks []FormatterHook
 }
 
+// SetServiceName set service name
 func (f *AcraJSONFormatter) SetServiceName(serviceName string) {
 	fields := log.Fields{FieldKeyProduct: serviceName}
 	for k, v := range extraJSONFields {
@@ -142,10 +148,12 @@ func (f *AcraJSONFormatter) SetServiceName(serviceName string) {
 	f.Fields = fields
 }
 
+// SetHooks set formatter hooks
 func (f *AcraJSONFormatter) SetHooks(hooks []FormatterHook) {
 	f.Hooks = hooks
 }
 
+// GetHooks get formatter hooks
 func (f *AcraJSONFormatter) GetHooks() []FormatterHook {
 	return f.Hooks
 }
@@ -159,6 +167,7 @@ type AcraCEFFormatter struct {
 	Hooks []FormatterHook
 }
 
+// SetServiceName set service name
 func (f *AcraCEFFormatter) SetServiceName(serviceName string) {
 	fields := log.Fields{FieldKeyProduct: serviceName}
 	for k, v := range extraJSONFields {
@@ -174,10 +183,12 @@ func (f *AcraCEFFormatter) SetServiceName(serviceName string) {
 	f.Fields = fields
 }
 
+// SetHooks set formatter hooks
 func (f *AcraCEFFormatter) SetHooks(hooks []FormatterHook) {
 	f.Hooks = hooks
 }
 
+// GetHooks get formatter hooks
 func (f *AcraCEFFormatter) GetHooks() []FormatterHook {
 	return f.Hooks
 }

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -37,6 +37,7 @@ const (
 	LogDiscard
 )
 
+// Log formats
 const (
 	PlaintextFormatString = "plaintext"
 	JsonFormatString      = "json"

--- a/network/connection_metadata.go
+++ b/network/connection_metadata.go
@@ -18,6 +18,7 @@ package network
 
 import "go.opencensus.io/trace"
 
+// ConnectionMetadataBuilder builds connection metadata
 type ConnectionMetadataBuilder struct {
 	clientID []byte
 	// opencensus uses and pass SpanContext by value everywhere to avoid problems with sharing state between thread

--- a/network/connection_wrapper.go
+++ b/network/connection_wrapper.go
@@ -27,6 +27,7 @@ type ConnectionTimeoutWrapper interface {
 	net.Conn
 }
 
+// ConnectionMetadata connection metadata
 type ConnectionMetadata interface {
 	SpanContext() (trace.SpanContext, bool)
 	ClientID() ([]byte, bool)

--- a/network/trace.go
+++ b/network/trace.go
@@ -52,6 +52,7 @@ type traceWrapper struct {
 	wrapper ConnectionWrapper
 }
 
+// NewTraceConnectionWrapper creates traceWrapper from ConnectionWrapper
 func NewTraceConnectionWrapper(wrapper ConnectionWrapper) (*traceWrapper, error) {
 	return &traceWrapper{wrapper}, nil
 }

--- a/sqlparser/dependency/sqltypes/bind_variables_test.go
+++ b/sqlparser/dependency/sqltypes/bind_variables_test.go
@@ -518,7 +518,7 @@ func TestBindVariableToValue(t *testing.T) {
 		t.Errorf("BindVarToValue(1): %v, want %v", v, want)
 	}
 
-	v, err = BindVariableToValue(&querypb.BindVariable{Type: querypb.Type_TUPLE})
+	_, err = BindVariableToValue(&querypb.BindVariable{Type: querypb.Type_TUPLE})
 	wantErr := "cannot convert a TUPLE bind var into a value"
 	if err == nil || err.Error() != wantErr {
 		t.Errorf(" BindVarToValue(TUPLE): %v, want %s", err, wantErr)

--- a/sqlparser/dependency/sqltypes/plan_value.go
+++ b/sqlparser/dependency/sqltypes/plan_value.go
@@ -221,7 +221,7 @@ func ResolveRows(pvs []PlanValue, bindVars map[string]*querypb.BindVariable) ([]
 		rows[i] = make([]Value, len(pvs))
 	}
 
-	// Using j becasue we're resolving by columns.
+	// Using j because we're resolving by columns.
 	for j, pv := range pvs {
 		switch {
 		case pv.Key != "":

--- a/sqlparser/dependency/sqltypes/value.go
+++ b/sqlparser/dependency/sqltypes/value.go
@@ -49,7 +49,7 @@ type BinWriter interface {
 }
 
 // Value can store any SQL value. If the value represents
-// an integral type, the bytes are always stored as a cannonical
+// an integral type, the bytes are always stored as a canonical
 // representation that matches how MySQL returns such values.
 type Value struct {
 	typ querypb.Type
@@ -127,7 +127,7 @@ func NewVarBinary(v string) Value {
 	return MakeTrusted(VarBinary, []byte(v))
 }
 
-// NewIntegral builds an integral type from a string representaion.
+// NewIntegral builds an integral type from a string representation.
 // The type will be Int64 or Uint64. Int64 will be preferred where possible.
 func NewIntegral(val string) (n Value, err error) {
 	signed, err := strconv.ParseInt(val, 0, 64)
@@ -170,7 +170,7 @@ func (v Value) Type() querypb.Type {
 	return v.typ
 }
 
-// Raw returns the internal represenation of the value. For newer types,
+// Raw returns the internal representation of the value. For newer types,
 // this may not match MySQL's representation.
 func (v Value) Raw() []byte {
 	return v.val

--- a/sqlparser/parse_test.go
+++ b/sqlparser/parse_test.go
@@ -1895,12 +1895,12 @@ func TestCreateTable(t *testing.T) {
 	}
 
 	sql := "create table t garbage"
-	tree, err := Parse(sql)
+	_, err := Parse(sql)
 	if err != nil {
 		t.Errorf("input: %s, err: %v", sql, err)
 	}
 
-	tree, err = ParseStrictDDL(sql)
+	tree, err := ParseStrictDDL(sql)
 	if tree != nil || err == nil {
 		t.Errorf("ParseStrictDDL unexpectedly accepted input %s", sql)
 	}

--- a/zone/zone_id_matcher_test.go
+++ b/zone/zone_id_matcher_test.go
@@ -58,7 +58,9 @@ func (storage *TestKeyStore) GetPeerPublicKey(id []byte) (*keys.PublicKey, error
 func (storage *TestKeyStore) GetPrivateKey(id []byte) (*keys.PrivateKey, error) {
 	return &keys.PrivateKey{Value: []byte{}}, nil
 }
-func (storage *TestKeyStore) GenerateZoneKey() ([]byte, []byte, error) { return []byte{}, []byte{}, nil }
+func (storage *TestKeyStore) GenerateZoneKey() ([]byte, []byte, error) {
+	return []byte{}, []byte{}, nil
+}
 
 func (storage *TestKeyStore) Reset()                                     {}
 func (storage *TestKeyStore) GenerateConnectorKeys(id []byte) error      { return nil }


### PR DESCRIPTION
* Fix `gofmt` issues (apply suggestions by `gofmt`)
* Fix misspells
* Fix golint issues (add comments to exported types and functions)
* Fix `ineffassign` issues (those are assignments to variables that are unused or rewritten afterwards)
* Fix two bugs (I guess) detected by `ineffassign`:
    * In `cmd/acra-server/client_commands_session.go` the function was
      returning instead of breaking `switch` and reporting error to client
    * In `decryptor/mysql/response_proxy.go` we had `:=` that overrides the
      scope so the new `err` was created instead of writing to already
      defined one

Feel free to remove the :beetle:`bug` label if those bugs are not actually bugs and I misunderstood the code.

It turns out that CircleCI scripts are a little bit broken and `golint` check was not performed automatically when PRs were created/updated. Gonna fix that in different PR as well as add `misspell` checker, and maybe `ineffassign` one.