### PR TITLE
Unify key ID paths in "acra-keys"

### DIFF
--- a/configs/acra-keys.yaml
+++ b/configs/acra-keys.yaml
@@ -53,11 +53,11 @@ src_keys_dir_public:
 # keystore format to use: v1 (current), v2 (new)
 src_keystore: 
 
-# client ID for which to retrieve key
-client_id: 
+# read private key of the keypair
+private: false
 
-# zone ID for which to retrieve key
-zone_id: 
+# read public key of the keypair
+public: false
 
 # Generate transport keypair for AcraConnector
 acraconnector_transport_key: false
@@ -71,6 +71,9 @@ acratranslator_transport_key: false
 # Generate symmetric key for AcraWebconfig's basic auth DB
 acrawebconfig_symmetric_key: false
 
+# Client ID
+client_id: 
+
 # Generate keypair for data encryption/decryption (for a client)
 client_storage_key: false
 
@@ -82,6 +85,9 @@ master_key_path:
 
 # Generate new Acra storage zone
 zone: false
+
+# Zone ID
+zone_id: 
 
 # Rotate existing Acra zone storagae keypair
 zone_storage_key: false

--- a/tests/test.py
+++ b/tests/test.py
@@ -62,7 +62,7 @@ import utils
 from utils import (read_storage_public_key, read_storage_private_key,
                    read_zone_public_key, read_zone_private_key,
                    read_poison_public_key, read_poison_private_key,
-                   destroy_key,
+                   destroy_connector_transport, destroy_server_transport,
                    decrypt_acrastruct,
                    load_random_data_config, get_random_data_files,
                    clean_test_data, safe_string, prepare_encryptor_config,
@@ -1801,9 +1801,8 @@ class TestKeyNonExistence(BaseTestCase):
     def test_without_acraconnector_public(self):
         """acra-server without acra-connector public key should drop connection
         from acra-connector than acra-connector should drop connection from psycopg2"""
-        destroy_key(kind='transport-connector',
-                    client_id=self.client_id,
-                    keys_dir=self.server_keys_dir)
+        destroy_connector_transport(client_id=self.client_id,
+                                    keys_dir=self.server_keys_dir)
         engine = None
         if TEST_MYSQL:
             expected_exception = pymysql.err.OperationalError
@@ -1842,9 +1841,8 @@ class TestKeyNonExistence(BaseTestCase):
 
     def test_without_acraconnector_private(self):
         """acra-connector shouldn't start without private key"""
-        destroy_key(kind='transport-connector',
-                    client_id=self.client_id,
-                    keys_dir=self.connector_keys_dir)
+        destroy_connector_transport(client_id=self.client_id,
+                                    keys_dir=self.connector_keys_dir)
         try:
             self.connector = self.fork_connector(
                 connector_port=self.CONNECTOR_PORT_1,
@@ -1862,9 +1860,8 @@ class TestKeyNonExistence(BaseTestCase):
     def test_without_acraserver_private(self):
         """acra-server without private key should drop connection
         from acra-connector than acra-connector should drop connection from psycopg2"""
-        destroy_key(kind='transport-server',
-                    client_id=self.client_id,
-                    keys_dir=self.server_keys_dir)
+        destroy_server_transport(client_id=self.client_id,
+                                 keys_dir=self.server_keys_dir)
         if TEST_MYSQL:
             expected_exception = pymysql.err.OperationalError
         elif TEST_POSTGRESQL:
@@ -1891,9 +1888,8 @@ class TestKeyNonExistence(BaseTestCase):
 
     def test_without_acraserver_public(self):
         """acra-connector shouldn't start without acra-server public key"""
-        destroy_key(kind='transport-server',
-                    client_id=self.client_id,
-                    keys_dir=self.connector_keys_dir)
+        destroy_server_transport(client_id=self.client_id,
+                                 keys_dir=self.connector_keys_dir)
         try:
             self.connector = self.fork_connector(
                 connector_port=self.CONNECTOR_PORT_1,
@@ -2376,9 +2372,8 @@ class TestKeyStorageClearing(BaseTestCase):
         with urlopen('http://127.0.0.1:{}/resetKeyStorage'.format(self.CONNECTOR_API_PORT_1)) as response:
             self.assertEqual(response.status, 200)
         # delete key for excluding reloading from FS
-        destroy_key(kind='transport-connector',
-                    client_id=self.client_id,
-                    keys_dir=self.server_keys_dir)
+        destroy_connector_transport(client_id=self.client_id,
+                                    keys_dir=self.server_keys_dir)
         # close connections in pool and reconnect to reinitiate secure session
         self.engine1.dispose()
         # acra-server should close connection when doesn't find key

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -115,13 +115,21 @@ def read_key(key_id, public, keys_dir='.acrakeys'):
     return subprocess.check_output(args)
 
 
-def destroy_key(kind, client_id=None, keys_dir='.acrakeys'):
+def destroy_key(key_id, keys_dir='.acrakeys'):
     """Destroys key in the keystore with acra-keys."""
     args = ['./acra-keys', 'destroy', '--keys_dir={}'.format(keys_dir)]
-    if client_id:
-        args.append('--client_id={}'.format(client_id))
-    args.append(kind)
+    args.append(key_id)
     return subprocess.check_output(args)
+
+
+def destroy_connector_transport(client_id, keys_dir='.acrakeys'):
+    return destroy_key('client/{}/transport/connector'.format(client_id),
+                       keys_dir=keys_dir)
+
+
+def destroy_server_transport(client_id, keys_dir='.acrakeys'):
+    return destroy_key('client/{}/transport/server'.format(client_id),
+                       keys_dir=keys_dir)
 
 
 def read_storage_public_key(client_id, keys_dir='.acrakeys'):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -104,14 +104,14 @@ def load_default_config(service_name):
     return config
 
 
-def read_key(kind, client_id=None, zone_id=None, keys_dir='.acrakeys'):
+def read_key(key_id, public, keys_dir='.acrakeys'):
     """Reads key from keystore with acra-keys."""
     args = ['./acra-keys', 'read', '--keys_dir={}'.format(keys_dir)]
-    if client_id is not None:
-        args.append('--client_id={}'.format(client_id))
-    if zone_id is not None:
-        args.append('--zone_id={}'.format(zone_id))
-    args.append(kind)
+    if public:
+        args.append('--public')
+    else:
+        args.append('--private')
+    args.append(key_id)
     return subprocess.check_output(args)
 
 
@@ -125,11 +125,13 @@ def destroy_key(kind, client_id=None, keys_dir='.acrakeys'):
 
 
 def read_storage_public_key(client_id, keys_dir='.acrakeys'):
-    return read_key('storage-public', client_id=client_id, keys_dir=keys_dir)
+    return read_key('client/{}/storage'.format(client_id),
+                    public=True, keys_dir=keys_dir)
 
 
 def read_zone_public_key(zone_id, keys_dir='.acrakeys'):
-    return read_key('zone-public', zone_id=zone_id, keys_dir=keys_dir)
+    return read_key('zone/{}/storage'.format(zone_id),
+                    public=True, keys_dir=keys_dir)
 
 
 def decrypt_acrastruct(data, private_key, client_id=None, zone_id=None):
@@ -145,19 +147,21 @@ def decrypt_acrastruct(data, private_key, client_id=None, zone_id=None):
 
 
 def read_storage_private_key(keys_folder, key_id):
-    return read_key('storage-private', client_id=key_id, keys_dir=keys_folder)
+    return read_key('client/{}/storage'.format(key_id),
+                    public=False, keys_dir=keys_folder)
 
 
 def read_zone_private_key(keys_folder, key_id):
-    return read_key('zone-private', zone_id=key_id, keys_dir=keys_folder)
+    return read_key('zone/{}/storage'.format(key_id),
+                    public=False, keys_dir=keys_folder)
 
 
 def read_poison_public_key(keys_dir):
-    return read_key('poison-public', keys_dir=keys_dir)
+    return read_key('poison-record', public=True, keys_dir=keys_dir)
 
 
 def read_poison_private_key(keys_dir):
-    return read_key('poison-private', keys_dir=keys_dir)
+    return read_key('poison-record', public=False, keys_dir=keys_dir)
 
 
 def prepare_encryptor_config(zone_id, config_path):


### PR DESCRIPTION
Change the CLI of `acra-keys read` and `acra-keys destroy` to match other subcommands (like `export` and `list`).

Now instead of

```
acra-keys read --client_id Alice storage-public
```

you should write

```
acra-keys read --public client/Alice/storage
```

where the last part is the "key ID" which you can see in `acra-keys list` output.

```
Key purpose                  | Client/Zone ID | Key ID
-----------------------------+----------------+----------------------------------
client storage key           | Alice          | client/Alice/storage
AcraConnector transport key  | Alice          | client/Alice/transport/connector
AcraServer transport key     | Alice          | client/Alice/transport/server
AcraTranslator transport key | Alice          | client/Alice/transport/translator
```

This makes the interface more consistent, without arbitrary "key kinds" exposed to the users. We still use the constants in the code though.

Both `read` and `destroy` subcommands were added for and are mostly useful in integration tests. This should not affect any real-world usage.