### PR TITLE
AcraServer refactoring for better shutdown control

### DIFF
--- a/cmd/acra-server/acra-server.go
+++ b/cmd/acra-server/acra-server.go
@@ -478,7 +478,7 @@ func main() {
 		logging.SetLogLevel(logging.LogDiscard)
 	}
 
-	ctx := context.TODO()
+	ctx := context.Background()
 	if os.Getenv(gracefulEnv) == "true" {
 		if *withZone || *enableHTTPAPI {
 			go server.StartCommandsFromFileDescriptor(ctx, descriptorAPI)

--- a/cmd/acra-server/acra-server.go
+++ b/cmd/acra-server/acra-server.go
@@ -31,6 +31,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"flag"
 	"net/http"
@@ -477,16 +478,17 @@ func main() {
 		logging.SetLogLevel(logging.LogDiscard)
 	}
 
+	ctx := context.TODO()
 	if os.Getenv(gracefulEnv) == "true" {
 		if *withZone || *enableHTTPAPI {
-			go server.StartCommandsFromFileDescriptor(descriptorAPI)
+			go server.StartCommandsFromFileDescriptor(ctx, descriptorAPI)
 		}
-		go server.StartFromFileDescriptor(descriptorAcra)
+		go server.StartFromFileDescriptor(ctx, descriptorAcra)
 	} else {
 		if *withZone || *enableHTTPAPI {
-			go server.StartCommands()
+			go server.StartCommands(ctx)
 		}
-		go server.Start()
+		go server.Start(ctx)
 	}
 
 	// on sighup we run callback that stop all listeners (that stop background goroutine of server.Start())

--- a/cmd/acra-server/common/listener.go
+++ b/cmd/acra-server/common/listener.go
@@ -19,10 +19,12 @@ package common
 import (
 	"context"
 	"errors"
+	"github.com/cossacklabs/acra/utils"
 	"io"
 	"net"
 	url_ "net/url"
 	"os"
+	"sync"
 	"syscall"
 	"time"
 
@@ -45,6 +47,8 @@ type SServer struct {
 	errorSignalChannel    chan os.Signal
 	restartSignalsChannel chan os.Signal
 	proxyFactory          base.ProxyFactory
+	backgroundWorkersSync sync.WaitGroup
+	stopListenersSignal   chan bool
 }
 
 // ErrWaitTimeout error indicates that server was shutdown and waited N seconds while shutting down all connections.
@@ -52,12 +56,14 @@ var ErrWaitTimeout = errors.New("timeout")
 
 // NewServer creates new SServer.
 func NewServer(config *Config, proxyFactory base.ProxyFactory, errorChan chan os.Signal, restarChan chan os.Signal) (server *SServer, err error) {
+	stopListenersSignal := make(chan bool)
 	return &SServer{
 		config:                config,
 		connectionManager:     network.NewConnectionManager(),
 		errorSignalChannel:    errorChan,
 		restartSignalsChannel: restarChan,
 		proxyFactory:          proxyFactory,
+		stopListenersSignal:   stopListenersSignal,
 	}, nil
 }
 
@@ -137,38 +143,43 @@ func (server *SServer) handleConnection(ctx context.Context, clientID []byte, co
 }
 
 func (server *SServer) handleClientSession(clientID []byte, clientSession *ClientSession) {
-	log := clientSession.Logger()
-	log.Infof("Handle client's connection")
+	sessionLogger := clientSession.Logger()
+	sessionLogger.Infof("Handle client's connection")
 	clientProxyErrorCh := make(chan error, 1)
 	dbProxyErrorCh := make(chan error, 1)
 
-	log.Debugf("Connecting to db")
+	sessionLogger.Debugf("Connecting to db")
 	err := clientSession.ConnectToDb()
 	if err != nil {
-		log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantConnectToDB).
+		sessionLogger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantConnectToDB).
 			Errorln("Can't connect to db")
 
-		log.Debugln("Close connection with acra-connector")
+		sessionLogger.Debugln("Close connection with acra-connector")
 		err = clientSession.ClientConnection().Close()
 		if err != nil {
-			log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantCloseConnectionToService).
+			sessionLogger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantCloseConnectionToService).
 				Errorln("Error with closing connection to acra-connector")
 		}
 		return
 	}
 
-	if err != nil {
-		log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorDataEncryptorInitialization).
-			Errorln("Can't initialize data encryptor to encrypt data in queries")
-		return
-	}
 	proxy, err := server.proxyFactory.New(clientID, clientSession)
 	if err != nil {
-		log.WithError(err).Errorln("Can't create new proxy for connection")
+		sessionLogger.WithError(err).Errorln("Can't create new proxy for connection")
 		return
 	}
-	go proxy.ProxyClientConnection(clientProxyErrorCh)
-	go proxy.ProxyDatabaseConnection(dbProxyErrorCh)
+
+	server.backgroundWorkersSync.Add(1)
+	go func() {
+		defer server.backgroundWorkersSync.Done()
+		proxy.ProxyClientConnection(clientProxyErrorCh)
+	}()
+
+	server.backgroundWorkersSync.Add(1)
+	go func() {
+		defer server.backgroundWorkersSync.Done()
+		proxy.ProxyDatabaseConnection(dbProxyErrorCh)
+	}()
 
 	var channelToWait chan error
 	const (
@@ -179,34 +190,34 @@ func (server *SServer) handleClientSession(clientID []byte, clientSession *Clien
 
 	select {
 	case err = <-dbProxyErrorCh:
-		log.Debugln("Stop to proxy Database -> AcraServer")
+		sessionLogger.Debugln("Stop to proxy Database -> AcraServer")
 		interruptSide = acraDbSide
 		channelToWait = clientProxyErrorCh
 	case err = <-clientProxyErrorCh:
 		interruptSide = clientAcraSide
-		log.Debugln("Stop to proxy AcraServer -> Client")
+		sessionLogger.Debugln("Stop to proxy AcraServer -> Client")
 		channelToWait = dbProxyErrorCh
 	}
-	log = log.WithField("interrupt_side", interruptSide)
+	sessionLogger = sessionLogger.WithField("interrupt_side", interruptSide)
 	if err == io.EOF {
-		log.Debugln("EOF connection closed")
+		sessionLogger.Debugln("EOF connection closed")
 	} else if err == nil {
-		log.Debugln("Err == nil from proxy goroutine")
+		sessionLogger.Debugln("Err == nil from proxy goroutine")
 	} else if netErr, ok := err.(net.Error); ok {
-		log.WithError(netErr).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorGeneralConnectionProcessing).
+		sessionLogger.WithError(netErr).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorGeneralConnectionProcessing).
 			Errorln("Network error")
 	} else if opErr, ok := err.(*net.OpError); ok {
-		log.WithError(opErr).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorGeneralConnectionProcessing).Errorln("Network error")
+		sessionLogger.WithError(opErr).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorGeneralConnectionProcessing).Errorln("Network error")
 	} else {
-		log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorGeneralConnectionProcessing).Errorln("Unexpected error")
+		sessionLogger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorGeneralConnectionProcessing).Errorln("Unexpected error")
 	}
 
-	log.Infof("Closing client's connection")
+	sessionLogger.Infof("Closing client's connection")
 	clientSession.Close()
 
 	// wait second error from closed second connection
-	log.WithError(<-channelToWait).Debugln("Second proxy goroutine stopped")
-	log.Infoln("Finished processing client's connection")
+	sessionLogger.WithError(<-channelToWait).Debugln("Second proxy goroutine stopped")
+	sessionLogger.Infoln("Finished processing client's connection")
 }
 
 func (server *SServer) processConnection(connection net.Conn, callback *callbackData) {
@@ -253,31 +264,47 @@ func (server *SServer) processConnection(connection net.Conn, callback *callback
 	callback.callbackFunc(ctx, clientID, wrappedConnection)
 }
 
-func (server *SServer) start(listener net.Listener, callback *callbackData, logger *log.Entry) {
+func (server *SServer) start(parentContext context.Context, listener net.Listener, callback *callbackData, logger *log.Entry, errCh chan<- error) {
 	logger.Infof("Start listening connections")
 	for {
-		connection, err := listener.Accept()
-		if err != nil {
-			if nerr, ok := err.(net.Error); ok && nerr.Timeout() {
-				logger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorConnectionDroppedByTimeout).
-					Errorln("Stop accepting new connections due net.Timeout")
+		if err := parentContext.Err(); err != nil {
+			// this means that parentContext is Done.
+			// And here we are not interesting in particular reasons of it, so just return
+			return
+		} else {
+			connection, err := listener.Accept()
+			if err != nil {
+				select {
+				case <-server.stopListenersSignal:
+					// situation when listener is stopped while accepting.
+					// This is typical for shutdown that invokes StopListeners functions, which closes signalling channel, just skip
+				default:
+					if nerr, ok := err.(net.Error); ok && nerr.Timeout() {
+						logger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorConnectionDroppedByTimeout).
+							Errorln("Stop accepting new connections due net.Timeout")
+					} else {
+						logger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantAcceptNewConnections).
+							Errorln("Can't accept new connection")
+					}
+					errCh <- err
+				}
 				return
 			}
-			logger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantAcceptNewConnections).
-				Errorln("Can't accept new connection")
-			return
+			// unix socket and value == '@'
+			if len(connection.RemoteAddr().String()) == 1 {
+				logger.Infof("Got new connection to AcraServer: %v", connection.LocalAddr())
+			} else {
+				logger.Infof("Got new connection to AcraServer: %v", connection.RemoteAddr())
+			}
+
+			server.backgroundWorkersSync.Add(1)
+			go func() {
+				defer server.backgroundWorkersSync.Done()
+				_ = server.connectionManager.AddConnection(connection)
+				server.processConnection(connection, callback)
+				_ = server.connectionManager.RemoveConnection(connection)
+			}()
 		}
-		// unix socket and value == '@'
-		if len(connection.RemoteAddr().String()) == 1 {
-			logger.Infof("Got new connection to AcraServer: %v", connection.LocalAddr())
-		} else {
-			logger.Infof("Got new connection to AcraServer: %v", connection.RemoteAddr())
-		}
-		go func() {
-			server.connectionManager.AddConnection(connection)
-			server.processConnection(connection, callback)
-			server.connectionManager.RemoveConnection(connection)
-		}()
 	}
 }
 
@@ -291,8 +318,19 @@ func (server *SServer) ListenerAPI() net.Listener {
 	return server.listenerAPI
 }
 
+func (server *SServer) waitForExitTimeout() {
+	// We should use this function when shutdown service as a defer. In this case global 'cancel'
+	// has been called. Now we should wait (not more than specified duration) until all
+	// background goroutines spawned by SServer will finish their execution or force their closing.
+	if utils.WaitWithTimeout(&server.backgroundWorkersSync, utils.DefaultWaitGroupTimeoutDuration) {
+		log.Errorf("Couldn't stop all background goroutines spawned by readerServer. Exited by timeout")
+	}
+}
+
 // Start listening connections from proxy
-func (server *SServer) Start() {
+func (server *SServer) Start(parentContext context.Context) {
+	defer server.waitForExitTimeout()
+
 	logger := log.WithFields(log.Fields{"connection_string": server.config.GetAcraConnectionString(), "from_descriptor": false})
 	logger.Infoln("Create listener")
 	var listener, err = network.Listen(server.config.GetAcraConnectionString())
@@ -304,11 +342,13 @@ func (server *SServer) Start() {
 	}
 	server.listenerACRA = listener
 	server.addListener(listener)
-	server.start(listener, &callbackData{funcName: "handleConnection", connectionType: dbConnectionType, callbackFunc: server.handleConnection}, logger)
+	server.run(parentContext, listener, &callbackData{funcName: "handleConnection", connectionType: dbConnectionType, callbackFunc: server.handleConnection}, logger)
 }
 
 // StartFromFileDescriptor starts listening Acra data connections from file descriptor.
-func (server *SServer) StartFromFileDescriptor(fd uintptr) {
+func (server *SServer) StartFromFileDescriptor(parentContext context.Context, fd uintptr) {
+	defer server.waitForExitTimeout()
+
 	logger := log.WithFields(log.Fields{"connection_string": server.config.GetAcraConnectionString(), "from_descriptor": true})
 	file := os.NewFile(fd, "/tmp/acra-server")
 	if file == nil {
@@ -332,7 +372,7 @@ func (server *SServer) StartFromFileDescriptor(fd uintptr) {
 	}
 	server.listenerACRA = listenerWithFileDescriptor
 	server.addListener(listenerWithFileDescriptor)
-	server.start(listenerWithFileDescriptor, &callbackData{funcName: "handleConnection", connectionType: dbConnectionType, callbackFunc: server.handleConnection}, logger)
+	server.run(parentContext, listenerWithFileDescriptor, &callbackData{funcName: "handleConnection", connectionType: dbConnectionType, callbackFunc: server.handleConnection}, logger)
 }
 
 // stopAcceptConnections stop accepting by setting deadline and then background code that call Accept will took error and
@@ -352,6 +392,10 @@ func stopAcceptConnections(listener network.DeadlineListener) (err error) {
 
 // StopListeners stops accepts new connections, and stops existing listeners with deadline.
 func (server *SServer) StopListeners() {
+	// Use this channel for signaling of closed listeners according to
+	// https://stackoverflow.com/questions/13417095/how-do-i-stop-a-listening-server-in-go
+	close(server.stopListenersSignal)
+
 	var err error
 	var deadlineListener network.DeadlineListener
 	log.Debugln("Stopping listeners")
@@ -398,10 +442,7 @@ func (server *SServer) ConnectionsCounter() int {
 	return server.connectionManager.Counter
 }
 
-/*
-handle new connection by initializing secure session, starting proxy request
-to db and decrypting responses from db
-*/
+// handleCommandsConnection handles requests to HTTP API
 func (server *SServer) handleCommandsConnection(ctx context.Context, clientID []byte, connection net.Conn) {
 	logger := logging.NewLoggerWithTrace(ctx)
 	clientSession, err := NewClientCommandsSession(ctx, server, server.config, connection)
@@ -416,7 +457,9 @@ func (server *SServer) handleCommandsConnection(ctx context.Context, clientID []
 }
 
 // StartCommands starts listening commands connections from proxy.
-func (server *SServer) StartCommands() {
+func (server *SServer) StartCommands(parentContext context.Context) {
+	defer server.waitForExitTimeout()
+
 	logger := log.WithFields(log.Fields{"connection_string": server.config.GetAcraAPIConnectionString(), "from_descriptor": false})
 	var listener, err = network.Listen(server.config.GetAcraAPIConnectionString())
 	if err != nil {
@@ -427,11 +470,13 @@ func (server *SServer) StartCommands() {
 	}
 	server.listenerAPI = listener
 	server.addListener(listener)
-	server.start(listener, &callbackData{funcName: "handleCommandsConnection", connectionType: apiConnectionType, callbackFunc: server.handleCommandsConnection}, logger)
+	server.run(parentContext, listener, &callbackData{funcName: "handleCommandsConnection", connectionType: apiConnectionType, callbackFunc: server.handleCommandsConnection}, logger)
 }
 
 // StartCommandsFromFileDescriptor starts listening commands connections from file descriptor.
-func (server *SServer) StartCommandsFromFileDescriptor(fd uintptr) {
+func (server *SServer) StartCommandsFromFileDescriptor(parentContext context.Context, fd uintptr) {
+	defer server.waitForExitTimeout()
+
 	logger := log.WithFields(log.Fields{"connection_string": server.config.GetAcraConnectionString(), "from_descriptor": true})
 	file := os.NewFile(fd, "/tmp/acra-server_http_api")
 	if file == nil {
@@ -443,16 +488,36 @@ func (server *SServer) StartCommandsFromFileDescriptor(fd uintptr) {
 	if err != nil {
 		logger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCantOpenFileByDescriptor).
 			Errorln("System error: can't start listen for file descriptor")
-		server.errorSignalChannel <- syscall.SIGTERM
 		return
 	}
 	listenerWithFileDescriptor, ok := listenerFile.(network.ListenerWithFileDescriptor)
 	if !ok {
 		logger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorFileDescriptionIsNotValid).
 			Errorf("System error: file descriptor %d is not a valid socket", fd)
+		server.errorSignalChannel <- syscall.SIGTERM
 		return
 	}
 	server.listenerAPI = listenerWithFileDescriptor
 	server.addListener(listenerWithFileDescriptor)
-	server.start(listenerWithFileDescriptor, &callbackData{funcName: "handleCommandsConnection", connectionType: apiConnectionType, callbackFunc: server.handleCommandsConnection}, logger)
+	server.run(parentContext, listenerWithFileDescriptor, &callbackData{funcName: "handleCommandsConnection", connectionType: apiConnectionType, callbackFunc: server.handleCommandsConnection}, logger)
+}
+
+func (server *SServer) run(parentContext context.Context, listener net.Listener, data *callbackData, logger *log.Entry) {
+	var errCh = make(chan error)
+	server.backgroundWorkersSync.Add(1)
+	go func() {
+		defer server.backgroundWorkersSync.Done()
+		server.start(parentContext, listener, data, logger, errCh)
+	}()
+
+	select {
+	case <-parentContext.Done():
+		break
+	case outErr := <-errCh:
+		if outErr != nil {
+			logger.WithError(outErr).Errorln("Error occurred on accepting/handling connection")
+		}
+		break
+	}
+	return
 }


### PR DESCRIPTION
This PR introduces refactoring on main component level (`SServer`) of AcraServer service.

I used approach, described in T1661 and already implemented in https://github.com/cossacklabs/acra/pull/414 for AcraTranslator. Just short reminder: we need better control of shutdown process because it is very important for EE version in context of audit logging (where we need to finish execution of service with special service log messages). So here on main component level I added synchronization of spawned goroutines (with a help of `waitGroup` mechanism) and signalling of shutdown invocation with a help of `parentContext` (passed to `SServer` from main function of AcraServer).

For testing I used two versions of AcraServer (CE and EE), according to the procedures described in https://github.com/cossacklabs/acra/pull/414 but with little modification, since we AcraServer works with databases. Test application is the following (basic Go's unit test):

```
func TestDebug(t *testing.T) {
	connectionsNum := 10
	queriesNum := 50000

	var wg sync.WaitGroup
	for i := 0; i < connectionsNum; i++ {
		wg.Add(1)
		go func() {
			defer wg.Done()
			db, err := sql.Open("postgres", "port=9393 user=test dbname=test password=test sslmode=disable")
			if err != nil {
				t.Fatal(err)
			}
			defer db.Close()
			var col string
			for i := 0; i < queriesNum; i++ {
				rows, err := db.Query("SELECT 2 + 2")
				if err != nil {
					t.Fatal(err)
				}
				defer rows.Close()
				for rows.Next() {
					err = rows.Scan(&col)
					if err != nil {
						t.Fatal(err)
					}
				}
			}
		}()
	}
	wg.Wait()
}
```

Here I create 10 simultaneous connections to AcraServer and execute 50000 toy queries (`SELECT 2+2`) inside each of them.
While execution, I send SIGHUP, SIGTERM signals and manually check the behavior of the service. While SIGHUP testing I encountered some errors when connections are cut:
```
time="2020-09-30T20:39:37+03:00" level=error msg="Network error" client_id=client code=1100 error="read tcp 127.0.0.1:9393->127.0.0.1:45902: use of closed network connection" interrupt_side="Client/Connector<->Database"

time="2020-09-30T20:39:37+03:00" level=warning msg="Can't flush writer" client_id=client code=1301 decrypt_mode=wholecell error="write tcp 127.0.0.1:9393->127.0.0.1:45908: use of closed network connection" proxy=server
```

As discussed with @Lagovas this seems to be expected errors, because connections are long-term and when they are cut, proxying functions (`ProxyClientConnection`, `ProxyDatabaseConnection`) that handle encryption/decryption are still try to use connection that is already closed (and proxies don't have information if this connection closing is caused by SIGHUP/SIGTERM, e.g. "legitimate" case or it is some unexpected network error). The rest of system signals handling works as expected. For SIGTERM it gracefully stops service (and we guarantee that all goroutines are finished before os.Exit), and SIGHUP forks child process and exits from parent. 

Changes in CE version of AcraServer also present in this PR (they are minimal), while changes in EE version will be introduced in separate PR to EE repository.