### PR TITLE
IDs for QueryDataEncryptors

### DIFF
--- a/decryptor/base/observers.go
+++ b/decryptor/base/observers.go
@@ -113,6 +113,7 @@ func (manager *ArrayQueryObserverableManager) OnQuery(query OnQueryObject) (OnQu
 	for _, observer := range manager.subscribers {
 		newQuery, changed, err := observer.OnQuery(currentQuery)
 		if err != nil {
+			manager.logger.WithField("observer", observer.ID()).WithError(err).Errorln("OnQuery failed")
 			return query, false, err
 		}
 		if changed {

--- a/decryptor/base/observers.go
+++ b/decryptor/base/observers.go
@@ -63,6 +63,7 @@ func NewOnQueryObjectFromQuery(query string) OnQueryObject {
 
 // QueryObserver will be used to notify about coming new query
 type QueryObserver interface {
+	ID() string
 	// OnQuery return true if output query was changed otherwise false
 	OnQuery(data OnQueryObject) (OnQueryObject, bool, error)
 }
@@ -98,6 +99,11 @@ func (manager *ArrayQueryObserverableManager) AddQueryObserver(obs QueryObserver
 // RegisteredObserversCount return count of registered observers
 func (manager *ArrayQueryObserverableManager) RegisteredObserversCount() int {
 	return len(manager.subscribers)
+}
+
+// ID returns name of this QueryObserver.
+func (manager *ArrayQueryObserverableManager) ID() string {
+	return "ArrayQueryObserverableManager"
 }
 
 // OnQuery would be called for each added observer to manager

--- a/decryptor/base/observers.go
+++ b/decryptor/base/observers.go
@@ -108,16 +108,17 @@ func (manager *ArrayQueryObserverableManager) ID() string {
 
 // OnQuery would be called for each added observer to manager
 func (manager *ArrayQueryObserverableManager) OnQuery(query OnQueryObject) (OnQueryObject, bool, error) {
-	changedOut := false
-	for _, obs := range manager.subscribers {
-		newQuery, changed, err := obs.OnQuery(query)
+	currentQuery := query
+	changedQuery := false
+	for _, observer := range manager.subscribers {
+		newQuery, changed, err := observer.OnQuery(currentQuery)
 		if err != nil {
 			return query, false, err
 		}
 		if changed {
-			changedOut = changed
-			query = newQuery
+			currentQuery = newQuery
+			changedQuery = true
 		}
 	}
-	return query, changedOut, nil
+	return currentQuery, changedQuery, nil
 }

--- a/decryptor/base/observers.go
+++ b/decryptor/base/observers.go
@@ -108,7 +108,6 @@ func (manager *ArrayQueryObserverableManager) ID() string {
 
 // OnQuery would be called for each added observer to manager
 func (manager *ArrayQueryObserverableManager) OnQuery(query OnQueryObject) (OnQueryObject, bool, error) {
-	manager.logger.Debugf("Handlers: %d; OnQuery for %s", len(manager.subscribers), query.Query())
 	changedOut := false
 	for _, obs := range manager.subscribers {
 		newQuery, changed, err := obs.OnQuery(query)

--- a/encryptor/queryDataEncryptor.go
+++ b/encryptor/queryDataEncryptor.go
@@ -54,6 +54,11 @@ func NewPostgresqlQueryEncryptor(schema config.TableSchemaStore, clientID []byte
 	return &QueryDataEncryptor{schemaStore: schema, clientID: clientID, encryptor: dataEncryptor, dataCoder: &PostgresqlDBDataCoder{}}, nil
 }
 
+// ID returns name of this QueryObserver.
+func (encryptor *QueryDataEncryptor) ID() string {
+	return "QueryDataEncryptor"
+}
+
 // encryptInsertQuery encrypt data in insert query in VALUES and ON DUPLICATE KEY UPDATE statements
 func (encryptor *QueryDataEncryptor) encryptInsertQuery(insert *sqlparser.Insert) (bool, error) {
 	tableName := insert.Table.Name


### PR DESCRIPTION
Since prepared statements are going to work closely with the `QueryDataEncryptor`, I've reviewed this interface and its uses. Turned out, it's very similar to `DecryptionSubscriber` which has recently acquired and `ID()` method, allowing to identify which of the subscribers have failed decrypting the query. The encryption code path has the same logic but no way to identify the culprit. Granted, Acra CE has only one `QueryDataEncryptor`, but Acra EE has several and it would be useful there.

Add an `ID()` method to `QueryDataEncryptor` and refactor the `ArrayQueryObserverableManager` – the entity providing multi-observer capabilities – to use this new method for improved error logging.

While we're here, do some other minor changes.

  - Do not log the query again in `ArrayQueryObserverableManager`, logging it just once in session proxies is enough.

  - Make sure to return the original query on failure, just in case. Session proxies ignore it, but if we say that the query has not been modified, we should return the original one.