### PR TITLE
PgProtocolState handler

### DIFF
--- a/cmd/acra-server/common/client_session.go
+++ b/cmd/acra-server/common/client_session.go
@@ -35,6 +35,7 @@ type ClientSession struct {
 	ctx            context.Context
 	logger         *log.Entry
 	statements     base.PreparedStatementRegistry
+	protocolState  interface{}
 }
 
 var sessionCounter uint32
@@ -80,6 +81,17 @@ func (clientSession *ClientSession) PreparedStatementRegistry() base.PreparedSta
 // SetPreparedStatementRegistry sets prepared statement registry for this session.
 func (clientSession *ClientSession) SetPreparedStatementRegistry(registry base.PreparedStatementRegistry) {
 	clientSession.statements = registry
+}
+
+// ProtocolState returns private protocol state of this session.
+// The session does not have any state by default, it must be set with SetProtocolState.
+func (clientSession *ClientSession) ProtocolState() interface{} {
+	return clientSession.protocolState
+}
+
+// SetProtocolState sets protocol state for this session.
+func (clientSession *ClientSession) SetProtocolState(state interface{}) {
+	clientSession.protocolState = state
 }
 
 // ConnectToDb connects to the database via tcp using Host and Port from config.

--- a/decryptor/base/proxy.go
+++ b/decryptor/base/proxy.go
@@ -96,6 +96,9 @@ type ClientSession interface {
 
 	PreparedStatementRegistry() PreparedStatementRegistry
 	SetPreparedStatementRegistry(registry PreparedStatementRegistry)
+
+	ProtocolState() interface{}
+	SetProtocolState(state interface{})
 }
 
 // ProxyFactory create new Proxy for specific database

--- a/decryptor/mysql/proxy_test.go
+++ b/decryptor/mysql/proxy_test.go
@@ -46,6 +46,13 @@ func (stubSession) PreparedStatementRegistry() base.PreparedStatementRegistry {
 func (stubSession) SetPreparedStatementRegistry(registry base.PreparedStatementRegistry) {
 }
 
+func (stubSession) ProtocolState() interface{} {
+	return nil
+}
+
+func (stubSession) SetProtocolState(state interface{}) {
+}
+
 func TestEncryptorTurnOnOff(t *testing.T) {
 	emptyStore := &tableSchemaStore{true}
 	nonEmptyStore := &tableSchemaStore{false}

--- a/decryptor/postgresql/packet_handler.go
+++ b/decryptor/postgresql/packet_handler.go
@@ -252,6 +252,11 @@ func (packet *PacketHandler) IsDataRow() bool {
 	return packet.messageType[0] == DataRowMessageType
 }
 
+// IsReadyForQuery returns true if packet has ReadyForQuery type.
+func (packet *PacketHandler) IsReadyForQuery() bool {
+	return packet.messageType[0] == ReadyForQueryMessageType
+}
+
 // IsSimpleQuery return true if packet has SimpleQuery type
 func (packet *PacketHandler) IsSimpleQuery() bool {
 	return packet.messageType[0] == QueryMessageType

--- a/decryptor/postgresql/pg_decryptor.go
+++ b/decryptor/postgresql/pg_decryptor.go
@@ -80,6 +80,9 @@ var (
 	ErrInvalidProtocolState             = errors.New("ClientSession contains invalid ProtocolState")
 )
 
+// ErrBlockedByCensor is returned when a query has been denied by AcraCensor.
+var ErrBlockedByCensor = NewPgError("AcraCensor blocked this query")
+
 // PgSQL constant sizes and types.
 const (
 	// DataRowLengthBufSize each postgresql packet contain 4 byte that store length of message contents in bytes, including self
@@ -321,7 +324,7 @@ func (proxy *PgProxy) handleQueryPacket(packet *PacketHandler, logger *log.Entry
 }
 
 func (proxy *PgProxy) sendClientAcraCensorError(logger *log.Entry) error {
-	errorMessage, err := NewPgError("AcraCensor blocked this query")
+	errorMessage, err := ErrBlockedByCensor
 	if err != nil {
 		logger.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCodingPostgresqlCantGenerateErrorPacket).
 			WithError(err).Errorln("Can't create PostgreSQL error message")

--- a/decryptor/postgresql/pg_decryptor.go
+++ b/decryptor/postgresql/pg_decryptor.go
@@ -269,11 +269,11 @@ func (proxy *PgProxy) ProxyClientConnection(errCh chan<- error) {
 
 func (proxy *PgProxy) handleClientPacket(packet *PacketHandler, logger *log.Entry) (bool, error) {
 	// Let the protocol observer take a look at the packet, keeping note of it.
-	packetType, err := proxy.protocolState.HandleClientPacket(packet)
+	err := proxy.protocolState.HandleClientPacket(packet)
 	if err != nil {
 		return false, err
 	}
-	switch packetType {
+	switch proxy.protocolState.LastPacketType() {
 	case QueryPacket:
 		// If that's some sort of a packet with a query inside it,
 		// process inline data if necessary and remember the query to handle future response.
@@ -582,11 +582,11 @@ func (proxy *PgProxy) ProxyDatabaseConnection(errCh chan<- error) {
 
 func (proxy *PgProxy) handleDatabasePacket(ctx context.Context, packet *PacketHandler, logger *log.Entry) error {
 	// Let the protocol observer take a look at the packet, keeping note of it.
-	packetType, err := proxy.protocolState.HandleDatabasePacket(packet)
+	err := proxy.protocolState.HandleDatabasePacket(packet)
 	if err != nil {
 		return err
 	}
-	switch packetType {
+	switch proxy.protocolState.LastPacketType() {
 	case DataPacket:
 		// If that's some sort of a packet with a query response inside it,
 		// decrypt and process the data in it.

--- a/decryptor/postgresql/pg_decryptor.go
+++ b/decryptor/postgresql/pg_decryptor.go
@@ -80,9 +80,6 @@ var (
 	ErrInvalidProtocolState             = errors.New("ClientSession contains invalid ProtocolState")
 )
 
-// ErrBlockedByCensor is returned when a query has been denied by AcraCensor.
-var ErrBlockedByCensor = NewPgError("AcraCensor blocked this query")
-
 // PgSQL constant sizes and types.
 const (
 	// DataRowLengthBufSize each postgresql packet contain 4 byte that store length of message contents in bytes, including self
@@ -324,7 +321,7 @@ func (proxy *PgProxy) handleQueryPacket(packet *PacketHandler, logger *log.Entry
 }
 
 func (proxy *PgProxy) sendClientAcraCensorError(logger *log.Entry) error {
-	errorMessage, err := ErrBlockedByCensor
+	errorMessage, err := NewPgError("AcraCensor blocked this query")
 	if err != nil {
 		logger.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCodingPostgresqlCantGenerateErrorPacket).
 			WithError(err).Errorln("Can't create PostgreSQL error message")

--- a/decryptor/postgresql/pg_decryptor.go
+++ b/decryptor/postgresql/pg_decryptor.go
@@ -87,10 +87,11 @@ const (
 	// random chosen
 	OutputDefaultSize = 1024
 	// https://www.postgresql.org/docs/9.4/static/protocol-message-formats.html
-	DataRowMessageType byte = 'D'
-	QueryMessageType   byte = 'Q'
-	ParseMessageType   byte = 'P'
-	TLSTimeout              = time.Second * 2
+	DataRowMessageType       byte = 'D'
+	QueryMessageType         byte = 'Q'
+	ParseMessageType         byte = 'P'
+	ReadyForQueryMessageType byte = 'Z'
+	TLSTimeout                    = time.Second * 2
 )
 
 // PgProxy represents PgSQL database connection between client and database with TLS support

--- a/decryptor/postgresql/pg_decryptor.go
+++ b/decryptor/postgresql/pg_decryptor.go
@@ -547,7 +547,7 @@ func (proxy *PgProxy) ProxyDatabaseConnection(errCh chan<- error) {
 			// If that's some sort of a packet with response data inside it, go on...
 
 		default:
-			// Pass all other uninteresting packets through to the database without processing.
+			// Pass all other uninteresting packets through to the client without processing.
 			if err = packetHandler.sendPacket(); err != nil {
 				logger.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorNetworkWrite).WithError(err).Errorln("Can't forward packet")
 				errCh <- err

--- a/decryptor/postgresql/protocol.go
+++ b/decryptor/postgresql/protocol.go
@@ -92,6 +92,13 @@ func (p *PgProtocolState) HandleDatabasePacket(packet *PacketHandler) (PacketTyp
 		return DataPacket, nil
 	}
 
+	// ReadyForQuery starts a new query processing. Forget pending queries.
+	// There is nothing interesting in the packet otherwise.
+	if packet.IsReadyForQuery() {
+		p.pendingQuery = nil
+		return PassthroughPacket, nil
+	}
+
 	// We are not interested in other packets, just pass them through.
 	return PassthroughPacket, nil
 }

--- a/decryptor/postgresql/protocol.go
+++ b/decryptor/postgresql/protocol.go
@@ -32,6 +32,7 @@ type PacketType int
 // Possible PacketType values.
 const (
 	QueryPacket PacketType = iota
+	DataPacket
 	PassthroughPacket
 	TerminationPacket
 )
@@ -80,5 +81,17 @@ func (p *PgProtocolState) HandleClientPacket(packet *PacketHandler) (PacketType,
 	if packet.terminatePacket {
 		return TerminationPacket, nil
 	}
+	return PassthroughPacket, nil
+}
+
+// HandleDatabasePacket observes a packet with database response,
+// extracts useful information from it, and confirms client requests.
+func (p *PgProtocolState) HandleDatabasePacket(packet *PacketHandler) (PacketType, error) {
+	// This is data response to the previously issued query.
+	if packet.IsDataRow() {
+		return DataPacket, nil
+	}
+
+	// We are not interested in other packets, just pass them through.
 	return PassthroughPacket, nil
 }

--- a/decryptor/postgresql/protocol.go
+++ b/decryptor/postgresql/protocol.go
@@ -33,7 +33,7 @@ type PacketType int
 const (
 	QueryPacket PacketType = iota
 	DataPacket
-	PassthroughPacket
+	OtherPacket
 )
 
 // NewPgProtocolState makes an initial PostgreSQL state, awaiting for queries.
@@ -76,7 +76,7 @@ func (p *PgProtocolState) HandleClientPacket(packet *PacketHandler) (PacketType,
 	}
 
 	// We are not interested in other packets, just pass them through.
-	return PassthroughPacket, nil
+	return OtherPacket, nil
 }
 
 // HandleDatabasePacket observes a packet with database response,
@@ -91,9 +91,9 @@ func (p *PgProtocolState) HandleDatabasePacket(packet *PacketHandler) (PacketTyp
 	// There is nothing interesting in the packet otherwise.
 	if packet.IsReadyForQuery() {
 		p.pendingQuery = nil
-		return PassthroughPacket, nil
+		return OtherPacket, nil
 	}
 
 	// We are not interested in other packets, just pass them through.
-	return PassthroughPacket, nil
+	return OtherPacket, nil
 }

--- a/decryptor/postgresql/protocol.go
+++ b/decryptor/postgresql/protocol.go
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2020, Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package postgresql
+
+import (
+	"github.com/cossacklabs/acra/decryptor/base"
+	"github.com/cossacklabs/acra/logging"
+)
+
+// PgProtocolState keeps track of PostgreSQL protocol state.
+type PgProtocolState struct {
+	pendingQuery base.OnQueryObject
+}
+
+// PacketType describes how to handle a message packet.
+type PacketType int
+
+// Possible PacketType values.
+const (
+	QueryPacket PacketType = iota
+	PassthroughPacket
+	TerminationPacket
+)
+
+// NewPgProtocolState makes an initial PostgreSQL state, awaiting for queries.
+func NewPgProtocolState() *PgProtocolState {
+	return &PgProtocolState{}
+}
+
+// PendingQuery returns a query object pending response from the database.
+func (p *PgProtocolState) PendingQuery() base.OnQueryObject {
+	return p.pendingQuery
+}
+
+// HandleClientPacket observes a packet from client to the database,
+// extracts query information from it, and anticipates future database responses.
+func (p *PgProtocolState) HandleClientPacket(packet *PacketHandler) (PacketType, error) {
+	logger := packet.logger
+
+	// Query packets are easy, that's a simple query protocol.
+	if packet.IsSimpleQuery() {
+		query, err := packet.GetSimpleQuery()
+		if err != nil {
+			logger.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCodingPostgresqlCantExtractQueryString).
+				WithError(err).Errorln("Can't fetch query string from Query packet")
+			return QueryPacket, err
+		}
+		p.pendingQuery = base.NewOnQueryObjectFromQuery(query)
+		return QueryPacket, nil
+	}
+
+	// Parse packets initiate extended query protocol.
+	if packet.IsParse() {
+		query, err := packet.GetParseQuery()
+		if err != nil {
+			logger.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCodingPostgresqlCantExtractQueryString).
+				WithError(err).Errorln("Can't fetch query string from Parse packet")
+			return QueryPacket, err
+		}
+		p.pendingQuery = base.NewOnQueryObjectFromQuery(query)
+		return QueryPacket, nil
+	}
+
+	// We are not interested in other packets, just pass them through.
+	// If that's a termination packet, ask for connection termination.
+	if packet.terminatePacket {
+		return TerminationPacket, nil
+	}
+	return PassthroughPacket, nil
+}

--- a/decryptor/postgresql/protocol.go
+++ b/decryptor/postgresql/protocol.go
@@ -34,7 +34,6 @@ const (
 	QueryPacket PacketType = iota
 	DataPacket
 	PassthroughPacket
-	TerminationPacket
 )
 
 // NewPgProtocolState makes an initial PostgreSQL state, awaiting for queries.
@@ -77,10 +76,6 @@ func (p *PgProtocolState) HandleClientPacket(packet *PacketHandler) (PacketType,
 	}
 
 	// We are not interested in other packets, just pass them through.
-	// If that's a termination packet, ask for connection termination.
-	if packet.terminatePacket {
-		return TerminationPacket, nil
-	}
 	return PassthroughPacket, nil
 }
 

--- a/decryptor/postgresql/proxy_test.go
+++ b/decryptor/postgresql/proxy_test.go
@@ -193,6 +193,13 @@ func (stubSession) PreparedStatementRegistry() base.PreparedStatementRegistry {
 func (stubSession) SetPreparedStatementRegistry(registry base.PreparedStatementRegistry) {
 }
 
+func (stubSession) ProtocolState() interface{} {
+	return nil
+}
+
+func (stubSession) SetProtocolState(state interface{}) {
+}
+
 func TestEncryptorTurnOnOff(t *testing.T) {
 	emptyStore := &tableSchemaStore{true}
 	nonEmptyStore := &tableSchemaStore{false}


### PR DESCRIPTION
Introduce a separate object to take care of PostgreSQL protocol packets. With extended protocol we will need to track both requests and responses before we are able to process a query, so we need a place to store this information temporarily.

The protocol state is fundamentally associated with the session so it makes sense to keep one there. However, we need to keep it opaque as MySQL and PostgreSQL protocols are very different. For now, let's use just `interface{}` as a placeholder. Maybe later we will be able to extract some more specific interface out of the implementations.

`PgProtocolState` keeps user query in memory until the database issues a response. The query text is sensitive information, especially when transparent encryption is in use. We should remove it from memory as soon as it possible. The database sends `ReadyForQuery` when it has completed processing of the previous query, this is the point when we know that the query is no longer needed and can be freed.

Expected review:

- [x] @Lagovas
- [ ] @iamnotacake