### PR TITLE
Use historical poison record keys

### DIFF
--- a/cmd/acra-translator/grpc_api/api_test.go
+++ b/cmd/acra-translator/grpc_api/api_test.go
@@ -104,6 +104,14 @@ func (keystore *testKeystore) GetPoisonKeyPair() (*keys.Keypair, error) {
 	return nil, nil
 }
 
+func (keystore *testKeystore) GetPoisonPrivateKeys() ([]*keys.PrivateKey, error) {
+	keypair, err := keystore.GetPoisonKeyPair()
+	if err != nil || keypair == nil {
+		return nil, err
+	}
+	return []*keys.PrivateKey{keypair.Private}, nil
+}
+
 func (*testKeystore) GetAuthKey(remove bool) ([]byte, error) { panic("implement me") }
 
 func (*testKeystore) Reset() { panic("implement me") }

--- a/cmd/acra-translator/http_api/mock_keystorage.go
+++ b/cmd/acra-translator/http_api/mock_keystorage.go
@@ -123,6 +123,14 @@ func (keystore *testKeystore) GetPoisonKeyPair() (*keys.Keypair, error) {
 	return keys.New(keys.TypeEC)
 }
 
+func (keystore *testKeystore) GetPoisonPrivateKeys() ([]*keys.PrivateKey, error) {
+	keypair, err := keystore.GetPoisonKeyPair()
+	if err != nil || keypair == nil {
+		return nil, err
+	}
+	return []*keys.PrivateKey{keypair.Private}, nil
+}
+
 func (*testKeystore) GetAuthKey(remove bool) ([]byte, error) {
 	panic("implement me")
 }

--- a/decryptor/base/utils.go
+++ b/decryptor/base/utils.go
@@ -49,6 +49,9 @@ var (
 	ErrIncorrectAcraStructDataLength = errors.New("AcraStruct has incorrect data length value")
 )
 
+// ErrNoPrivateKeys is returned when DecryptRotatedAcrastruct is given an empty key list
+var ErrNoPrivateKeys = errors.New("cannot decrypt AcraStruct with empty key list")
+
 // ValidateAcraStructLength check that data has minimal length for AcraStruct and data block equal to data length in AcraStruct
 func ValidateAcraStructLength(data []byte) error {
 	baseLength := GetMinAcraStructLength()
@@ -99,7 +102,7 @@ func DecryptAcrastruct(data []byte, privateKey *keys.PrivateKey, zone []byte) ([
 // DecryptRotatedAcrastruct tries decrypting an AcraStruct with a set of rotated keys.
 // It either returns decrypted data if one of the keys succeeds, or an error if none is good.
 func DecryptRotatedAcrastruct(data []byte, privateKeys []*keys.PrivateKey, zone []byte) ([]byte, error) {
-	var err error
+	var err error = ErrNoPrivateKeys
 	var decryptedData []byte
 	for _, privateKey := range privateKeys {
 		decryptedData, err = DecryptAcrastruct(data, privateKey, zone)

--- a/decryptor/mysql/decryptor.go
+++ b/decryptor/mysql/decryptor.go
@@ -179,6 +179,7 @@ func (decryptor *Decryptor) checkPoisonRecord(block []byte) error {
 		decryptor.log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantReadKeys).Errorln("Can't load private key for poison records")
 		return err
 	}
+	defer utils.ZeroizePrivateKeys(poisonKeys)
 	_, err = decryptor.decryptBlock(bytes.NewReader(data), nil, poisonKeys)
 	if err == nil {
 		decryptor.log.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorDecryptorRecognizedPoisonRecord).Warningln("Recognized poison record")

--- a/decryptor/mysql/decryptor_test.go
+++ b/decryptor/mysql/decryptor_test.go
@@ -25,6 +25,14 @@ func (keystore *testKeystore) GetPoisonKeyPair() (*keys.Keypair, error) {
 	return keystore.PoisonKeypair, nil
 }
 
+func (keystore *testKeystore) GetPoisonPrivateKeys() ([]*keys.PrivateKey, error) {
+	keypair, err := keystore.GetPoisonKeyPair()
+	if err != nil || keypair == nil {
+		return nil, err
+	}
+	return []*keys.PrivateKey{keypair.Private}, nil
+}
+
 func (keystore *testKeystore) GetPrivateKey(id []byte) (*keys.PrivateKey, error) {
 	return nil, nil
 }

--- a/decryptor/postgresql/pg_general_decryptor.go
+++ b/decryptor/postgresql/pg_general_decryptor.go
@@ -361,6 +361,7 @@ func (decryptor *PgDecryptor) CheckPoisonRecord(reader io.Reader) (bool, error) 
 		decryptor.logger.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantReadKeys).WithError(err).Errorln("Can't load poison keypair")
 		return true, err
 	}
+	defer utils.ZeroizePrivateKeys(poisonKeys)
 
 	_, err = base.DecryptRotatedAcrastruct(data, poisonKeys, nil)
 	if err == nil {

--- a/decryptor/postgresql/pg_general_decryptor.go
+++ b/decryptor/postgresql/pg_general_decryptor.go
@@ -355,14 +355,14 @@ func (decryptor *PgDecryptor) CheckPoisonRecord(reader io.Reader) (bool, error) 
 		return false, err
 	}
 
-	// check poison record
-	poisonKeypair, err := decryptor.keyStore.GetPoisonKeyPair()
+	// If we fail to get poison record keys, propagate the error assuming it is a poison record.
+	poisonKeys, err := decryptor.keyStore.GetPoisonPrivateKeys()
 	if err != nil {
 		decryptor.logger.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantReadKeys).WithError(err).Errorln("Can't load poison keypair")
 		return true, err
 	}
 
-	_, err = base.DecryptAcrastruct(data, poisonKeypair.Private, nil)
+	_, err = base.DecryptRotatedAcrastruct(data, poisonKeys, nil)
 	if err == nil {
 		decryptor.logger.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorDecryptorRecognizedPoisonRecord).Warningln("Recognized poison record")
 		if decryptor.GetPoisonCallbackStorage().HasCallbacks() {

--- a/keystore/filesystem/server_keystore.go
+++ b/keystore/filesystem/server_keystore.go
@@ -674,6 +674,31 @@ func (store *KeyStore) GetPoisonKeyPair() (*keys.Keypair, error) {
 	return store.generateKeyPair(PoisonKeyFilename, []byte(PoisonKeyFilename))
 }
 
+// GetPoisonPrivateKeys returns all private keys used to decrypt poison records, from newest to oldest.
+// If a poison record does not exist, it is created and its sole private key is returned.
+// Returns a list of private poison keys (possibly empty), or an error if decryption fails.
+func (store *KeyStore) GetPoisonPrivateKeys() ([]*keys.PrivateKey, error) {
+	poisonKeyExists, err := store.fs.Exists(store.GetPrivateKeyFilePath(PoisonKeyFilename))
+	if err != nil {
+		return nil, err
+	}
+	// If there is no poison record keypair, generated one and returns its private key.
+	if !poisonKeyExists {
+		log.Debug("Generate poison key pair")
+		keypair, err := store.generateKeyPair(PoisonKeyFilename, []byte(PoisonKeyFilename))
+		if err != nil {
+			return nil, err
+		}
+		return []*keys.PrivateKey{keypair.Private}, nil
+	}
+	// If some poison keypairs exist, pull their private keys.
+	filenames, err := store.GetHistoricalPrivateKeyFilenames(PoisonKeyFilename)
+	if err != nil {
+		return nil, err
+	}
+	return store.getPrivateKeysByFilenames([]byte(PoisonKeyFilename), filenames)
+}
+
 // GetAuthKey generates basic auth key for acraWebconfig, and writes it encrypted to fs,
 // or reads existing key from fs.
 // Returns key or error of generation/decryption failed.

--- a/keystore/filesystem/server_keystore.go
+++ b/keystore/filesystem/server_keystore.go
@@ -415,9 +415,6 @@ func (store *KeyStore) loadPublicKey(path string) (*keys.PublicKey, error) {
 }
 
 func (store *KeyStore) getPrivateKeyByFilename(id []byte, filename string) (*keys.PrivateKey, error) {
-	if !keystore.ValidateID(id) {
-		return nil, keystore.ErrInvalidClientID
-	}
 	store.lock.Lock()
 	defer store.lock.Unlock()
 	encryptedKey, ok := store.cache.Get(filename)

--- a/keystore/keystore.go
+++ b/keystore/keystore.go
@@ -218,6 +218,7 @@ type KeyMaking interface {
 type PoisonKeyStore interface {
 	// Reads current poison record key pair, creating it if it does not exist yet.
 	GetPoisonKeyPair() (*keys.Keypair, error)
+	GetPoisonPrivateKeys() ([]*keys.PrivateKey, error)
 }
 
 // RotateStorageKeyStore enables storage key rotation. It is used by acra-rotate tool.

--- a/zone/zone_id_matcher_test.go
+++ b/zone/zone_id_matcher_test.go
@@ -76,7 +76,8 @@ func (storage *TestKeyStore) GetServerDecryptionPrivateKeys(id []byte) ([]*keys.
 func (keystore *TestKeyStore) GetAuthKey(remove bool) ([]byte, error) {
 	return nil, nil
 }
-func (storage *TestKeyStore) GetPoisonKeyPair() (*keys.Keypair, error) { return nil, nil }
+func (storage *TestKeyStore) GetPoisonKeyPair() (*keys.Keypair, error)          { return nil, nil }
+func (storage *TestKeyStore) GetPoisonPrivateKeys() ([]*keys.PrivateKey, error) { return nil, nil }
 func (*TestKeyStore) SaveDataEncryptionKeys(id []byte, keypair *keys.Keypair) error {
 	panic("implement me")
 }


### PR DESCRIPTION
Previously we have implemented usage of historical decryption keys for AcraStructs with user data. This PR teaches Acra to use historical keys for poison records as well. While it is currently not possible to rotate poison record keys, it might become possible in the future and with this PR we will be ready for that. With this change the `DecryptAcrastruct` function is no longer used directly in any code other than tests (which test that AcraStructs decrypt with a specific key). Now all code is using `DecryptRotatedAcrastruct` with multiple keys.

A new keystore method `GetPoisonPrivateKeys` returns all private keys used for poison records. It is similar to `GetPrivateKeys` used to retrieve private keys for user data decryption. Just like `GetPoisonKeyPair`, it will implicitly generate a poison record keypair if it does not exist already.

There are also a couple of fixups here and there for minor issues in keystore found along the way.