### PR TITLE
Move AcraServer common files into "common" package

### DIFF
--- a/cmd/acra-server/acra-server.go
+++ b/cmd/acra-server/acra-server.go
@@ -32,7 +32,6 @@ package main
 
 import (
 	"crypto/tls"
-	"errors"
 	"flag"
 	"net/http"
 	_ "net/http/pprof"
@@ -73,9 +72,6 @@ const (
 
 // defaultConfigPath relative path to config which will be parsed as default
 var defaultConfigPath = utils.GetConfigPathByName(ServiceName)
-
-// ErrWaitTimeout error indicates that server was shutdown and waited N seconds while shutting down all connections.
-var ErrWaitTimeout = errors.New("timeout")
 
 func main() {
 	loggingFormat := flag.String("logging_format", "plaintext", "Logging format: plaintext, json or CEF")
@@ -357,7 +353,7 @@ func main() {
 		server.StopListeners()
 		// Wait a maximum of N seconds for existing connections to finish
 		err := server.WaitWithTimeout(time.Duration(*closeConnectionTimeout) * time.Second)
-		if err == ErrWaitTimeout {
+		if err == common.ErrWaitTimeout {
 			log.Warningf("Server shutdown Timeout: %d active connections will be cut", server.ConnectionsCounter())
 			server.Close()
 			os.Exit(1)
@@ -411,7 +407,7 @@ func main() {
 
 		// Wait a maximum of N seconds for existing connections to finish
 		err = server.WaitWithTimeout(time.Duration(*closeConnectionTimeout) * time.Second)
-		if err == ErrWaitTimeout {
+		if err == common.ErrWaitTimeout {
 			log.Warningf("Server shutdown Timeout: %d active connections will be cut", server.ConnectionsCounter())
 			os.Exit(0)
 		}

--- a/cmd/acra-server/acra-server.go
+++ b/cmd/acra-server/acra-server.go
@@ -330,7 +330,11 @@ func main() {
 	}
 
 	if *prometheusAddress != "" {
-		registerMetrics()
+		version, err := utils.GetParsedVersion()
+		if err != nil {
+			log.WithError(err).Fatal("Invalid version string")
+		}
+		common.RegisterMetrics(ServiceName, version, utils.CommunityEdition)
 		_, prometheusHTTPServer, err := cmd.RunPrometheusHTTPHandler(*prometheusAddress)
 		if err != nil {
 			panic(err)

--- a/cmd/acra-server/acra-server.go
+++ b/cmd/acra-server/acra-server.go
@@ -309,8 +309,6 @@ func main() {
 	}
 
 	if os.Getenv(gracefulEnv) == "true" {
-		server.fddACRA = descriptorAcra
-		server.fdAPI = descriptorAPI
 		log.Debugf("Will be using GRACEFUL_RESTART if configured from WebUI")
 	}
 

--- a/cmd/acra-server/acra-server.go
+++ b/cmd/acra-server/acra-server.go
@@ -374,13 +374,13 @@ func main() {
 
 		// Get socket file descriptor to pass it to fork
 		var fdACRA, fdAPI uintptr
-		fdACRA, err = network.ListenerFileDescriptor(server.listenerACRA)
+		fdACRA, err = network.ListenerFileDescriptor(server.ListenerAcra())
 		if err != nil {
 			log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantGetFileDescriptor).
 				Fatalln("System error: failed to get acra-socket file descriptor:", err)
 		}
 		if *withZone || *enableHTTPAPI {
-			fdAPI, err = network.ListenerFileDescriptor(server.listenerAPI)
+			fdAPI, err = network.ListenerFileDescriptor(server.ListenerAPI())
 			if err != nil {
 				log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantGetFileDescriptor).
 					Fatalln("System error: failed to get api-socket file descriptor:", err)

--- a/cmd/acra-server/acra-server.go
+++ b/cmd/acra-server/acra-server.go
@@ -206,6 +206,7 @@ func main() {
 	config.SetDebug(*debug)
 	config.SetAuthDataPath(*authPath)
 	config.SetServiceName(ServiceName)
+	config.SetConfigPath(cmd.ConfigPath(defaultConfigPath))
 
 	log.Infof("Initialising keystore...")
 	var keyStore keystore.ServerKeyStore

--- a/cmd/acra-server/acra-server.go
+++ b/cmd/acra-server/acra-server.go
@@ -41,6 +41,7 @@ import (
 	"time"
 
 	"github.com/cossacklabs/acra/cmd"
+	"github.com/cossacklabs/acra/cmd/acra-server/common"
 	"github.com/cossacklabs/acra/decryptor/base"
 	"github.com/cossacklabs/acra/decryptor/mysql"
 	"github.com/cossacklabs/acra/decryptor/postgresql"
@@ -146,7 +147,7 @@ func main() {
 
 	log.WithField("version", utils.VERSION).Infof("Starting service %v [pid=%v]", ServiceName, os.Getpid())
 
-	config, err := NewConfig()
+	config, err := common.NewConfig()
 	if err != nil {
 		log.WithError(err).Errorln("Can't initialize config")
 		os.Exit(1)
@@ -203,6 +204,8 @@ func main() {
 	config.SetWholeMatch(!(*injectedcell))
 	config.SetEnableHTTPAPI(*enableHTTPAPI)
 	config.SetDebug(*debug)
+	config.SetAuthDataPath(*authPath)
+	config.SetServiceName(ServiceName)
 
 	log.Infof("Initialising keystore...")
 	var keyStore keystore.ServerKeyStore

--- a/cmd/acra-server/common/client_commands_session.go
+++ b/cmd/acra-server/common/client_commands_session.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package common
 
 import (
 	"bufio"
@@ -57,7 +57,6 @@ func NewClientCommandsSession(keystorage keystore.ServerKeyStore, config *Config
 		return nil, err
 	}
 	return &ClientCommandsSession{ClientSession: *clientSession, keystore: keystorage}, nil
-
 }
 
 // ConnectToDb should not be called, because command session must not connect to any DB
@@ -177,7 +176,6 @@ func (clientSession *ClientCommandsSession) HandleSession() {
 				Errorln("DumpConfig failed")
 			response = Response500Error
 			break
-
 		}
 		logger.Infoln("Handled request correctly, restarting server")
 		clientSession.Server.restartSignalsChannel <- syscall.SIGHUP

--- a/cmd/acra-server/common/client_commands_session.go
+++ b/cmd/acra-server/common/client_commands_session.go
@@ -124,7 +124,8 @@ func (clientSession *ClientCommandsSession) HandleSession() {
 			response = Response500Error
 			break
 		}
-		authDataCrypted, err := utils.ReadFile(*authPath)
+		authDataPath := clientSession.Server.config.GetAuthDataPath()
+		authDataCrypted, err := utils.ReadFile(authDataPath)
 		if err != nil {
 			logger.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorHTTPAPICantLoadAuthData).WithError(err).Warningln("loadAuthData: no auth data")
 			response = Response500Error
@@ -170,7 +171,9 @@ func (clientSession *ClientCommandsSession) HandleSession() {
 		flag.Set("poison_shutdown_enable", fmt.Sprintf("%v", configFromUI.StopOnPoison))
 		flag.Set("zonemode_enable", fmt.Sprintf("%v", configFromUI.WithZone))
 
-		err = cmd.DumpConfig(clientSession.Server.config.GetConfigPath(), ServiceName, false)
+		configPath := clientSession.Server.config.GetConfigPath()
+		serviceName := clientSession.config.GetServiceName()
+		err = cmd.DumpConfig(configPath, serviceName, false)
 		if err != nil {
 			logger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantDumpConfig).
 				Errorln("DumpConfig failed")

--- a/cmd/acra-server/common/client_session.go
+++ b/cmd/acra-server/common/client_session.go
@@ -14,21 +14,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package common
 
 import (
 	"context"
-	"net"
-
-	"github.com/cossacklabs/acra/network"
-
-	log "github.com/sirupsen/logrus"
-
 	"io"
+	"net"
 
 	"github.com/cossacklabs/acra/decryptor/base"
 	"github.com/cossacklabs/acra/keystore"
 	"github.com/cossacklabs/acra/logging"
+	"github.com/cossacklabs/acra/network"
+	log "github.com/sirupsen/logrus"
 )
 
 // ClientSession handles connection between database and AcraServer.

--- a/cmd/acra-server/common/config.go
+++ b/cmd/acra-server/common/config.go
@@ -56,6 +56,7 @@ type Config struct {
 	traceOptions            []trace.StartOption
 	authDataPath            string
 	serviceName             string
+	configPath              string
 }
 
 // UIEditableConfig describes which parts of AcraServer configuration can be changed from AcraWebconfig page
@@ -230,9 +231,14 @@ func (config *Config) SetWholeMatch(value bool) {
 	config.wholeMatch = value
 }
 
+// SetConfigPath sets AcraServer config path
+func (config *Config) SetConfigPath(path string) {
+	config.configPath = path
+}
+
 // GetConfigPath returns AcraServer config path
 func (config *Config) GetConfigPath() string {
-	return defaultConfigPath
+	return config.configPath
 }
 
 // ToJSON AcraServer editable config in JSON format

--- a/cmd/acra-server/common/config.go
+++ b/cmd/acra-server/common/config.go
@@ -83,7 +83,8 @@ func NewConfig() (*Config, error) {
 // ErrTwoDBSetup shows that AcraServer can connects only to one database at the same time
 var ErrTwoDBSetup = errors.New("only one db supported at one time")
 
-func (config *Config) setDBConnectionSettings(host string, port int) {
+// SetDBConnectionSettings sets address of the database.
+func (config *Config) SetDBConnectionSettings(host string, port int) {
 	config.dbHost = host
 	config.dbPort = port
 }
@@ -93,8 +94,8 @@ func (config *Config) WithConnector() bool {
 	return config.withConnector
 }
 
-// setWithConnector set that acra-server will or not accept connections from acra-connector
-func (config *Config) setWithConnector(v bool) {
+// SetWithConnector set that acra-server will or not accept connections from acra-connector
+func (config *Config) SetWithConnector(v bool) {
 	config.withConnector = v
 }
 
@@ -112,6 +113,11 @@ func (config *Config) LoadMapTableSchemaConfig(path string) error {
 	}
 	config.tableSchema = schema
 	return nil
+}
+
+// GetTableSchema returns table schema in use.
+func (config *Config) GetTableSchema() encryptorConfig.TableSchemaStore {
+	return config.tableSchema
 }
 
 // SetCensor creates AcraCensor and sets its configuration
@@ -269,8 +275,8 @@ func (config *Config) GetAcraAPIConnectionString() string {
 	return config.acraAPIConnectionString
 }
 
-// setKeyStore set keystore
-func (config *Config) setKeyStore(k keystore.ServerKeyStore) {
+// SetKeyStore sets keystore.
+func (config *Config) SetKeyStore(k keystore.ServerKeyStore) {
 	config.keystore = k
 }
 
@@ -302,4 +308,14 @@ func (config *Config) SetServiceName(name string) {
 // GetServiceName returns AcraServer service name.
 func (config *Config) GetServiceName() string {
 	return config.serviceName
+}
+
+// SetScriptOnPoison sets path to script to execute when poison record is triggered.
+func (config *Config) SetScriptOnPoison(script string) {
+	config.scriptOnPoison = script
+}
+
+// SetStopOnPoison tells AcraServer to shutdown when poison record is triggered.
+func (config *Config) SetStopOnPoison(stop bool) {
+	config.stopOnPoison = stop
 }

--- a/cmd/acra-server/common/config.go
+++ b/cmd/acra-server/common/config.go
@@ -54,6 +54,8 @@ type Config struct {
 	dataEncryptor           encryptor.DataEncryptor
 	keystore                keystore.ServerKeyStore
 	traceOptions            []trace.StartOption
+	authDataPath            string
+	serviceName             string
 }
 
 // UIEditableConfig describes which parts of AcraServer configuration can be changed from AcraWebconfig page
@@ -274,4 +276,24 @@ func (config *Config) GetKeyStore() keystore.ServerKeyStore {
 // GetTraceOptions return configured trace StartOptions
 func (config *Config) GetTraceOptions() []trace.StartOption {
 	return config.traceOptions
+}
+
+// SetAuthDataPath sets basic authentication data path.
+func (config *Config) SetAuthDataPath(path string) {
+	config.authDataPath = path
+}
+
+// GetAuthDataPath returns basic authentication data path.
+func (config *Config) GetAuthDataPath() string {
+	return config.authDataPath
+}
+
+// SetServiceName sets AcraServer service name.
+func (config *Config) SetServiceName(name string) {
+	config.serviceName = name
+}
+
+// GetServiceName returns AcraServer service name.
+func (config *Config) GetServiceName() string {
+	return config.serviceName
 }

--- a/cmd/acra-server/common/config.go
+++ b/cmd/acra-server/common/config.go
@@ -14,12 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package common
 
 import (
 	"encoding/json"
 	"errors"
-	"github.com/cossacklabs/acra/acra-censor"
+	"io/ioutil"
+
+	acracensor "github.com/cossacklabs/acra/acra-censor"
 	"github.com/cossacklabs/acra/encryptor"
 	encryptorConfig "github.com/cossacklabs/acra/encryptor/config"
 	"github.com/cossacklabs/acra/keystore"
@@ -27,7 +29,6 @@ import (
 	"github.com/cossacklabs/acra/network"
 	log "github.com/sirupsen/logrus"
 	"go.opencensus.io/trace"
-	"io/ioutil"
 )
 
 // Config describes AcraServer configuration

--- a/cmd/acra-server/common/listener.go
+++ b/cmd/acra-server/common/listener.go
@@ -39,8 +39,6 @@ type SServer struct {
 	config                *Config
 	listenerACRA          net.Listener
 	listenerAPI           net.Listener
-	fddACRA               uintptr
-	fdAPI                 uintptr
 	connectionManager     *network.ConnectionManager
 	listeners             []net.Listener
 	errorSignalChannel    chan os.Signal

--- a/cmd/acra-server/common/listener.go
+++ b/cmd/acra-server/common/listener.go
@@ -208,6 +208,16 @@ func (server *SServer) start(listener net.Listener, callback *callbackData, logg
 	}
 }
 
+// ListenerAcra returns listener for AcraServer database connections.
+func (server *SServer) ListenerAcra() net.Listener {
+	return server.listenerACRA
+}
+
+// ListenerAPI returns listener for AcraServer management API connections.
+func (server *SServer) ListenerAPI() net.Listener {
+	return server.listenerAPI
+}
+
 // Start listening connections from proxy
 func (server *SServer) Start() {
 	logger := log.WithFields(log.Fields{"connection_string": server.config.GetAcraConnectionString(), "from_descriptor": false})

--- a/cmd/acra-server/common/listener.go
+++ b/cmd/acra-server/common/listener.go
@@ -14,11 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package common
 
 import (
 	"context"
-	"go.opencensus.io/trace"
 	"net"
 	url_ "net/url"
 	"os"
@@ -30,6 +29,7 @@ import (
 	"github.com/cossacklabs/acra/network"
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
+	"go.opencensus.io/trace"
 )
 
 // SServer represents AcraServer server, connects with KeyStorage, configuration file,

--- a/cmd/acra-server/common/listener.go
+++ b/cmd/acra-server/common/listener.go
@@ -18,6 +18,7 @@ package common
 
 import (
 	"context"
+	"errors"
 	"net"
 	url_ "net/url"
 	"os"
@@ -46,6 +47,9 @@ type SServer struct {
 	restartSignalsChannel chan os.Signal
 	proxyFactory          base.ProxyFactory
 }
+
+// ErrWaitTimeout error indicates that server was shutdown and waited N seconds while shutting down all connections.
+var ErrWaitTimeout = errors.New("timeout")
 
 // NewServer creates new SServer.
 func NewServer(config *Config, proxyFactory base.ProxyFactory, errorChan chan os.Signal, restarChan chan os.Signal) (server *SServer, err error) {

--- a/cmd/acra-server/common/prometheus.go
+++ b/cmd/acra-server/common/prometheus.go
@@ -13,14 +13,16 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package main
+
+package common
 
 import (
+	"sync"
+
 	"github.com/cossacklabs/acra/cmd"
 	"github.com/cossacklabs/acra/decryptor/base"
 	"github.com/cossacklabs/acra/utils"
 	"github.com/prometheus/client_golang/prometheus"
-	"sync"
 )
 
 const (

--- a/cmd/acra-server/common/prometheus.go
+++ b/cmd/acra-server/common/prometheus.go
@@ -47,17 +47,14 @@ var (
 
 var registerLock = sync.Once{}
 
-func registerMetrics() {
+// RegisterMetrics registers AcraServer metrics.
+func RegisterMetrics(serviceName string, version *utils.Version, edition utils.ProductEdition) {
 	registerLock.Do(func() {
 		prometheus.MustRegister(connectionCounter)
 		prometheus.MustRegister(connectionProcessingTimeHistogram)
 		base.RegisterAcraStructProcessingMetrics()
 		base.RegisterDbProcessingMetrics()
-		version, err := utils.GetParsedVersion()
-		if err != nil {
-			panic(err)
-		}
-		cmd.RegisterVersionMetrics(ServiceName, version)
-		cmd.RegisterBuildInfoMetrics(ServiceName, utils.CommunityEdition)
+		cmd.RegisterVersionMetrics(serviceName, version)
+		cmd.RegisterBuildInfoMetrics(serviceName, edition)
 	})
 }

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -255,6 +255,15 @@ func GenerateMarkdownDocFromFlagSets(flagSets []*flag_.FlagSet, output io.Writer
 	})
 }
 
+// ConfigPath returns path to configuration file.
+// The given default value is used, unless it has been overridden on the command line.
+func ConfigPath(defaultPath string) string {
+	if *config == "" {
+		return defaultPath
+	}
+	return *config
+}
+
 // DumpConfig writes CLI params to configPath
 func DumpConfig(configPath, serviceName string, useDefault bool) error {
 	return DumpConfigFromFlagSets([]*flag_.FlagSet{flag_.CommandLine}, configPath, serviceName, useDefault)
@@ -262,19 +271,9 @@ func DumpConfig(configPath, serviceName string, useDefault bool) error {
 
 // DumpConfigFromFlagSets writes CLI params to configPath
 func DumpConfigFromFlagSets(flagSets []*flag_.FlagSet, configPath, serviceName string, useDefault bool) error {
-	var absPath string
-	var err error
-
-	if *config == "" {
-		absPath, err = filepath.Abs(configPath)
-		if err != nil {
-			return err
-		}
-	} else {
-		absPath, err = filepath.Abs(*config)
-		if err != nil {
-			return err
-		}
+	absPath, err := filepath.Abs(ConfigPath(configPath))
+	if err != nil {
+		return err
 	}
 
 	dirPath := filepath.Dir(absPath)
@@ -352,9 +351,7 @@ func ParseFlagsWithConfig(flags *flag_.FlagSet, arguments []string, configPath, 
 		return err
 	}
 
-	if *config != "" {
-		configPath = *config
-	}
+	configPath = ConfigPath(configPath)
 	var yamlConfig map[string]interface{}
 	var extraArgs []string
 	// parse yaml and add params that wasn't passed from cli


### PR DESCRIPTION
This PR improves code reuse in AcraServer by moving shared code into a separate package which can be imported from Acra EE. (It is not possible to import packages providing binaries.)

The shared code now lives in the `common` module, similar to AcraTranslator. It has been cleaned up and refactored a bit to allow Acra EE to inject its own configuration where necessary.

Here we make no effort to split the ginormous `main` function into more reusable bits. This is an adventure for another day.

There should be no user-visible changes due to this refactoring. More technical details are available in commit messages.