### PR TITLE
Prepared statement and cursor registries

### DIFF
--- a/cmd/acra-server/common/client_session.go
+++ b/cmd/acra-server/common/client_session.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"sync/atomic"
 
+	"github.com/cossacklabs/acra/decryptor/base"
 	"github.com/cossacklabs/acra/logging"
 	"github.com/cossacklabs/acra/network"
 	log "github.com/sirupsen/logrus"
@@ -33,6 +34,7 @@ type ClientSession struct {
 	connectionToDb net.Conn
 	ctx            context.Context
 	logger         *log.Entry
+	statements     base.PreparedStatementRegistry
 }
 
 var sessionCounter uint32
@@ -67,6 +69,17 @@ func (clientSession *ClientSession) ClientConnection() net.Conn {
 // It must be established first by ConnectToDb().
 func (clientSession *ClientSession) DatabaseConnection() net.Conn {
 	return clientSession.connectionToDb
+}
+
+// PreparedStatementRegistry returns prepared statement registry of this session.
+// The session does not have a registry by default, it must be set with SetPreparedStatementRegistry.
+func (clientSession *ClientSession) PreparedStatementRegistry() base.PreparedStatementRegistry {
+	return clientSession.statements
+}
+
+// SetPreparedStatementRegistry sets prepared statement registry for this session.
+func (clientSession *ClientSession) SetPreparedStatementRegistry(registry base.PreparedStatementRegistry) {
+	clientSession.statements = registry
 }
 
 // ConnectToDb connects to the database via tcp using Host and Port from config.

--- a/cmd/acra-server/common/client_session.go
+++ b/cmd/acra-server/common/client_session.go
@@ -35,6 +35,7 @@ type ClientSession struct {
 	ctx            context.Context
 	logger         *log.Entry
 	statements     base.PreparedStatementRegistry
+	cursors        base.CursorRegistry
 }
 
 var sessionCounter uint32
@@ -80,6 +81,17 @@ func (clientSession *ClientSession) PreparedStatementRegistry() base.PreparedSta
 // SetPreparedStatementRegistry sets prepared statement registry for this session.
 func (clientSession *ClientSession) SetPreparedStatementRegistry(registry base.PreparedStatementRegistry) {
 	clientSession.statements = registry
+}
+
+// CursorRegistry returns cursor registry of this session.
+// The session does not have a registry by default, it must be set with SetCursorRegistry.
+func (clientSession *ClientSession) CursorRegistry() base.CursorRegistry {
+	return clientSession.cursors
+}
+
+// SetCursorRegistry sets cursor registry for this session.
+func (clientSession *ClientSession) SetCursorRegistry(registry base.CursorRegistry) {
+	clientSession.cursors = registry
 }
 
 // ConnectToDb connects to the database via tcp using Host and Port from config.

--- a/cmd/acra-server/common/client_session.go
+++ b/cmd/acra-server/common/client_session.go
@@ -35,7 +35,6 @@ type ClientSession struct {
 	ctx            context.Context
 	logger         *log.Entry
 	statements     base.PreparedStatementRegistry
-	cursors        base.CursorRegistry
 }
 
 var sessionCounter uint32
@@ -81,17 +80,6 @@ func (clientSession *ClientSession) PreparedStatementRegistry() base.PreparedSta
 // SetPreparedStatementRegistry sets prepared statement registry for this session.
 func (clientSession *ClientSession) SetPreparedStatementRegistry(registry base.PreparedStatementRegistry) {
 	clientSession.statements = registry
-}
-
-// CursorRegistry returns cursor registry of this session.
-// The session does not have a registry by default, it must be set with SetCursorRegistry.
-func (clientSession *ClientSession) CursorRegistry() base.CursorRegistry {
-	return clientSession.cursors
-}
-
-// SetCursorRegistry sets cursor registry for this session.
-func (clientSession *ClientSession) SetCursorRegistry(registry base.CursorRegistry) {
-	clientSession.cursors = registry
 }
 
 // ConnectToDb connects to the database via tcp using Host and Port from config.

--- a/decryptor/base/proxy.go
+++ b/decryptor/base/proxy.go
@@ -96,8 +96,6 @@ type ClientSession interface {
 
 	PreparedStatementRegistry() PreparedStatementRegistry
 	SetPreparedStatementRegistry(registry PreparedStatementRegistry)
-	CursorRegistry() CursorRegistry
-	SetCursorRegistry(registry CursorRegistry)
 }
 
 // ProxyFactory create new Proxy for specific database
@@ -105,10 +103,13 @@ type ProxyFactory interface {
 	New(clientID []byte, clientSession ClientSession) (Proxy, error)
 }
 
-// PreparedStatementRegistry keeps track of active prepared statements within a ClientSession.
+// PreparedStatementRegistry keeps track of active prepared statements and cursors within a ClientSession.
 type PreparedStatementRegistry interface {
-	Add(statement PreparedStatement) error
+	AddStatement(statement PreparedStatement) error
 	StatementByName(name string) (PreparedStatement, error)
+
+	AddCursor(cursor Cursor) error
+	CursorByName(name string) (Cursor, error)
 }
 
 // PreparedStatement is a prepared statement, ready to be executed.
@@ -117,12 +118,6 @@ type PreparedStatement interface {
 	Name() string
 	Query() sqlparser.Statement
 	QueryText() string
-}
-
-// CursorRegistry keeps track of active cursors within a ClientSession.
-type CursorRegistry interface {
-	Add(cursor Cursor) error
-	CursorByName(name string) (Cursor, error)
 }
 
 // Cursor is used to iterate over a prepared statement.

--- a/decryptor/base/proxy.go
+++ b/decryptor/base/proxy.go
@@ -24,6 +24,7 @@ import (
 	acracensor "github.com/cossacklabs/acra/acra-censor"
 	"github.com/cossacklabs/acra/encryptor/config"
 	"github.com/cossacklabs/acra/keystore"
+	"github.com/cossacklabs/acra/sqlparser"
 )
 
 // ProxySetting provide data access methods for proxy factories
@@ -92,9 +93,26 @@ type ClientSession interface {
 	Context() context.Context
 	ClientConnection() net.Conn
 	DatabaseConnection() net.Conn
+
+	PreparedStatementRegistry() PreparedStatementRegistry
+	SetPreparedStatementRegistry(registry PreparedStatementRegistry)
 }
 
 // ProxyFactory create new Proxy for specific database
 type ProxyFactory interface {
 	New(clientID []byte, clientSession ClientSession) (Proxy, error)
+}
+
+// PreparedStatementRegistry keeps track of active prepared statements within a ClientSession.
+type PreparedStatementRegistry interface {
+	Add(statement PreparedStatement) (bool, error)
+	StatementByName(name string) (PreparedStatement, error)
+}
+
+// PreparedStatement is a prepared statement, ready to be executed.
+// It can be either a textual SQL statement from "PREPARE", or a database protocol equivalent.
+type PreparedStatement interface {
+	Name() string
+	Query() sqlparser.Statement
+	QueryText() string
 }

--- a/decryptor/base/proxy.go
+++ b/decryptor/base/proxy.go
@@ -106,9 +106,11 @@ type ProxyFactory interface {
 // PreparedStatementRegistry keeps track of active prepared statements and cursors within a ClientSession.
 type PreparedStatementRegistry interface {
 	AddStatement(statement PreparedStatement) error
+	DeleteStatement(name string) error
 	StatementByName(name string) (PreparedStatement, error)
 
 	AddCursor(cursor Cursor) error
+	DeleteCursor(name string) error
 	CursorByName(name string) (Cursor, error)
 }
 

--- a/decryptor/base/proxy.go
+++ b/decryptor/base/proxy.go
@@ -107,7 +107,7 @@ type ProxyFactory interface {
 
 // PreparedStatementRegistry keeps track of active prepared statements within a ClientSession.
 type PreparedStatementRegistry interface {
-	Add(statement PreparedStatement) (bool, error)
+	Add(statement PreparedStatement) error
 	StatementByName(name string) (PreparedStatement, error)
 }
 
@@ -121,7 +121,7 @@ type PreparedStatement interface {
 
 // CursorRegistry keeps track of active cursors within a ClientSession.
 type CursorRegistry interface {
-	Add(cursor Cursor) (bool, error)
+	Add(cursor Cursor) error
 	CursorByName(name string) (Cursor, error)
 }
 

--- a/decryptor/base/proxy.go
+++ b/decryptor/base/proxy.go
@@ -96,6 +96,8 @@ type ClientSession interface {
 
 	PreparedStatementRegistry() PreparedStatementRegistry
 	SetPreparedStatementRegistry(registry PreparedStatementRegistry)
+	CursorRegistry() CursorRegistry
+	SetCursorRegistry(registry CursorRegistry)
 }
 
 // ProxyFactory create new Proxy for specific database
@@ -115,4 +117,17 @@ type PreparedStatement interface {
 	Name() string
 	Query() sqlparser.Statement
 	QueryText() string
+}
+
+// CursorRegistry keeps track of active cursors within a ClientSession.
+type CursorRegistry interface {
+	Add(cursor Cursor) (bool, error)
+	CursorByName(name string) (Cursor, error)
+}
+
+// Cursor is used to iterate over a prepared statement.
+// It can be either a textual SQL statement from "DEFINE CURSOR", or a database protocol equivalent.
+type Cursor interface {
+	Name() string
+	PreparedStatement() PreparedStatement
 }

--- a/decryptor/mysql/proxy_test.go
+++ b/decryptor/mysql/proxy_test.go
@@ -46,6 +46,13 @@ func (stubSession) PreparedStatementRegistry() base.PreparedStatementRegistry {
 func (stubSession) SetPreparedStatementRegistry(registry base.PreparedStatementRegistry) {
 }
 
+func (stubSession) CursorRegistry() base.CursorRegistry {
+	return nil
+}
+
+func (stubSession) SetCursorRegistry(registry base.CursorRegistry) {
+}
+
 func TestEncryptorTurnOnOff(t *testing.T) {
 	emptyStore := &tableSchemaStore{true}
 	nonEmptyStore := &tableSchemaStore{false}

--- a/decryptor/mysql/proxy_test.go
+++ b/decryptor/mysql/proxy_test.go
@@ -46,13 +46,6 @@ func (stubSession) PreparedStatementRegistry() base.PreparedStatementRegistry {
 func (stubSession) SetPreparedStatementRegistry(registry base.PreparedStatementRegistry) {
 }
 
-func (stubSession) CursorRegistry() base.CursorRegistry {
-	return nil
-}
-
-func (stubSession) SetCursorRegistry(registry base.CursorRegistry) {
-}
-
 func TestEncryptorTurnOnOff(t *testing.T) {
 	emptyStore := &tableSchemaStore{true}
 	nonEmptyStore := &tableSchemaStore{false}

--- a/decryptor/mysql/proxy_test.go
+++ b/decryptor/mysql/proxy_test.go
@@ -39,6 +39,13 @@ func (stubSession) DatabaseConnection() net.Conn {
 	return nil
 }
 
+func (stubSession) PreparedStatementRegistry() base.PreparedStatementRegistry {
+	return nil
+}
+
+func (stubSession) SetPreparedStatementRegistry(registry base.PreparedStatementRegistry) {
+}
+
 func TestEncryptorTurnOnOff(t *testing.T) {
 	emptyStore := &tableSchemaStore{true}
 	nonEmptyStore := &tableSchemaStore{false}

--- a/decryptor/postgresql/pg_decryptor.go
+++ b/decryptor/postgresql/pg_decryptor.go
@@ -117,9 +117,6 @@ func NewPgProxy(session base.ClientSession, decryptor base.Decryptor, setting ba
 	if session.PreparedStatementRegistry() == nil {
 		session.SetPreparedStatementRegistry(NewPreparedStatementRegistry())
 	}
-	if session.CursorRegistry() == nil {
-		session.SetCursorRegistry(NewPortalRegistry())
-	}
 	return &PgProxy{
 		session:              session,
 		clientConnection:     session.ClientConnection(),

--- a/decryptor/postgresql/prepared_statements.go
+++ b/decryptor/postgresql/prepared_statements.go
@@ -32,14 +32,14 @@ var (
 // PgPreparedStatementRegistry is a PostgreSQL PreparedStatementRegistry.
 type PgPreparedStatementRegistry struct {
 	statements map[string]base.PreparedStatement
-	portals    map[string]base.Cursor
+	cursors    map[string]base.Cursor
 }
 
 // NewPreparedStatementRegistry makes a new empty prepared statement registry.
 func NewPreparedStatementRegistry() *PgPreparedStatementRegistry {
 	return &PgPreparedStatementRegistry{
 		statements: make(map[string]base.PreparedStatement),
-		portals:    make(map[string]base.Cursor),
+		cursors:    make(map[string]base.Cursor),
 	}
 }
 
@@ -54,7 +54,7 @@ func (r *PgPreparedStatementRegistry) StatementByName(name string) (base.Prepare
 
 // CursorByName returns a cursor from the registry by its name, if it exists.
 func (r *PgPreparedStatementRegistry) CursorByName(name string) (base.Cursor, error) {
-	s, ok := r.portals[name]
+	s, ok := r.cursors[name]
 	if ok {
 		return s, nil
 	}
@@ -73,15 +73,15 @@ func (r *PgPreparedStatementRegistry) AddStatement(statement base.PreparedStatem
 	return nil
 }
 
-// AddCursor adds a portal to the registry.
-// If an existing portal with the same name exists, it is replaced with the new one.
-func (r *PgPreparedStatementRegistry) AddCursor(portal base.Cursor) error {
-	// TODO(ilammy, 2020-10-02): allow updates only for unnamed portals
+// AddCursor adds a cursor to the registry.
+// If an existing cursor with the same name exists, it is replaced with the new one.
+func (r *PgPreparedStatementRegistry) AddCursor(cursor base.Cursor) error {
+	// TODO(ilammy, 2020-10-02): allow updates only for unnamed cursors
 	// PostgreSQL protocol allows repeated Bind messages (without matching Close)
-	// only for unnamed portals. SQL DECLARE CURSOR cannot be repeated too.
+	// only for unnamed cursors. SQL DECLARE CURSOR cannot be repeated too.
 	// Currently, Delete() is not called so we allow updates, but we shouldn't.
-	name := portal.Name()
-	r.portals[name] = portal
+	name := cursor.Name()
+	r.cursors[name] = cursor
 	return nil
 }
 
@@ -116,11 +116,11 @@ func (s *PgPreparedStatement) QueryText() string {
 // Cursors are called "portals" in PostgreSQL protocol specs.
 type PgPortal struct {
 	name      string
-	statement *PgPreparedStatement
+	statement base.PreparedStatement
 }
 
 // NewPortal makes a new portal.
-func NewPortal(name string, statement *PgPreparedStatement) *PgPortal {
+func NewPortal(name string, statement base.PreparedStatement) *PgPortal {
 	return &PgPortal{name, statement}
 }
 

--- a/decryptor/postgresql/prepared_statements.go
+++ b/decryptor/postgresql/prepared_statements.go
@@ -118,7 +118,7 @@ func (r *PgPreparedStatementRegistry) DeleteStatement(name string) error {
 		return nil
 	}
 	// First, remove all cursors over the statement.
-	cursors, ok := r.cursorsOfStatement[name]
+	cursors := r.cursorsOfStatement[name]
 	for cursor := range cursors {
 		delete(r.cursors, cursor)
 	}

--- a/decryptor/postgresql/prepared_statements.go
+++ b/decryptor/postgresql/prepared_statements.go
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2020, Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package postgresql
+
+import (
+	"errors"
+
+	"github.com/cossacklabs/acra/decryptor/base"
+	"github.com/cossacklabs/acra/sqlparser"
+)
+
+// Errors returned by prepared statement registry.
+var (
+	ErrStatementNotFound = errors.New("no prepared statement with given name")
+)
+
+// PgPreparedStatementRegistry is a PostgreSQL PreparedStatementRegistry.
+type PgPreparedStatementRegistry struct {
+	registry map[string]base.PreparedStatement
+}
+
+// NewPreparedStatementRegistry makes a new empty prepared statement registry.
+func NewPreparedStatementRegistry() *PgPreparedStatementRegistry {
+	return &PgPreparedStatementRegistry{registry: make(map[string]base.PreparedStatement)}
+}
+
+// StatementByName returns a prepared statement from the registry by its name, if it exists.
+func (r *PgPreparedStatementRegistry) StatementByName(name string) (base.PreparedStatement, error) {
+	s, ok := r.registry[name]
+	if ok {
+		return s, nil
+	}
+	return nil, ErrStatementNotFound
+}
+
+// Add a statement to the registry. If an existing statement with the same name exists,
+// it is replaced with the new one. Returns "true" if statement has been replaced.
+func (r *PgPreparedStatementRegistry) Add(statement base.PreparedStatement) (bool, error) {
+	name := statement.Name()
+	_, exists := r.registry[name]
+	r.registry[name] = statement
+	return exists, nil
+}
+
+// PgPreparedStatement is a PostgreSQL PreparedStatement.
+type PgPreparedStatement struct {
+	name string
+	text string
+	sql  sqlparser.Statement
+}
+
+// NewPreparedStatement makes a new prepared statement.
+func NewPreparedStatement(name string, text string, sql sqlparser.Statement) *PgPreparedStatement {
+	return &PgPreparedStatement{name, text, sql}
+}
+
+// Name returns the name of the prepared statement.
+func (s *PgPreparedStatement) Name() string {
+	return s.name
+}
+
+// Query returns the prepared query, in its parsed form.
+func (s *PgPreparedStatement) Query() sqlparser.Statement {
+	return s.sql
+}
+
+// QueryText returns text of the prepared query, as provided by the client.
+func (s *PgPreparedStatement) QueryText() string {
+	return s.text
+}

--- a/decryptor/postgresql/prepared_statements.go
+++ b/decryptor/postgresql/prepared_statements.go
@@ -50,11 +50,14 @@ func (r *PgPreparedStatementRegistry) StatementByName(name string) (base.Prepare
 
 // Add a statement to the registry. If an existing statement with the same name exists,
 // it is replaced with the new one. Returns "true" if statement has been replaced.
-func (r *PgPreparedStatementRegistry) Add(statement base.PreparedStatement) (bool, error) {
+func (r *PgPreparedStatementRegistry) Add(statement base.PreparedStatement) error {
+	// TODO(ilammy, 2020-10-02): allow updates only for unnamed statements
+	// PostgreSQL protocol allows repeated Parse messages (without matching Close)
+	// only for unnamed prepared statements. SQL PREPARE cannot be repeated too.
+	// Currently, Delete() is not called so we allow updates, but we shouldn't.
 	name := statement.Name()
-	_, exists := r.registry[name]
 	r.registry[name] = statement
-	return exists, nil
+	return nil
 }
 
 // PgPreparedStatement is a PostgreSQL PreparedStatement.
@@ -106,11 +109,14 @@ func (r *PgPortalRegistry) CursorByName(name string) (base.Cursor, error) {
 
 // Add a portal to the registry. If an existing portal with the same name exists,
 // it is replaced with the new one. Returns "true" if portal has been replaced.
-func (r *PgPortalRegistry) Add(portal base.Cursor) (bool, error) {
+func (r *PgPortalRegistry) Add(portal base.Cursor) error {
+	// TODO(ilammy, 2020-10-02): allow updates only for unnamed portals
+	// PostgreSQL protocol allows repeated Bind messages (without matching Close)
+	// only for unnamed portals. SQL DECLARE CURSOR cannot be repeated too.
+	// Currently, Delete() is not called so we allow updates, but we shouldn't.
 	name := portal.Name()
-	_, exists := r.registry[name]
 	r.registry[name] = portal
-	return exists, nil
+	return nil
 }
 
 // PgPortal is a PostgreSQL Cursor.

--- a/decryptor/postgresql/prepared_statements_test.go
+++ b/decryptor/postgresql/prepared_statements_test.go
@@ -1,0 +1,307 @@
+/*
+ * Copyright 2020, Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package postgresql
+
+import "testing"
+
+func TestStatementInsert(t *testing.T) {
+	registry := NewPreparedStatementRegistry()
+
+	statement := NewPreparedStatement("statement", "SELECT 1", nil)
+
+	// There is no such statement in the registry initially.
+	initialStatement, err := registry.StatementByName("statement")
+	if err != ErrStatementNotFound {
+		t.Error("unexpected error when looking for missing statement", err)
+	}
+	if initialStatement != nil {
+		t.Error("unexpected statement in empty registry", initialStatement)
+	}
+
+	// Now add it...
+	err = registry.AddStatement(statement)
+	if err != nil {
+		t.Fatal("cannot add initial statement", err)
+	}
+
+	// And it should be there as a result.
+	foundStatement, err := registry.StatementByName("statement")
+	if err != nil {
+		t.Fatal("cannot look up statement after add", err)
+	}
+	if foundStatement != statement {
+		t.Error("did not find the same statement")
+	}
+}
+
+func TestStatementUpdateNamed(t *testing.T) {
+	registry := NewPreparedStatementRegistry()
+
+	// Insert a statement into the registry.
+	statement1 := NewPreparedStatement("statement", "SELECT 1", nil)
+	err := registry.AddStatement(statement1)
+	if err != nil {
+		t.Fatal("cannot add initial statement", err)
+	}
+
+	// Then do it again, using the same name.
+	statement2 := NewPreparedStatement("statement", "SELECT 2", nil)
+	err = registry.AddStatement(statement2)
+	if err != nil {
+		t.Fatal("cannot update existing named statement", err)
+	}
+
+	// The statement should be updated.
+	foundStatement, err := registry.StatementByName("statement")
+	if err != nil {
+		t.Fatal("cannot look up statement after update", err)
+	}
+	if foundStatement != statement2 {
+		t.Error("did not find the same statement")
+	}
+}
+
+func TestCursorInsertion(t *testing.T) {
+	registry := NewPreparedStatementRegistry()
+
+	statement := NewPreparedStatement("statement", "SELECT * FROM TEST", nil)
+	cursor := NewPortal("cursor", statement)
+
+	// It should not be possible to add a cursor into the registry
+	// without its associated statement already being there.
+	err := registry.AddCursor(cursor)
+	if err != ErrStatementNotFound {
+		t.Error("unexpected error when adding cursor without statement", err)
+	}
+
+	// And of course there is no such cursor in the registry initially.
+	initialCursor, err := registry.CursorByName("cursor")
+	if err != ErrCursorNotFound {
+		t.Error("unexpected error when looking for missing cursor", err)
+	}
+	if initialCursor != nil {
+		t.Error("unexpected cursor in empty registry", initialCursor)
+	}
+
+	// Now, add the statement and its cursor into the registry.
+	err = registry.AddStatement(statement)
+	if err != nil {
+		t.Fatal("cannot add statement", err)
+	}
+	err = registry.AddCursor(cursor)
+	if err != nil {
+		t.Fatal("cannot add cursor", err)
+	}
+
+	// The cursor should be available by its name after that.
+	foundCursor, err := registry.CursorByName("cursor")
+	if err != nil {
+		t.Fatal("cannot look up cursor after add", err)
+	}
+	if foundCursor != cursor {
+		t.Error("did not find the same cursor")
+	}
+}
+
+func TestCursorUpdateNamed(t *testing.T) {
+	registry := NewPreparedStatementRegistry()
+
+	// Insert a cursor into the registry.
+	statement := NewPreparedStatement("statement", "SELECT 1", nil)
+	err := registry.AddStatement(statement)
+	if err != nil {
+		t.Fatal("cannot add initial statement", err)
+	}
+	cursor1 := NewPortal("cursor", statement)
+	err = registry.AddCursor(cursor1)
+	if err != nil {
+		t.Fatal("cannot add cursor", err)
+	}
+
+	// Then create a new cursor for the same statement and insert it again.
+	cursor2 := NewPortal("cursor", statement)
+	err = registry.AddCursor(cursor2)
+	if err != nil {
+		t.Fatal("cannot update existing named cursor", err)
+	}
+
+	// The cursor should be updated.
+	foundCursor, err := registry.CursorByName("cursor")
+	if err != nil {
+		t.Fatal("cannot look up cursor after update", err)
+	}
+	if foundCursor != cursor2 {
+		t.Error("did not find the same cursor")
+	}
+
+	// Now, the same should work just find if a cursor for different statement reuses the same name,
+	// provided that the statement is in the registry and all.
+	statement2 := NewPreparedStatement("statement", "SELECT 2", nil)
+	cursor3 := NewPortal("cursor", statement2)
+	err = registry.AddStatement(statement2)
+	if err != nil {
+		t.Fatal("cannot add second statement", err)
+	}
+	err = registry.AddCursor(cursor3)
+	if err != nil {
+		t.Fatal("cannot update existing named cursor again", err)
+	}
+	// And it should point to that different cursor.
+	foundCursor3, err := registry.CursorByName("cursor")
+	if err != nil {
+		t.Fatal("cannot look up cursor after update", err)
+	}
+	if foundCursor3 != cursor3 {
+		t.Error("did not find the same cursor")
+	}
+}
+
+func TestStatementRemoval(t *testing.T) {
+	registry := NewPreparedStatementRegistry()
+
+	// Insert some statement into the registry.
+	statement := NewPreparedStatement("statement", "SELECT 1", nil)
+	err := registry.AddStatement(statement)
+	if err != nil {
+		t.Fatal("cannot add initial statement", err)
+	}
+
+	// Quickly remove it...
+	err = registry.DeleteStatement("statement")
+	if err != nil {
+		t.Fatal("cannot remove statement", err)
+	}
+
+	// There should no statement now.
+	notFoundStatement, err := registry.StatementByName("statement")
+	if err != ErrStatementNotFound {
+		t.Error("unexpected error when looking for removed statement", err)
+	}
+	if notFoundStatement != nil {
+		t.Error("unexpected non-nil removed statement", notFoundStatement)
+	}
+}
+
+func TestStatementRemovalMissing(t *testing.T) {
+	registry := NewPreparedStatementRegistry()
+
+	// It's okay to remove the statement which was not there in the first place
+	// since it is allowed by PostgreSQL protocol.
+	err := registry.DeleteStatement("missing")
+	if err != nil {
+		t.Error("cannot remove missing statement", err)
+	}
+}
+
+func TestCursorRemoval(t *testing.T) {
+	registry := NewPreparedStatementRegistry()
+
+	// Insert some statement and cursors into the registry.
+	statement := NewPreparedStatement("statement", "SELECT 1", nil)
+	err := registry.AddStatement(statement)
+	if err != nil {
+		t.Fatal("cannot add initial statement", err)
+	}
+	cursor1 := NewPortal("cursor1", statement)
+	err = registry.AddCursor(cursor1)
+	if err != nil {
+		t.Fatal("cannot add cursor", err)
+	}
+	cursor2 := NewPortal("cursor2", statement)
+	err = registry.AddCursor(cursor2)
+	if err != nil {
+		t.Fatal("cannot add cursor", err)
+	}
+
+	// Remove one of the cursors.
+	err = registry.DeleteCursor("cursor1")
+	if err != nil {
+		t.Fatal("cannot remove cursor", err)
+	}
+
+	// Removed cursor should not be present now.
+	notFoundCursor, err := registry.CursorByName("cursor1")
+	if err != ErrCursorNotFound {
+		t.Error("unexpected error when looking for removed cursor", err)
+	}
+	if notFoundCursor != nil {
+		t.Error("unexpected non-nil removed cursor", notFoundCursor)
+	}
+
+	// Though, the other cursor should still be there.
+	foundCursor, err := registry.CursorByName("cursor2")
+	if err != nil {
+		t.Fatal("failed to get surviving cursor", err)
+	}
+	if foundCursor != cursor2 {
+		t.Error("unexpected surviving cursor", foundCursor)
+	}
+}
+
+func TestCursorRemovalMissing(t *testing.T) {
+	registry := NewPreparedStatementRegistry()
+
+	// It's okay to remove the cursor which was not there in the first place
+	// since it is allowed by PostgreSQL protocol.
+	err := registry.DeleteCursor("missing")
+	if err != nil {
+		t.Error("cannot remove missing cursor", err)
+	}
+}
+
+func TestCursorRemovalWithStatement(t *testing.T) {
+	registry := NewPreparedStatementRegistry()
+
+	// Insert some statement and cursors into the registry.
+	statement := NewPreparedStatement("statement", "SELECT 1", nil)
+	err := registry.AddStatement(statement)
+	if err != nil {
+		t.Fatal("cannot add initial statement", err)
+	}
+	cursor1 := NewPortal("cursor1", statement)
+	err = registry.AddCursor(cursor1)
+	if err != nil {
+		t.Fatal("cannot add cursor", err)
+	}
+	cursor2 := NewPortal("cursor2", statement)
+	err = registry.AddCursor(cursor2)
+	if err != nil {
+		t.Fatal("cannot add cursor", err)
+	}
+
+	// Remove the statement
+	err = registry.DeleteStatement("statement")
+	if err != nil {
+		t.Fatal("cannot remove statement", err)
+	}
+
+	// This should also axe all of its cursors.
+	notFoundCursor1, err := registry.CursorByName("cursor1")
+	if err != ErrCursorNotFound {
+		t.Error("unexpected error when looking for removed cursor", err)
+	}
+	if notFoundCursor1 != nil {
+		t.Error("unexpected non-nil removed cursor", notFoundCursor1)
+	}
+	notFoundCursor2, err := registry.CursorByName("cursor2")
+	if err != ErrCursorNotFound {
+		t.Error("unexpected error when looking for removed cursor", err)
+	}
+	if notFoundCursor2 != nil {
+		t.Error("unexpected non-nil removed cursor", notFoundCursor2)
+	}
+}

--- a/decryptor/postgresql/prepared_statements_test.go
+++ b/decryptor/postgresql/prepared_statements_test.go
@@ -148,7 +148,7 @@ func TestCursorUpdateNamed(t *testing.T) {
 		t.Error("did not find the same cursor")
 	}
 
-	// Now, the same should work just find if a cursor for different statement reuses the same name,
+	// Now, the same should work just fine if a cursor for different statement reuses the same name,
 	// provided that the statement is in the registry and all.
 	statement2 := NewPreparedStatement("statement", "SELECT 2", nil)
 	cursor3 := NewPortal("cursor", statement2)
@@ -186,7 +186,7 @@ func TestStatementRemoval(t *testing.T) {
 		t.Fatal("cannot remove statement", err)
 	}
 
-	// There should no statement now.
+	// There should be no statement now.
 	notFoundStatement, err := registry.StatementByName("statement")
 	if err != ErrStatementNotFound {
 		t.Error("unexpected error when looking for removed statement", err)

--- a/decryptor/postgresql/proxy_test.go
+++ b/decryptor/postgresql/proxy_test.go
@@ -193,6 +193,13 @@ func (stubSession) PreparedStatementRegistry() base.PreparedStatementRegistry {
 func (stubSession) SetPreparedStatementRegistry(registry base.PreparedStatementRegistry) {
 }
 
+func (stubSession) CursorRegistry() base.CursorRegistry {
+	return nil
+}
+
+func (stubSession) SetCursorRegistry(registry base.CursorRegistry) {
+}
+
 func TestEncryptorTurnOnOff(t *testing.T) {
 	emptyStore := &tableSchemaStore{true}
 	nonEmptyStore := &tableSchemaStore{false}

--- a/decryptor/postgresql/proxy_test.go
+++ b/decryptor/postgresql/proxy_test.go
@@ -193,13 +193,6 @@ func (stubSession) PreparedStatementRegistry() base.PreparedStatementRegistry {
 func (stubSession) SetPreparedStatementRegistry(registry base.PreparedStatementRegistry) {
 }
 
-func (stubSession) CursorRegistry() base.CursorRegistry {
-	return nil
-}
-
-func (stubSession) SetCursorRegistry(registry base.CursorRegistry) {
-}
-
 func TestEncryptorTurnOnOff(t *testing.T) {
 	emptyStore := &tableSchemaStore{true}
 	nonEmptyStore := &tableSchemaStore{false}

--- a/decryptor/postgresql/proxy_test.go
+++ b/decryptor/postgresql/proxy_test.go
@@ -186,6 +186,13 @@ func (stubSession) DatabaseConnection() net.Conn {
 	return nil
 }
 
+func (stubSession) PreparedStatementRegistry() base.PreparedStatementRegistry {
+	return nil
+}
+
+func (stubSession) SetPreparedStatementRegistry(registry base.PreparedStatementRegistry) {
+}
+
 func TestEncryptorTurnOnOff(t *testing.T) {
 	emptyStore := &tableSchemaStore{true}
 	nonEmptyStore := &tableSchemaStore{false}


### PR DESCRIPTION
In order to handle prepared statements we need to keep track of them. This is what registries are for.

Implement a couple of simple objects to keep track of name → entity mappings. Both prepared statements and cursors are identified by name. (In PostgreSQL they may be anonymous as well, with empty names.) There are simple accessors to their core properties: the query which is prepared, and the statement which is iterated by a cursor.

These interfaces are pretty much preliminary as I'm not sure what we'll need for the implementation. They may also be unnecessarily extensible. For one, we might not actually need PostgreSQL and MySQL specific registries. For now, keep it like that in case we'd need to add something PostgreSQL-specific. However, if that won't happen then all of this is likely to move to the `base` module as shared utilities.

Expected approvals:
- [X] @Lagovas 
- [x] @iamnotacake