### PR TITLE
Observe extended query protocol

### DIFF
--- a/decryptor/postgresql/packet_handler.go
+++ b/decryptor/postgresql/packet_handler.go
@@ -288,6 +288,11 @@ func (packet *PacketHandler) IsBindComplete() bool {
 	return packet.messageType[0] == BindCompleteMessageType
 }
 
+// IsExecute return true if packet has Execute type
+func (packet *PacketHandler) IsExecute() bool {
+	return packet.messageType[0] == ExecuteMessageType
+}
+
 // GetParseData returns parsed Parse packet data.
 // Use this only if IsParse() is true.
 func (packet *PacketHandler) GetParseData() (*ParsePacket, error) {
@@ -310,6 +315,18 @@ func (packet *PacketHandler) GetBindData() (*BindPacket, error) {
 		return nil, err
 	}
 	return bind, nil
+}
+
+// GetExecuteData returns parsed Execute packet data.
+// Use this only if IsExecute() is true.
+func (packet *PacketHandler) GetExecuteData() (*ExecutePacket, error) {
+	packet.logger.Debugln("GetExecuteData")
+	execute, err := NewExecutePacket(packet.descriptionBufferCopy())
+	if err != nil {
+		packet.logger.Debugln("Failed to parse Bind packet")
+		return nil, err
+	}
+	return execute, nil
 }
 
 // ReplaceQuery query in packet with new query and update packet length

--- a/decryptor/postgresql/packet_handler.go
+++ b/decryptor/postgresql/packet_handler.go
@@ -272,6 +272,16 @@ func (packet *PacketHandler) IsParseComplete() bool {
 	return packet.messageType[0] == ParseCompleteMessageType
 }
 
+// IsBind return true if packet has Bind type
+func (packet *PacketHandler) IsBind() bool {
+	return packet.messageType[0] == BindMessageType
+}
+
+// IsBindComplete return true if packet has BindComplete type
+func (packet *PacketHandler) IsBindComplete() bool {
+	return packet.messageType[0] == BindCompleteMessageType
+}
+
 // GetParseData returns parsed Parse packet data.
 // Use this only if IsParse() is true.
 func (packet *PacketHandler) GetParseData() (*ParsePacket, error) {
@@ -282,6 +292,18 @@ func (packet *PacketHandler) GetParseData() (*ParsePacket, error) {
 		return nil, err
 	}
 	return parse, nil
+}
+
+// GetBindData returns parsed Bind packet data.
+// Use this only if IsBind() is true.
+func (packet *PacketHandler) GetBindData() (*BindPacket, error) {
+	packet.logger.Debugln("GetBindData")
+	bind, err := NewBindPacket(packet.descriptionBuf.Bytes())
+	if err != nil {
+		packet.logger.Debugln("Failed to parse Bind packet")
+		return nil, err
+	}
+	return bind, nil
 }
 
 // ReplaceQuery query in packet with new query and update packet length

--- a/decryptor/postgresql/packet_handler.go
+++ b/decryptor/postgresql/packet_handler.go
@@ -267,6 +267,11 @@ func (packet *PacketHandler) IsParse() bool {
 	return packet.messageType[0] == ParseMessageType
 }
 
+// IsParseComplete return true if packet has ParseComplete type
+func (packet *PacketHandler) IsParseComplete() bool {
+	return packet.messageType[0] == ParseCompleteMessageType
+}
+
 // GetParseData returns parsed Parse packet data.
 // Use this only if IsParse() is true.
 func (packet *PacketHandler) GetParseData() (*ParsePacket, error) {

--- a/decryptor/postgresql/packet_handler.go
+++ b/decryptor/postgresql/packet_handler.go
@@ -242,6 +242,12 @@ func (packet *PacketHandler) Reset() {
 	packet.messageType[0] = 0
 }
 
+func (packet *PacketHandler) descriptionBufferCopy() []byte {
+	buffer := make([]byte, packet.descriptionBuf.Len())
+	copy(buffer, packet.descriptionBuf.Bytes())
+	return buffer
+}
+
 func (packet *PacketHandler) readMessageType() error {
 	n, err := io.ReadFull(packet.reader, packet.messageType[:])
 	return base.CheckReadWrite(n, 1, err)
@@ -286,7 +292,7 @@ func (packet *PacketHandler) IsBindComplete() bool {
 // Use this only if IsParse() is true.
 func (packet *PacketHandler) GetParseData() (*ParsePacket, error) {
 	packet.logger.Debugln("GetParseData")
-	parse, err := NewParsePacket(packet.descriptionBuf.Bytes())
+	parse, err := NewParsePacket(packet.descriptionBufferCopy())
 	if err != nil {
 		packet.logger.Debugln("Failed to parse Parse packet")
 		return nil, err
@@ -298,7 +304,7 @@ func (packet *PacketHandler) GetParseData() (*ParsePacket, error) {
 // Use this only if IsBind() is true.
 func (packet *PacketHandler) GetBindData() (*BindPacket, error) {
 	packet.logger.Debugln("GetBindData")
-	bind, err := NewBindPacket(packet.descriptionBuf.Bytes())
+	bind, err := NewBindPacket(packet.descriptionBufferCopy())
 	if err != nil {
 		packet.logger.Debugln("Failed to parse Bind packet")
 		return nil, err

--- a/decryptor/postgresql/packet_handler.go
+++ b/decryptor/postgresql/packet_handler.go
@@ -267,15 +267,16 @@ func (packet *PacketHandler) IsParse() bool {
 	return packet.messageType[0] == ParseMessageType
 }
 
-//GetParseQuery return query string from Parse packet or error
-func (packet *PacketHandler) GetParseQuery() (string, error) {
-	packet.logger.Debugln("GetParseQuery")
+// GetParseData returns parsed Parse packet data.
+// Use this only if IsParse() is true.
+func (packet *PacketHandler) GetParseData() (*ParsePacket, error) {
+	packet.logger.Debugln("GetParseData")
 	parse, err := NewParsePacket(packet.descriptionBuf.Bytes())
 	if err != nil {
-		packet.logger.Debugln("GetParseQuery error")
-		return "", err
+		packet.logger.Debugln("Failed to parse Parse packet")
+		return nil, err
 	}
-	return parse.QueryString(), nil
+	return parse, nil
 }
 
 // ReplaceQuery query in packet with new query and update packet length

--- a/decryptor/postgresql/pg_decryptor.go
+++ b/decryptor/postgresql/pg_decryptor.go
@@ -92,6 +92,7 @@ const (
 	QueryMessageType         byte = 'Q'
 	ParseMessageType         byte = 'P'
 	BindMessageType          byte = 'B'
+	ExecuteMessageType       byte = 'E'
 	ParseCompleteMessageType byte = '1'
 	BindCompleteMessageType  byte = '2'
 	ReadyForQueryMessageType byte = 'Z'

--- a/decryptor/postgresql/pg_decryptor.go
+++ b/decryptor/postgresql/pg_decryptor.go
@@ -91,7 +91,9 @@ const (
 	DataRowMessageType       byte = 'D'
 	QueryMessageType         byte = 'Q'
 	ParseMessageType         byte = 'P'
+	BindMessageType          byte = 'B'
 	ParseCompleteMessageType byte = '1'
+	BindCompleteMessageType  byte = '2'
 	ReadyForQueryMessageType byte = 'Z'
 	TLSTimeout                    = time.Second * 2
 )

--- a/decryptor/postgresql/protocol.go
+++ b/decryptor/postgresql/protocol.go
@@ -35,6 +35,7 @@ type PacketType int
 const (
 	SimpleQueryPacket PacketType = iota
 	ParseStatementPacket
+	ParseCompletePacket
 	DataPacket
 	OtherPacket
 )
@@ -102,6 +103,11 @@ func (p *PgProtocolState) HandleDatabasePacket(packet *PacketHandler) error {
 	// This is data response to the previously issued query.
 	if packet.IsDataRow() {
 		p.lastPacketType = DataPacket
+		return nil
+	}
+
+	if packet.IsParseComplete() {
+		p.lastPacketType = ParseCompletePacket
 		return nil
 	}
 

--- a/decryptor/postgresql/protocol.go
+++ b/decryptor/postgresql/protocol.go
@@ -160,6 +160,8 @@ func (p *PgProtocolState) HandleDatabasePacket(packet *PacketHandler) error {
 	// ReadyForQuery starts a new query processing. Forget pending queries.
 	// There is nothing interesting in the packet otherwise.
 	if packet.IsReadyForQuery() {
+		// TODO(ilammy, 2020-10-08): zeroize, not just drop
+		// Query content is sensitive so we should clean it out really good.
 		p.pendingQuery = nil
 		p.pendingParse = nil
 		p.pendingBind = nil

--- a/decryptor/postgresql/protocol.go
+++ b/decryptor/postgresql/protocol.go
@@ -33,7 +33,8 @@ type PacketType int
 
 // Possible PacketType values.
 const (
-	QueryPacket PacketType = iota
+	SimpleQueryPacket PacketType = iota
+	ParseStatementPacket
 	DataPacket
 	OtherPacket
 )
@@ -71,7 +72,7 @@ func (p *PgProtocolState) HandleClientPacket(packet *PacketHandler) error {
 				WithError(err).Errorln("Can't fetch query string from Query packet")
 			return err
 		}
-		p.lastPacketType = QueryPacket
+		p.lastPacketType = SimpleQueryPacket
 		p.pendingQuery = base.NewOnQueryObjectFromQuery(query)
 		return nil
 	}
@@ -84,7 +85,7 @@ func (p *PgProtocolState) HandleClientPacket(packet *PacketHandler) error {
 				WithError(err).Errorln("Can't fetch query string from Parse packet")
 			return err
 		}
-		p.lastPacketType = QueryPacket
+		p.lastPacketType = ParseStatementPacket
 		p.pendingQuery = base.NewOnQueryObjectFromQuery(parsePacket.QueryString())
 		p.pendingParse = parsePacket
 		return nil

--- a/decryptor/postgresql/utils.go
+++ b/decryptor/postgresql/utils.go
@@ -225,11 +225,14 @@ func (p *ExecutePacket) PortalName() string {
 func (p *ExecutePacket) Zeroize() {
 }
 
-// NewExecutePacket parses Executre packet from data.
+// NewExecutePacket parses Execute packet from data.
 func NewExecutePacket(data []byte) (*ExecutePacket, error) {
 	portal, data, err := readString(data)
 	if err != nil {
 		return nil, err
+	}
+	if len(data) < 4 {
+		return nil, ErrPacketTruncated
 	}
 	maxRows := binary.BigEndian.Uint32(data)
 	return &ExecutePacket{portal, maxRows}, nil

--- a/decryptor/postgresql/utils.go
+++ b/decryptor/postgresql/utils.go
@@ -84,8 +84,16 @@ func (packet *ParsePacket) Length() int {
 	return len(packet.name) + len(packet.query) + len(packet.paramsNum) + (4 * len(packet.params))
 }
 
+// Name returns requested prepared statement name.
+// Note that empty string is a valid value indicating unnamed prepared statement.
+func (packet *ParsePacket) Name() string {
+	// Trailing null byte is included into the slice for faster Marshal().
+	return string(packet.name[:len(packet.name)-1])
+}
+
 // QueryString return query as string
 func (packet *ParsePacket) QueryString() string {
+	// Trailing null byte is included into the slice for faster Marshal().
 	return string(packet.query[:len(packet.query)-1])
 }
 

--- a/decryptor/postgresql/utils.go
+++ b/decryptor/postgresql/utils.go
@@ -194,7 +194,7 @@ func NewBindPacket(data []byte) (*BindPacket, error) {
 	if err != nil {
 		return nil, err
 	}
-	resultFormats, data, err := readUint16Array(data)
+	resultFormats, _, err := readUint16Array(data)
 	if err != nil {
 		return nil, err
 	}

--- a/decryptor/postgresql/utils.go
+++ b/decryptor/postgresql/utils.go
@@ -20,6 +20,8 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
+
+	"github.com/cossacklabs/acra/utils"
 )
 
 var terminator = []byte{0}
@@ -105,6 +107,11 @@ func (packet *ParsePacket) ReplaceQuery(newQuery string) {
 	packet.query = append([]byte(newQuery), 0)
 }
 
+// Zeroize sensitive data in the packet.
+func (packet *ParsePacket) Zeroize() {
+	utils.ZeroizeBytes(packet.query)
+}
+
 // NewParsePacket parse data and return as ParsePacket or error
 func NewParsePacket(data []byte) (*ParsePacket, error) {
 	startIndex := bytes.Index(data, terminator)
@@ -162,6 +169,13 @@ func (p *BindPacket) StatementName() string {
 	return p.statement
 }
 
+// Zeroize sensitive data in the packet.
+func (p *BindPacket) Zeroize() {
+	for _, value := range p.paramValues {
+		utils.ZeroizeBytes(value)
+	}
+}
+
 // NewBindPacket parses Bind packet from data.
 func NewBindPacket(data []byte) (*BindPacket, error) {
 	portal, data, err := readString(data)
@@ -205,6 +219,10 @@ type ExecutePacket struct {
 // An empty name means unnamed portal.
 func (p *ExecutePacket) PortalName() string {
 	return p.portal
+}
+
+// Zeroize sensitive data in the packet.
+func (p *ExecutePacket) Zeroize() {
 }
 
 // NewExecutePacket parses Executre packet from data.

--- a/decryptor/postgresql/utils.go
+++ b/decryptor/postgresql/utils.go
@@ -193,6 +193,30 @@ func NewBindPacket(data []byte) (*BindPacket, error) {
 	}, nil
 }
 
+// ExecutePacket represents "Execute" packet of the PostgreSQL protocol,
+// containing the name of the portal to query for data.
+// See https://www.postgresql.org/docs/current/protocol-message-formats.html
+type ExecutePacket struct {
+	portal  string
+	maxRows uint32
+}
+
+// PortalName returns the name of the portal queried by this request.
+// An empty name means unnamed portal.
+func (p *ExecutePacket) PortalName() string {
+	return p.portal
+}
+
+// NewExecutePacket parses Executre packet from data.
+func NewExecutePacket(data []byte) (*ExecutePacket, error) {
+	portal, data, err := readString(data)
+	if err != nil {
+		return nil, err
+	}
+	maxRows := binary.BigEndian.Uint32(data)
+	return &ExecutePacket{portal, maxRows}, nil
+}
+
 func readString(data []byte) (string, []byte, error) {
 	// Read null-terminated string, don't include the terminator into value.
 	end := bytes.Index(data, terminator)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -141,7 +141,9 @@ func FillSlice(value byte, data []byte) {
 
 // ZeroizeBytes wipes a byte slice from memory, filling it with zeros.
 func ZeroizeBytes(data []byte) {
-	FillSlice(0, data)
+	for i := range data {
+		data[i] = 0
+	}
 }
 
 // ZeroizeSymmetricKey wipes a symmetric key from memory, filling it with zero bytes.

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -139,15 +139,20 @@ func FillSlice(value byte, data []byte) {
 	}
 }
 
+// ZeroizeBytes wipes a byte slice from memory, filling it with zeros.
+func ZeroizeBytes(data []byte) {
+	FillSlice(0, data)
+}
+
 // ZeroizeSymmetricKey wipes a symmetric key from memory, filling it with zero bytes.
 func ZeroizeSymmetricKey(key []byte) {
-	FillSlice(0, key)
+	ZeroizeBytes(key)
 }
 
 // ZeroizePrivateKey wipes a private key from memory, filling it with zero bytes.
 func ZeroizePrivateKey(privateKey *keys.PrivateKey) {
 	if privateKey != nil {
-		FillSlice(0, privateKey.Value)
+		ZeroizeBytes(privateKey.Value)
 	}
 }
 


### PR DESCRIPTION
Add (or update) parsers for new extended protocol packets that we're interested in:

  - **Parse** and **ParseComplete** which prepare statements for execution
  - **Bind** and **BindComplete** which carry parameters for prepared statements
  - **Execute** which initiate prepared statement execution

This gives us all the context information we will need for later processing of extended queries. Use it to maintain prepared statement and cursor registries.

For now, we only observe the protocol flow between the client and the database and don't do much extra about it, only logging when we catch this or that packet. The current integration test suite already has some tests which use the extended protocol: `TestPgPlaceholders`, `CensorBlacklistTest`, `CensorWhitelistTest`, `TestPostgresqlBinaryPreparedStatement`. They all use unnamed cursors and sometimes named prepared statements. I've been looking at these tests to ensure that the parsers don't crash Acra. The coverage is not perfect but that's at least something. In the future I'd like to extend the `BasePrepareStatementMixin` test to include more diverse prepared statements.

Prerequisites:
- [X] #424 needs to be merged
- [X] Zeroize packet content after we're done with the query

Expected review:
- [x] @Lagovas
- [x] @iamnotacake