### PR TITLE
Extract ClientSession interface

### DIFF
--- a/cmd/acra-server/common/client_commands_session.go
+++ b/cmd/acra-server/common/client_commands_session.go
@@ -45,18 +45,16 @@ const (
 
 // ClientCommandsSession handles Secure Session for client commands API
 type ClientCommandsSession struct {
-	ClientSession
-	Server   *SServer
-	keystore keystore.ServerKeyStore
+	ctx        context.Context
+	server     *SServer
+	config     *Config
+	keystore   keystore.ServerKeyStore
+	connection net.Conn
 }
 
 // NewClientCommandsSession returns new ClientCommandsSession
-func NewClientCommandsSession(keystorage keystore.ServerKeyStore, config *Config, connection net.Conn) (*ClientCommandsSession, error) {
-	clientSession, err := NewClientSession(context.Background(), config, connection)
-	if err != nil {
-		return nil, err
-	}
-	return &ClientCommandsSession{ClientSession: *clientSession, keystore: keystorage}, nil
+func NewClientCommandsSession(ctx context.Context, server *SServer, config *Config, connection net.Conn) (*ClientCommandsSession, error) {
+	return &ClientCommandsSession{ctx: ctx, server: server, config: config, keystore: config.GetKeyStore(), connection: connection}, nil
 }
 
 // ConnectToDb should not be called, because command session must not connect to any DB
@@ -124,7 +122,7 @@ func (clientSession *ClientCommandsSession) HandleSession() {
 			response = Response500Error
 			break
 		}
-		authDataPath := clientSession.Server.config.GetAuthDataPath()
+		authDataPath := clientSession.config.GetAuthDataPath()
 		authDataCrypted, err := utils.ReadFile(authDataPath)
 		if err != nil {
 			logger.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorHTTPAPICantLoadAuthData).WithError(err).Warningln("loadAuthData: no auth data")
@@ -171,7 +169,7 @@ func (clientSession *ClientCommandsSession) HandleSession() {
 		flag.Set("poison_shutdown_enable", fmt.Sprintf("%v", configFromUI.StopOnPoison))
 		flag.Set("zonemode_enable", fmt.Sprintf("%v", configFromUI.WithZone))
 
-		configPath := clientSession.Server.config.GetConfigPath()
+		configPath := clientSession.config.GetConfigPath()
 		serviceName := clientSession.config.GetServiceName()
 		err = cmd.DumpConfig(configPath, serviceName, false)
 		if err != nil {
@@ -181,7 +179,7 @@ func (clientSession *ClientCommandsSession) HandleSession() {
 			break
 		}
 		logger.Infoln("Handled request correctly, restarting server")
-		clientSession.Server.restartSignalsChannel <- syscall.SIGHUP
+		clientSession.server.restartSignalsChannel <- syscall.SIGHUP
 	default:
 		requestSpan.AddAttributes(trace.StringAttribute("http.url", "undefined"))
 	}

--- a/cmd/acra-server/common/client_commands_session.go
+++ b/cmd/acra-server/common/client_commands_session.go
@@ -52,7 +52,7 @@ type ClientCommandsSession struct {
 
 // NewClientCommandsSession returns new ClientCommandsSession
 func NewClientCommandsSession(keystorage keystore.ServerKeyStore, config *Config, connection net.Conn) (*ClientCommandsSession, error) {
-	clientSession, err := NewClientSession(context.Background(), keystorage, config, connection)
+	clientSession, err := NewClientSession(context.Background(), config, connection)
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +99,7 @@ func (clientSession *ClientCommandsSession) HandleSession() {
 	switch req.URL.Path {
 	case "/getNewZone":
 		logger.Debugln("Got /getNewZone request")
-		id, publicKey, err := clientSession.keystorage.GenerateZoneKey()
+		id, publicKey, err := clientSession.keystore.GenerateZoneKey()
 		if err != nil {
 			logger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorHTTPAPICantGenerateZone).Errorln("Can't generate zone key")
 		} else {
@@ -113,7 +113,7 @@ func (clientSession *ClientCommandsSession) HandleSession() {
 		}
 	case "/resetKeyStorage":
 		logger.Debugln("Got /resetKeyStorage request")
-		clientSession.keystorage.Reset()
+		clientSession.keystore.Reset()
 		response = "HTTP/1.1 200 OK Found\r\n\r\n"
 		logger.Debugln("Cleared key storage cache")
 	case "/loadAuthData":

--- a/cmd/acra-server/common/client_session.go
+++ b/cmd/acra-server/common/client_session.go
@@ -44,6 +44,22 @@ func (clientSession *ClientSession) Logger() *log.Entry {
 	return clientSession.logger
 }
 
+// Context returns session's context.
+func (clientSession *ClientSession) Context() context.Context {
+	return clientSession.ctx
+}
+
+// ClientConnection returns connection to AcraConnector.
+func (clientSession *ClientSession) ClientConnection() net.Conn {
+	return clientSession.connection
+}
+
+// DatabaseConnection returns connection to database.
+// It must be established first by ConnectToDb().
+func (clientSession *ClientSession) DatabaseConnection() net.Conn {
+	return clientSession.connectionToDb
+}
+
 // ConnectToDb connects to the database via tcp using Host and Port from config.
 func (clientSession *ClientSession) ConnectToDb() error {
 	conn, err := network.Dial(network.BuildConnectionString("tcp", clientSession.config.GetDBHost(), clientSession.config.GetDBPort(), ""))

--- a/cmd/acra-server/common/client_session.go
+++ b/cmd/acra-server/common/client_session.go
@@ -18,10 +18,8 @@ package common
 
 import (
 	"context"
-	"io"
 	"net"
 
-	"github.com/cossacklabs/acra/decryptor/base"
 	"github.com/cossacklabs/acra/logging"
 	"github.com/cossacklabs/acra/network"
 	log "github.com/sirupsen/logrus"
@@ -66,78 +64,4 @@ func (clientSession *ClientSession) close() {
 			Errorln("Error with closing connection to db")
 	}
 	clientSession.logger.Debugln("All connections closed")
-}
-
-// HandleClientConnection handles Acra-connector connections from client to db and decrypt responses from db to client.
-// If any error occurred – ends processing.
-func (clientSession *ClientSession) HandleClientConnection(clientID []byte, proxyFactory base.ProxyFactory) {
-	clientSession.logger.Infof("Handle client's connection")
-	clientProxyErrorCh := make(chan error, 1)
-	dbProxyErrorCh := make(chan error, 1)
-
-	clientSession.logger.Debugf("Connecting to db")
-	err := clientSession.ConnectToDb()
-	if err != nil {
-		clientSession.logger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantConnectToDB).
-			Errorln("Can't connect to db")
-
-		clientSession.logger.Debugln("Close connection with acra-connector")
-		err = clientSession.connection.Close()
-		if err != nil {
-			clientSession.logger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantCloseConnectionToService).
-				Errorln("Error with closing connection to acra-connector")
-		}
-		return
-	}
-
-	if err != nil {
-		clientSession.logger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorDataEncryptorInitialization).
-			Errorln("Can't initialize data encryptor to encrypt data in queries")
-		return
-	}
-	proxy, err := proxyFactory.New(clientSession.ctx, clientID, clientSession.connectionToDb, clientSession.connection)
-	if err != nil {
-		clientSession.logger.WithError(err).Errorln("Can't create new proxy for connection")
-		return
-	}
-	go proxy.ProxyClientConnection(clientProxyErrorCh)
-	go proxy.ProxyDatabaseConnection(dbProxyErrorCh)
-
-	var channelToWait chan error
-	const (
-		acraDbSide     = "AcraServer<->Database"
-		clientAcraSide = "Client/Connector<->Database"
-	)
-	var interruptSide string
-
-	select {
-	case err = <-dbProxyErrorCh:
-		clientSession.logger.Debugln("Stop to proxy Database -> AcraServer")
-		interruptSide = acraDbSide
-		channelToWait = clientProxyErrorCh
-	case err = <-clientProxyErrorCh:
-		interruptSide = clientAcraSide
-		clientSession.logger.Debugln("Stop to proxy AcraServer -> Client")
-		channelToWait = dbProxyErrorCh
-	}
-	clientSession.logger = clientSession.logger.WithField("interrupt_side", interruptSide)
-	if err == io.EOF {
-		clientSession.logger.Debugln("EOF connection closed")
-	} else if err == nil {
-		clientSession.logger.Debugln("Err == nil from proxy goroutine")
-	} else if netErr, ok := err.(net.Error); ok {
-		clientSession.logger.WithError(netErr).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorGeneralConnectionProcessing).
-			Errorln("Network error")
-	} else if opErr, ok := err.(*net.OpError); ok {
-		clientSession.logger.WithError(opErr).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorGeneralConnectionProcessing).Errorln("Network error")
-	} else {
-		clientSession.logger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorGeneralConnectionProcessing).Errorln("Unexpected error")
-	}
-
-	clientSession.logger.Infof("Closing client's connection")
-	clientSession.close()
-
-	// wait second error from closed second connection
-	clientSession.logger.WithError(<-channelToWait).Debugln("Second proxy goroutine stopped")
-	clientSession.logger.Infoln("Finished processing client's connection")
 }

--- a/cmd/acra-server/common/client_session.go
+++ b/cmd/acra-server/common/client_session.go
@@ -49,7 +49,8 @@ func (clientSession *ClientSession) ConnectToDb() error {
 	return nil
 }
 
-func (clientSession *ClientSession) close() {
+// Close session connections to AcraConnector and database.
+func (clientSession *ClientSession) Close() {
 	clientSession.logger.Debugln("Close acra-connector connection")
 
 	err := clientSession.connection.Close()

--- a/cmd/acra-server/common/client_session.go
+++ b/cmd/acra-server/common/client_session.go
@@ -22,7 +22,6 @@ import (
 	"net"
 
 	"github.com/cossacklabs/acra/decryptor/base"
-	"github.com/cossacklabs/acra/keystore"
 	"github.com/cossacklabs/acra/logging"
 	"github.com/cossacklabs/acra/network"
 	log "github.com/sirupsen/logrus"
@@ -31,17 +30,15 @@ import (
 // ClientSession handles connection between database and AcraServer.
 type ClientSession struct {
 	config         *Config
-	keystorage     keystore.ServerKeyStore
 	connection     net.Conn
 	connectionToDb net.Conn
-	Server         *SServer
 	ctx            context.Context
 	logger         *log.Entry
 }
 
 // NewClientSession creates new ClientSession object.
-func NewClientSession(ctx context.Context, keystorage keystore.ServerKeyStore, config *Config, connection net.Conn) (*ClientSession, error) {
-	return &ClientSession{connection: connection, keystorage: keystorage, config: config, ctx: ctx, logger: logging.GetLoggerFromContext(ctx)}, nil
+func NewClientSession(ctx context.Context, config *Config, connection net.Conn) (*ClientSession, error) {
+	return &ClientSession{connection: connection, config: config, ctx: ctx, logger: logging.GetLoggerFromContext(ctx)}, nil
 }
 
 // ConnectToDb connects to the database via tcp using Host and Port from config.

--- a/cmd/acra-server/common/client_session.go
+++ b/cmd/acra-server/common/client_session.go
@@ -39,6 +39,11 @@ func NewClientSession(ctx context.Context, config *Config, connection net.Conn) 
 	return &ClientSession{connection: connection, config: config, ctx: ctx, logger: logging.GetLoggerFromContext(ctx)}, nil
 }
 
+// Logger returns session's logger.
+func (clientSession *ClientSession) Logger() *log.Entry {
+	return clientSession.logger
+}
+
 // ConnectToDb connects to the database via tcp using Host and Port from config.
 func (clientSession *ClientSession) ConnectToDb() error {
 	conn, err := network.Dial(network.BuildConnectionString("tcp", clientSession.config.GetDBHost(), clientSession.config.GetDBPort(), ""))

--- a/cmd/acra-server/common/listener.go
+++ b/cmd/acra-server/common/listener.go
@@ -162,7 +162,7 @@ func (server *SServer) handleClientSession(clientID []byte, clientSession *Clien
 			Errorln("Can't initialize data encryptor to encrypt data in queries")
 		return
 	}
-	proxy, err := proxyFactory.New(clientSession.Context(), clientID, clientSession.ClientConnection(), clientSession.DatabaseConnection())
+	proxy, err := proxyFactory.New(clientID, clientSession)
 	if err != nil {
 		log.WithError(err).Errorln("Can't create new proxy for connection")
 		return

--- a/cmd/acra-server/common/listener.go
+++ b/cmd/acra-server/common/listener.go
@@ -122,8 +122,7 @@ to db and decrypting responses from db
 func (server *SServer) handleConnection(ctx context.Context, clientID []byte, connection net.Conn) {
 	logger := logging.NewLoggerWithTrace(ctx)
 	logging.SetLoggerToContext(ctx, logger)
-	clientSession, err := NewClientSession(ctx, server.config.GetKeyStore(), server.config, connection)
-	clientSession.Server = server
+	clientSession, err := NewClientSession(ctx, server.config, connection)
 	if err != nil {
 		logger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantInitClientSession).
 			Errorln("Can't initialize client session")

--- a/cmd/acra-server/common/listener.go
+++ b/cmd/acra-server/common/listener.go
@@ -330,8 +330,7 @@ to db and decrypting responses from db
 */
 func (server *SServer) handleCommandsConnection(ctx context.Context, clientID []byte, connection net.Conn) {
 	logger := logging.NewLoggerWithTrace(ctx)
-	clientSession, err := NewClientCommandsSession(server.config.GetKeyStore(), server.config, connection)
-	clientSession.Server = server
+	clientSession, err := NewClientCommandsSession(ctx, server, server.config, connection)
 	if err != nil {
 		logger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantStartConnection).
 			Errorln("Can't init API session")

--- a/cmd/acra-server/common/listener.go
+++ b/cmd/acra-server/common/listener.go
@@ -201,7 +201,7 @@ func (server *SServer) handleClientSession(clientID []byte, clientSession *Clien
 	}
 
 	clientSession.logger.Infof("Closing client's connection")
-	clientSession.close()
+	clientSession.Close()
 
 	// wait second error from closed second connection
 	clientSession.logger.WithError(<-channelToWait).Debugln("Second proxy goroutine stopped")

--- a/cmd/acra-server/common/listener.go
+++ b/cmd/acra-server/common/listener.go
@@ -137,33 +137,34 @@ func (server *SServer) handleConnection(ctx context.Context, clientID []byte, co
 }
 
 func (server *SServer) handleClientSession(clientID []byte, clientSession *ClientSession, proxyFactory base.ProxyFactory) {
-	clientSession.logger.Infof("Handle client's connection")
+	log := clientSession.Logger()
+	log.Infof("Handle client's connection")
 	clientProxyErrorCh := make(chan error, 1)
 	dbProxyErrorCh := make(chan error, 1)
 
-	clientSession.logger.Debugf("Connecting to db")
+	log.Debugf("Connecting to db")
 	err := clientSession.ConnectToDb()
 	if err != nil {
-		clientSession.logger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantConnectToDB).
+		log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantConnectToDB).
 			Errorln("Can't connect to db")
 
-		clientSession.logger.Debugln("Close connection with acra-connector")
+		log.Debugln("Close connection with acra-connector")
 		err = clientSession.connection.Close()
 		if err != nil {
-			clientSession.logger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantCloseConnectionToService).
+			log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantCloseConnectionToService).
 				Errorln("Error with closing connection to acra-connector")
 		}
 		return
 	}
 
 	if err != nil {
-		clientSession.logger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorDataEncryptorInitialization).
+		log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorDataEncryptorInitialization).
 			Errorln("Can't initialize data encryptor to encrypt data in queries")
 		return
 	}
 	proxy, err := proxyFactory.New(clientSession.ctx, clientID, clientSession.connectionToDb, clientSession.connection)
 	if err != nil {
-		clientSession.logger.WithError(err).Errorln("Can't create new proxy for connection")
+		log.WithError(err).Errorln("Can't create new proxy for connection")
 		return
 	}
 	go proxy.ProxyClientConnection(clientProxyErrorCh)
@@ -178,34 +179,34 @@ func (server *SServer) handleClientSession(clientID []byte, clientSession *Clien
 
 	select {
 	case err = <-dbProxyErrorCh:
-		clientSession.logger.Debugln("Stop to proxy Database -> AcraServer")
+		log.Debugln("Stop to proxy Database -> AcraServer")
 		interruptSide = acraDbSide
 		channelToWait = clientProxyErrorCh
 	case err = <-clientProxyErrorCh:
 		interruptSide = clientAcraSide
-		clientSession.logger.Debugln("Stop to proxy AcraServer -> Client")
+		log.Debugln("Stop to proxy AcraServer -> Client")
 		channelToWait = dbProxyErrorCh
 	}
-	clientSession.logger = clientSession.logger.WithField("interrupt_side", interruptSide)
+	log = log.WithField("interrupt_side", interruptSide)
 	if err == io.EOF {
-		clientSession.logger.Debugln("EOF connection closed")
+		log.Debugln("EOF connection closed")
 	} else if err == nil {
-		clientSession.logger.Debugln("Err == nil from proxy goroutine")
+		log.Debugln("Err == nil from proxy goroutine")
 	} else if netErr, ok := err.(net.Error); ok {
-		clientSession.logger.WithError(netErr).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorGeneralConnectionProcessing).
+		log.WithError(netErr).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorGeneralConnectionProcessing).
 			Errorln("Network error")
 	} else if opErr, ok := err.(*net.OpError); ok {
-		clientSession.logger.WithError(opErr).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorGeneralConnectionProcessing).Errorln("Network error")
+		log.WithError(opErr).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorGeneralConnectionProcessing).Errorln("Network error")
 	} else {
-		clientSession.logger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorGeneralConnectionProcessing).Errorln("Unexpected error")
+		log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorGeneralConnectionProcessing).Errorln("Unexpected error")
 	}
 
-	clientSession.logger.Infof("Closing client's connection")
+	log.Infof("Closing client's connection")
 	clientSession.Close()
 
 	// wait second error from closed second connection
-	clientSession.logger.WithError(<-channelToWait).Debugln("Second proxy goroutine stopped")
-	clientSession.logger.Infoln("Finished processing client's connection")
+	log.WithError(<-channelToWait).Debugln("Second proxy goroutine stopped")
+	log.Infoln("Finished processing client's connection")
 }
 
 func (server *SServer) processConnection(connection net.Conn, callback *callbackData) {

--- a/cmd/acra-server/common/listener.go
+++ b/cmd/acra-server/common/listener.go
@@ -149,7 +149,7 @@ func (server *SServer) handleClientSession(clientID []byte, clientSession *Clien
 			Errorln("Can't connect to db")
 
 		log.Debugln("Close connection with acra-connector")
-		err = clientSession.connection.Close()
+		err = clientSession.ClientConnection().Close()
 		if err != nil {
 			log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantCloseConnectionToService).
 				Errorln("Error with closing connection to acra-connector")
@@ -162,7 +162,7 @@ func (server *SServer) handleClientSession(clientID []byte, clientSession *Clien
 			Errorln("Can't initialize data encryptor to encrypt data in queries")
 		return
 	}
-	proxy, err := proxyFactory.New(clientSession.ctx, clientID, clientSession.connectionToDb, clientSession.connection)
+	proxy, err := proxyFactory.New(clientSession.Context(), clientID, clientSession.ClientConnection(), clientSession.DatabaseConnection())
 	if err != nil {
 		log.WithError(err).Errorln("Can't create new proxy for connection")
 		return

--- a/cmd/acra-server/common/listener.go
+++ b/cmd/acra-server/common/listener.go
@@ -133,10 +133,10 @@ func (server *SServer) handleConnection(ctx context.Context, clientID []byte, co
 		}
 		return
 	}
-	server.handleClientSession(clientID, clientSession, server.proxyFactory)
+	server.handleClientSession(clientID, clientSession)
 }
 
-func (server *SServer) handleClientSession(clientID []byte, clientSession *ClientSession, proxyFactory base.ProxyFactory) {
+func (server *SServer) handleClientSession(clientID []byte, clientSession *ClientSession) {
 	log := clientSession.Logger()
 	log.Infof("Handle client's connection")
 	clientProxyErrorCh := make(chan error, 1)
@@ -162,7 +162,7 @@ func (server *SServer) handleClientSession(clientID []byte, clientSession *Clien
 			Errorln("Can't initialize data encryptor to encrypt data in queries")
 		return
 	}
-	proxy, err := proxyFactory.New(clientID, clientSession)
+	proxy, err := server.proxyFactory.New(clientID, clientSession)
 	if err != nil {
 		log.WithError(err).Errorln("Can't create new proxy for connection")
 		return

--- a/decryptor/base/proxy.go
+++ b/decryptor/base/proxy.go
@@ -87,7 +87,14 @@ type Proxy interface {
 	ProxyDatabaseConnection(chan<- error)
 }
 
+// ClientSession is a connection between the client and the database, mediated by AcraServer.
+type ClientSession interface {
+	Context() context.Context
+	ClientConnection() net.Conn
+	DatabaseConnection() net.Conn
+}
+
 // ProxyFactory create new Proxy for specific database
 type ProxyFactory interface {
-	New(ctx context.Context, clientID []byte, dbConnection, clientConnection net.Conn) (Proxy, error)
+	New(clientID []byte, clientSession ClientSession) (Proxy, error)
 }

--- a/decryptor/mysql/proxy.go
+++ b/decryptor/mysql/proxy.go
@@ -17,10 +17,8 @@ limitations under the License.
 package mysql
 
 import (
-	"context"
 	"github.com/cossacklabs/acra/decryptor/base"
 	"github.com/cossacklabs/acra/encryptor"
-	"net"
 )
 
 type proxyFactory struct {
@@ -41,12 +39,12 @@ func NewProxyFactory(proxySetting base.ProxySetting) (base.ProxyFactory, error) 
 }
 
 // New return mysql proxy implementation
-func (factory *proxyFactory) New(ctx context.Context, clientID []byte, dbConnection, clientConnection net.Conn) (base.Proxy, error) {
+func (factory *proxyFactory) New(clientID []byte, clientSession base.ClientSession) (base.Proxy, error) {
 	decryptor, err := factory.setting.DecryptorFactory().New(clientID)
 	if err != nil {
 		return nil, err
 	}
-	proxy, err := NewMysqlProxy(ctx, decryptor, dbConnection, clientConnection, factory.setting)
+	proxy, err := NewMysqlProxy(clientSession, decryptor, factory.setting)
 	if err != nil {
 		return nil, err
 	}

--- a/decryptor/mysql/proxy_test.go
+++ b/decryptor/mysql/proxy_test.go
@@ -2,9 +2,11 @@ package mysql
 
 import (
 	"context"
+	"net"
+	"testing"
+
 	"github.com/cossacklabs/acra/decryptor/base"
 	"github.com/cossacklabs/acra/encryptor/config"
-	"testing"
 )
 
 type decryptorFactory struct{}
@@ -23,6 +25,20 @@ func (store *tableSchemaStore) IsEmpty() bool {
 	return store.empty
 }
 
+type stubSession struct{}
+
+func (stubSession) Context() context.Context {
+	return context.TODO()
+}
+
+func (stubSession) ClientConnection() net.Conn {
+	return nil
+}
+
+func (stubSession) DatabaseConnection() net.Conn {
+	return nil
+}
+
 func TestEncryptorTurnOnOff(t *testing.T) {
 	emptyStore := &tableSchemaStore{true}
 	nonEmptyStore := &tableSchemaStore{false}
@@ -31,7 +47,7 @@ func TestEncryptorTurnOnOff(t *testing.T) {
 	if err != nil {
 		t.Fatal(setting)
 	}
-	proxy, err := proxyFactory.New(context.TODO(), nil, nil, nil)
+	proxy, err := proxyFactory.New(nil, &stubSession{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -44,7 +60,7 @@ func TestEncryptorTurnOnOff(t *testing.T) {
 	if err != nil {
 		t.Fatal(setting)
 	}
-	proxy, err = proxyFactory.New(context.TODO(), nil, nil, nil)
+	proxy, err = proxyFactory.New(nil, &stubSession{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/decryptor/mysql/response_proxy.go
+++ b/decryptor/mysql/response_proxy.go
@@ -160,8 +160,8 @@ type Handler struct {
 }
 
 // NewMysqlProxy returns new Handler
-func NewMysqlProxy(ctx context.Context, decryptor base.Decryptor, dbConnection, clientConnection net.Conn, setting base.ProxySetting) (*Handler, error) {
-	observerManager, err := base.NewArrayQueryObserverableManager(ctx)
+func NewMysqlProxy(session base.ClientSession, decryptor base.Decryptor, setting base.ProxySetting) (*Handler, error) {
+	observerManager, err := base.NewArrayQueryObserverableManager(session.Context())
 	if err != nil {
 		return nil, err
 	}
@@ -172,12 +172,12 @@ func NewMysqlProxy(ctx context.Context, decryptor base.Decryptor, dbConnection, 
 		decryptor:              decryptor,
 		responseHandler:        defaultResponseHandler,
 		acracensor:             setting.Censor(),
-		clientConnection:       clientConnection,
-		dbConnection:           dbConnection,
+		clientConnection:       session.ClientConnection(),
+		dbConnection:           session.DatabaseConnection(),
 		clientTLSConfig:        tweakTLSConfigForMySQL(setting.ClientTLSConfig()),
 		dbTLSConfig:            tweakTLSConfigForMySQL(setting.DatabaseTLSConfig()),
-		ctx:                    ctx,
-		logger:                 logging.GetLoggerFromContext(ctx),
+		ctx:                    session.Context(),
+		logger:                 logging.GetLoggerFromContext(session.Context()),
 		queryObserverManager:   observerManager,
 		decryptionObserver:     base.NewColumnDecryptionObserver(),
 	}, nil

--- a/decryptor/postgresql/pg_decryptor.go
+++ b/decryptor/postgresql/pg_decryptor.go
@@ -102,16 +102,16 @@ type PgProxy struct {
 }
 
 // NewPgProxy returns new PgProxy
-func NewPgProxy(ctx context.Context, decryptor base.Decryptor, dbConnection, clientConnection net.Conn, setting base.ProxySetting) (*PgProxy, error) {
-	observerManager, err := base.NewArrayQueryObserverableManager(ctx)
+func NewPgProxy(session base.ClientSession, decryptor base.Decryptor, setting base.ProxySetting) (*PgProxy, error) {
+	observerManager, err := base.NewArrayQueryObserverableManager(session.Context())
 	if err != nil {
 		return nil, err
 	}
 	return &PgProxy{
-		clientConnection:     clientConnection,
-		dbConnection:         dbConnection,
+		clientConnection:     session.ClientConnection(),
+		dbConnection:         session.DatabaseConnection(),
 		TLSCh:                make(chan bool),
-		ctx:                  ctx,
+		ctx:                  session.Context(),
 		queryObserverManager: observerManager,
 		clientTLSConfig:      setting.ClientTLSConfig(),
 		dbTLSConfig:          setting.DatabaseTLSConfig(),

--- a/decryptor/postgresql/proxy.go
+++ b/decryptor/postgresql/proxy.go
@@ -17,11 +17,10 @@ limitations under the License.
 package postgresql
 
 import (
-	"context"
 	"errors"
+
 	"github.com/cossacklabs/acra/decryptor/base"
 	"github.com/cossacklabs/acra/encryptor"
-	"net"
 )
 
 type proxyFactory struct {
@@ -36,13 +35,13 @@ func NewProxyFactory(proxySetting base.ProxySetting) (base.ProxyFactory, error) 
 }
 
 // New return postgresql proxy implementation
-func (factory *proxyFactory) New(ctx context.Context, clientID []byte, dbConnection, clientConnection net.Conn) (base.Proxy, error) {
+func (factory *proxyFactory) New(clientID []byte, clientSession base.ClientSession) (base.Proxy, error) {
 	decryptor, err := factory.setting.DecryptorFactory().New(clientID)
 	if err != nil {
 		return nil, err
 	}
 	decryptor.SetDataProcessor(base.DecryptProcessor{})
-	proxy, err := NewPgProxy(ctx, decryptor, dbConnection, clientConnection, factory.setting)
+	proxy, err := NewPgProxy(clientSession, decryptor, factory.setting)
 	if err != nil {
 		return nil, err
 	}

--- a/decryptor/postgresql/proxy_test.go
+++ b/decryptor/postgresql/proxy_test.go
@@ -2,14 +2,16 @@ package postgresql
 
 import (
 	"context"
+	"io"
+	"net"
+	"testing"
+
 	"github.com/cossacklabs/acra/decryptor/base"
 	"github.com/cossacklabs/acra/encryptor/config"
 	"github.com/cossacklabs/acra/keystore"
 	"github.com/cossacklabs/acra/zone"
 	"github.com/cossacklabs/themis/gothemis/keys"
 	"github.com/sirupsen/logrus"
-	"io"
-	"testing"
 )
 
 type testDecryptor struct{}
@@ -170,6 +172,20 @@ func (store *tableSchemaStore) IsEmpty() bool {
 	return store.empty
 }
 
+type stubSession struct{}
+
+func (stubSession) Context() context.Context {
+	return context.TODO()
+}
+
+func (stubSession) ClientConnection() net.Conn {
+	return nil
+}
+
+func (stubSession) DatabaseConnection() net.Conn {
+	return nil
+}
+
 func TestEncryptorTurnOnOff(t *testing.T) {
 	emptyStore := &tableSchemaStore{true}
 	nonEmptyStore := &tableSchemaStore{false}
@@ -178,7 +194,7 @@ func TestEncryptorTurnOnOff(t *testing.T) {
 	if err != nil {
 		t.Fatal(setting)
 	}
-	proxy, err := proxyFactory.New(context.TODO(), nil, nil, nil)
+	proxy, err := proxyFactory.New(nil, &stubSession{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -191,7 +207,7 @@ func TestEncryptorTurnOnOff(t *testing.T) {
 	if err != nil {
 		t.Fatal(setting)
 	}
-	proxy, err = proxyFactory.New(context.TODO(), nil, nil, nil)
+	proxy, err = proxyFactory.New(nil, &stubSession{})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This is a preparatory refactoring for prepared statement implementation.

Prepared statements are inherently associated with a *session* – a connection from the client to the database which is effectively proxied by AcraServer. There is a concept of session in AcraServer's command code (`cmd/acra-server` module), but the decryption proxy code is oblivious to that. It works with just a pair of connections: the one from the client to the AcraServer, and other one from AcraServer to the database.

Here we introduce a more specific concept of client session, defined by the `ClientSession` interface which the proxy code is taught to use. In order to make that happen we need to refactor quite a bunch of code so there are a lot of things happening in this PR.

### How to read this changset

The recommended way to review is by commit. Most of the comments with rational are there.

* **Remove unused fields from ClientSession**
* **Refactor ClientCommandSession construction**

First some unneeded code is removed to make further things cleaner.

* **Move HandleClientConnection to SServer**

Then we move business logic of connection proxying into AcraServer's code (`SServer`) rather than keeping it as an attribute of the client session itself. Now the session is just a passive vessel for two connections and associated context.

* **Export ClientSession's Close() method**
* **Use ClientSession's logger via accessor** 
* **Introduce other ClientSession accessors**

Miscellaneous minor changes to avoid accessing client session data directly. Instead, new accessor methods are introduces (which will later be used by proxies outside of `cmd/acra-server` module).

* **Unique session IDs on ClientSession's logs**

Make sure that each session gets a unique `session_id` field in logs. This makes is really trivial to filter logs for activity of a particular session.

Don't be too smart with GUIDs or something, keep the field as short as possible. We only need it to be unique for a relatively short timeframe.

* **Use ClientSession in session proxy constructors**

Finally, instead of passing just two connections and an unrelated context, pass a `ClientSession` instance over to the proxy. Introduce an interface which allows access to interesting fields of AcraServer's `ClientSession`.