### PR TITLE
Transparent encryption of prepared statement parameters

### DIFF
--- a/decryptor/base/observers.go
+++ b/decryptor/base/observers.go
@@ -18,6 +18,7 @@ package base
 
 import (
 	"context"
+
 	"github.com/cossacklabs/acra/logging"
 	"github.com/cossacklabs/acra/sqlparser"
 	"github.com/sirupsen/logrus"
@@ -61,11 +62,50 @@ func NewOnQueryObjectFromQuery(query string) OnQueryObject {
 	return &onQueryObject{query: query}
 }
 
-// QueryObserver will be used to notify about coming new query
+// BoundValue is a value provided for prepared statement execution.
+// Its exact type and meaning depends on the corresponding query.
+type BoundValue interface {
+	Data() []byte
+	Encoding() BoundValueEncoding
+}
+
+// BoundValueEncoding specifies how to interpret the bound data.
+type BoundValueEncoding int
+
+// Supported values of BoundValueEncoding.
+const (
+	BindText BoundValueEncoding = iota
+	BindBinary
+)
+
+type boundValue struct {
+	data     []byte
+	encoding BoundValueEncoding
+}
+
+// Data of the bound value.
+func (v *boundValue) Data() []byte {
+	return v.data
+}
+
+// Encoding of the bound value data.
+func (v *boundValue) Encoding() BoundValueEncoding {
+	return v.encoding
+}
+
+// NewBoundValue makes a standard BoundValue from value data.
+func NewBoundValue(data []byte, encoding BoundValueEncoding) BoundValue {
+	return &boundValue{data, encoding}
+}
+
+// QueryObserver observes database queries and is able to modify them.
+// Methods should return "true" as their second bool result if the data has been modified.
 type QueryObserver interface {
 	ID() string
-	// OnQuery return true if output query was changed otherwise false
+	// Simple queries and prepared statements during preparation stage. SQL is modifiable.
 	OnQuery(data OnQueryObject) (OnQueryObject, bool, error)
+	// Prepared statement parameters during execution stage. Parameter values are modifiable.
+	OnBind(statement sqlparser.Statement, values []BoundValue) ([]BoundValue, bool, error)
 }
 
 // QueryObservable used to handle subscribers for new incoming queries
@@ -122,4 +162,21 @@ func (manager *ArrayQueryObserverableManager) OnQuery(query OnQueryObject) (OnQu
 		}
 	}
 	return currentQuery, changedQuery, nil
+}
+
+// OnBind would be called for each added observer to manager.
+func (manager *ArrayQueryObserverableManager) OnBind(statement sqlparser.Statement, values []BoundValue) ([]BoundValue, bool, error) {
+	currentValues := values
+	changedValues := false
+	for _, observer := range manager.subscribers {
+		newValues, changedNow, err := observer.OnBind(statement, currentValues)
+		if err != nil {
+			return values, false, err
+		}
+		if changedNow {
+			currentValues = newValues
+			changedValues = true
+		}
+	}
+	return currentValues, changedValues, nil
 }

--- a/decryptor/base/observers.go
+++ b/decryptor/base/observers.go
@@ -66,21 +66,21 @@ func NewOnQueryObjectFromQuery(query string) OnQueryObject {
 // Its exact type and meaning depends on the corresponding query.
 type BoundValue interface {
 	Data() []byte
-	Encoding() BoundValueEncoding
+	Format() BoundValueFormat
 }
 
-// BoundValueEncoding specifies how to interpret the bound data.
-type BoundValueEncoding int
+// BoundValueFormat specifies how to interpret the bound data.
+type BoundValueFormat int
 
-// Supported values of BoundValueEncoding.
+// Supported values of BoundValueFormat.
 const (
-	BindText BoundValueEncoding = iota
-	BindBinary
+	TextFormat BoundValueFormat = iota
+	BinaryFormat
 )
 
 type boundValue struct {
-	data     []byte
-	encoding BoundValueEncoding
+	data   []byte
+	format BoundValueFormat
 }
 
 // Data of the bound value.
@@ -88,14 +88,14 @@ func (v *boundValue) Data() []byte {
 	return v.data
 }
 
-// Encoding of the bound value data.
-func (v *boundValue) Encoding() BoundValueEncoding {
-	return v.encoding
+// Format of the bound value data.
+func (v *boundValue) Format() BoundValueFormat {
+	return v.format
 }
 
 // NewBoundValue makes a standard BoundValue from value data.
-func NewBoundValue(data []byte, encoding BoundValueEncoding) BoundValue {
-	return &boundValue{data, encoding}
+func NewBoundValue(data []byte, format BoundValueFormat) BoundValue {
+	return &boundValue{data, format}
 }
 
 // QueryObserver observes database queries and is able to modify them.

--- a/decryptor/postgresql/packet_handler.go
+++ b/decryptor/postgresql/packet_handler.go
@@ -353,6 +353,19 @@ func (packet *PacketHandler) ReplaceQuery(newQuery string) {
 	}
 }
 
+// ReplaceBind update Bind packet with new data, update packet length.
+func (packet *PacketHandler) ReplaceBind(bindPacket *BindPacket) error {
+	packet.logger.Debugln("ReplaceBind for prepared statement")
+	buffer := new(bytes.Buffer)
+	n, err := bindPacket.MarshalInto(buffer)
+	if err != nil {
+		return err
+	}
+	packet.descriptionBuf = buffer
+	packet.updatePacketLength(n)
+	return nil
+}
+
 // GetSimpleQuery return query value as string from Query packet
 func (packet *PacketHandler) GetSimpleQuery() (string, error) {
 	return string(packet.descriptionBuf.Bytes()[:packet.dataLength-1]), nil

--- a/decryptor/postgresql/pg_decryptor.go
+++ b/decryptor/postgresql/pg_decryptor.go
@@ -362,8 +362,14 @@ func (proxy *PgProxy) handleBindPacket(packet *PacketHandler, logger *log.Entry)
 		return false, nil
 	}
 	// Finally, if the parameter values have been changed, update the packet.
+	// If that fails, send the packet unchanged, as usual.
 	if changed {
 		bind.SetParameters(newParameters)
+		err = packet.ReplaceBind(bind)
+		if err != nil {
+			log.WithError(err).Error("Failed to update Bind packet")
+		}
+		return false, nil
 	}
 	return false, nil
 }

--- a/decryptor/postgresql/utils.go
+++ b/decryptor/postgresql/utils.go
@@ -229,11 +229,6 @@ func (p *BindPacket) parameterEncodingByIndex(i int) (base.BoundValueEncoding, e
 
 // SetParameters updates statement parameters from Bind packet.
 func (p *BindPacket) SetParameters(values []base.BoundValue) {
-	p.updateParameterFormats(values)
-	p.updateParameterValues(values)
-}
-
-func (p *BindPacket) updateParameterFormats(values []base.BoundValue) {
 	// See "Bind" description in https://www.postgresql.org/docs/current/protocol-message-formats.html
 	// If there are no parameters then don't bother.
 	if len(values) == 0 {
@@ -273,10 +268,10 @@ func (p *BindPacket) updateParameterFormats(values []base.BoundValue) {
 			}
 		}
 	}
-}
-
-func (p *BindPacket) updateParameterValues(values []base.BoundValue) {
-	p.paramValues = make([][]byte, len(values))
+	// Finally, replace parameter values. Reuse the top-level array if we can.
+	if len(values) != len(p.paramValues) {
+		p.paramValues = make([][]byte, len(values))
+	}
 	for i := range p.paramValues {
 		p.paramValues[i] = values[i].Data()
 	}

--- a/decryptor/postgresql/utils.go
+++ b/decryptor/postgresql/utils.go
@@ -166,8 +166,8 @@ type BindPacket struct {
 // ErrUnknownFormat is returned when Bind packet contains a value format that we don't recognize.
 var ErrUnknownFormat = errors.New("unknown Bind packet format")
 
-// ErrNotEnougFormats is returned when Bind packet is malformed and does not contain enough formats for values.
-var ErrNotEnougFormats = errors.New("format index out of range")
+// ErrNotEnoughFormats is returned when Bind packet is malformed and does not contain enough formats for values.
+var ErrNotEnoughFormats = errors.New("format index out of range")
 
 const (
 	bindFormatText   = 0
@@ -220,7 +220,7 @@ func (p *BindPacket) parameterEncodingByIndex(i int) (base.BoundValueEncoding, e
 		format = p.paramFormats[i]
 	} else {
 		log.WithField("index", i).WithField("max", len(p.paramFormats)).Debug("Bind format array too short")
-		return base.BindText, ErrNotEnougFormats
+		return base.BindText, ErrNotEnoughFormats
 	}
 	// Options currently include text and binary formats.
 	switch format {

--- a/decryptor/postgresql/utils.go
+++ b/decryptor/postgresql/utils.go
@@ -193,7 +193,7 @@ func (p *BindPacket) Zeroize() {
 func (p *BindPacket) GetParameters() ([]base.BoundValue, error) {
 	values := make([]base.BoundValue, len(p.paramValues))
 	for i := range values {
-		encoding, err := p.parameterEncoding(i)
+		encoding, err := p.parameterEncodingByIndex(i)
 		if err != nil {
 			return nil, err
 		}
@@ -202,7 +202,7 @@ func (p *BindPacket) GetParameters() ([]base.BoundValue, error) {
 	return values, nil
 }
 
-func (p *BindPacket) parameterEncoding(i int) (base.BoundValueEncoding, error) {
+func (p *BindPacket) parameterEncodingByIndex(i int) (base.BoundValueEncoding, error) {
 	// See "Bind" description in https://www.postgresql.org/docs/current/protocol-message-formats.html
 	// If there are no formats then all values use the default: text.
 	if len(p.paramFormats) == 0 {

--- a/decryptor/postgresql/utils.go
+++ b/decryptor/postgresql/utils.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
+	"math"
 
 	"github.com/cossacklabs/acra/decryptor/base"
 	"github.com/cossacklabs/acra/utils"
@@ -388,9 +389,6 @@ func NewExecutePacket(data []byte) (*ExecutePacket, error) {
 	return &ExecutePacket{portal, maxRows}, nil
 }
 
-const maxUint16 = 1<<16 - 1
-const maxUint32 = 1<<32 - 1
-
 func readString(data []byte) (string, []byte, error) {
 	// Read null-terminated string, don't include the terminator into value.
 	end := bytes.Index(data, terminator)
@@ -433,7 +431,7 @@ func writeUint16Array(buf *bytes.Buffer, values []uint16) (int, error) {
 	buf.Grow(totalLength)
 
 	tmp := make([]byte, 2)
-	if len(values) > maxUint16 {
+	if len(values) > math.MaxUint16 {
 		return 0, ErrArrayTooBig
 	}
 	binary.BigEndian.PutUint16(tmp, uint16(len(values)))
@@ -489,14 +487,14 @@ func writeParameterArray(buf *bytes.Buffer, parameters [][]byte) (int, error) {
 	buf.Grow(totalLength)
 
 	tmp := make([]byte, 4)
-	if len(parameters) > maxUint16 {
+	if len(parameters) > math.MaxUint16 {
 		return 0, ErrArrayTooBig
 	}
 	binary.BigEndian.PutUint16(tmp[0:2], uint16(len(parameters)))
 	buf.Write(tmp[0:2])
 
 	for _, parameter := range parameters {
-		if len(parameter) > maxUint32 {
+		if len(parameter) > math.MaxUint32 {
 			return 0, ErrArrayTooBig
 		}
 		binary.BigEndian.PutUint32(tmp[0:4], uint32(len(parameter)))

--- a/encryptor/queryDataEncryptor.go
+++ b/encryptor/queryDataEncryptor.go
@@ -316,8 +316,8 @@ func (encryptor *QueryDataEncryptor) OnQuery(query base.OnQueryObject) (base.OnQ
 	return query, false, nil
 }
 
-// ErrInvalidPlacholder is returned when Acra cannot parse SQL placeholder expression.
-var ErrInvalidPlacholder = errors.New("invalid placeholder value")
+// ErrInvalidPlaceholder is returned when Acra cannot parse SQL placeholder expression.
+var ErrInvalidPlaceholder = errors.New("invalid placeholder value")
 
 // ErrInconsistentPlacholder is returned when a placeholder refers to multiple different columns.
 var ErrInconsistentPlacholder = errors.New("inconsistent placeholder usage")
@@ -468,7 +468,7 @@ func (encryptor *QueryDataEncryptor) updatePlaceholderMap(values []base.BoundVal
 		if index >= len(values) {
 			logrus.WithFields(logrus.Fields{"placeholder": text, "index": index, "values": len(values)}).
 				Warning("Invalid placeholder index")
-			return ErrInvalidPlacholder
+			return ErrInvalidPlaceholder
 		}
 		// Placeholders must map to columns uniquely.
 		// If there is already a column for given placholder and it's not the same,

--- a/encryptor/queryDataEncryptor.go
+++ b/encryptor/queryDataEncryptor.go
@@ -396,6 +396,9 @@ func (encryptor *QueryDataEncryptor) encryptInsertValues(insert *sqlparser.Inser
 	// These clauses are handled for textual queries. It would be nice to encrypt
 	// any prepared statement parameters that are used there as well.
 	// See "encryptInsertQuery" for reference.
+	if len(insert.OnDup) > 0 {
+		logrus.Warning("ON DUPLICATE KEY UPDATE is not supported in prepared statements")
+	}
 
 	// Now that we know the placeholder mapping,
 	// encrypt the values inserted into encrypted columns.

--- a/encryptor/queryDataEncryptor.go
+++ b/encryptor/queryDataEncryptor.go
@@ -319,8 +319,8 @@ func (encryptor *QueryDataEncryptor) OnQuery(query base.OnQueryObject) (base.OnQ
 // ErrInvalidPlaceholder is returned when Acra cannot parse SQL placeholder expression.
 var ErrInvalidPlaceholder = errors.New("invalid placeholder value")
 
-// ErrInconsistentPlacholder is returned when a placeholder refers to multiple different columns.
-var ErrInconsistentPlacholder = errors.New("inconsistent placeholder usage")
+// ErrInconsistentPlaceholder is returned when a placeholder refers to multiple different columns.
+var ErrInconsistentPlaceholder = errors.New("inconsistent placeholder usage")
 
 // OnBind process bound values for prepared statement based on TableSchemaStore.
 func (encryptor *QueryDataEncryptor) OnBind(statement sqlparser.Statement, values []base.BoundValue) ([]base.BoundValue, bool, error) {
@@ -477,7 +477,7 @@ func (encryptor *QueryDataEncryptor) updatePlaceholderMap(values []base.BoundVal
 		if exists && name != columnName {
 			logrus.WithFields(logrus.Fields{"placeholder": text, "old_column": name, "new_column": columnName}).
 				Warning("Inconsistent placeholder mapping")
-			return ErrInconsistentPlacholder
+			return ErrInconsistentPlaceholder
 		}
 		placeholders[index] = columnName
 	default:

--- a/encryptor/queryDataEncryptor.go
+++ b/encryptor/queryDataEncryptor.go
@@ -514,7 +514,9 @@ func (encryptor *QueryDataEncryptor) encryptValuesWithPlaceholders(values []base
 			encryptedData, err := encryptor.encryptWithColumnSettings(settings, data)
 			// If the data turns out to be already encrypted then it's fatal. Otherwise, bail out.
 			if err != nil && err != ErrUpdateLeaveDataUnchanged {
-				return oldValues, false, nil
+				logrus.WithError(err).WithFields(logrus.Fields{"index": valueIndex, "column": columnName}).
+					Debug("Failed to encrypt column")
+				return oldValues, false, err
 			}
 			values[valueIndex] = base.NewBoundValue(encryptedData, base.BindBinary)
 

--- a/encryptor/queryDataEncryptor.go
+++ b/encryptor/queryDataEncryptor.go
@@ -507,10 +507,10 @@ func (encryptor *QueryDataEncryptor) encryptValuesWithPlaceholders(values []base
 		changed = true
 
 		settings := schema.GetColumnEncryptionSettings(columnName)
-		encoding := values[valueIndex].Encoding()
+		format := values[valueIndex].Format()
 		data := values[valueIndex].Data()
-		switch encoding {
-		case base.BindBinary:
+		switch format {
+		case base.BinaryFormat:
 			encryptedData, err := encryptor.encryptWithColumnSettings(settings, data)
 			// If the data turns out to be already encrypted then it's fatal. Otherwise, bail out.
 			if err != nil && err != ErrUpdateLeaveDataUnchanged {
@@ -518,15 +518,15 @@ func (encryptor *QueryDataEncryptor) encryptValuesWithPlaceholders(values []base
 					Debug("Failed to encrypt column")
 				return oldValues, false, err
 			}
-			values[valueIndex] = base.NewBoundValue(encryptedData, base.BindBinary)
+			values[valueIndex] = base.NewBoundValue(encryptedData, base.BinaryFormat)
 
-		// TODO(ilammy, 2020-10-14): implement support for base.BindText format
+		// TODO(ilammy, 2020-10-14): implement support for base.TextFormat
 		// We should parse and decode the data, encrypt it, and then either force binary format,
 		// or reencode the data back into text.
 
 		default:
-			logrus.WithFields(logrus.Fields{"encoding": encoding, "index": valueIndex, "column": columnName}).
-				Warning("Parameter encoding not supported, skipping")
+			logrus.WithFields(logrus.Fields{"format": format, "index": valueIndex, "column": columnName}).
+				Warning("Parameter format not supported, skipping")
 		}
 	}
 

--- a/encryptor/queryDataEncryptor.go
+++ b/encryptor/queryDataEncryptor.go
@@ -313,6 +313,33 @@ func (encryptor *QueryDataEncryptor) OnQuery(query base.OnQueryObject) (base.OnQ
 	return query, false, nil
 }
 
+// OnBind process bound values for prepared statement based on TableSchemaStore.
+func (encryptor *QueryDataEncryptor) OnBind(statement sqlparser.Statement, values []base.BoundValue) ([]base.BoundValue, bool, error) {
+	newValues := values
+	changed := false
+	var err error
+	switch statement := statement.(type) {
+	case *sqlparser.Insert:
+		newValues, changed, err = encryptor.encryptInsertValues(statement, values)
+	case *sqlparser.Update:
+		newValues, changed, err = encryptor.encryptUpdateValues(statement, values)
+	}
+	if err != nil {
+		return values, false, err
+	}
+	return newValues, changed, nil
+}
+
+func (encryptor *QueryDataEncryptor) encryptInsertValues(insert *sqlparser.Insert, values []base.BoundValue) ([]base.BoundValue, bool, error) {
+	logrus.Debugln("QueryDataEncryptor.encryptInsertValues")
+	return values, false, nil
+}
+
+func (encryptor *QueryDataEncryptor) encryptUpdateValues(update *sqlparser.Update, values []base.BoundValue) ([]base.BoundValue, bool, error) {
+	logrus.Debugln("QueryDataEncryptor.encryptUpdateValues")
+	return values, false, nil
+}
+
 // encryptWithColumnSettings encrypt data and use ZoneId or ClientID from ColumnEncryptionSetting if not empty otherwise static ClientID that passed to parser
 func (encryptor *QueryDataEncryptor) encryptWithColumnSettings(columnSetting config.ColumnEncryptionSetting, data []byte) ([]byte, error) {
 	logger := logrus.WithFields(logrus.Fields{"column": columnSetting.ColumnName()})

--- a/encryptor/queryDataEncryptor.go
+++ b/encryptor/queryDataEncryptor.go
@@ -472,16 +472,24 @@ func (encryptor *QueryDataEncryptor) encryptValuesWithPlaceholders(values []base
 		changed = true
 
 		settings := schema.GetColumnEncryptionSettings(columnName)
-		switch values[valueIndex].Encoding() {
+		encoding := values[valueIndex].Encoding()
+		data := values[valueIndex].Data()
+		switch encoding {
 		case base.BindBinary:
-			encryptedData, err := encryptor.encryptWithColumnSettings(settings, values[valueIndex].Data())
+			encryptedData, err := encryptor.encryptWithColumnSettings(settings, data)
 			// If the data turns out to be already encrypted then it's fatal. Otherwise, bail out.
 			if err != nil && err != ErrUpdateLeaveDataUnchanged {
 				return oldValues, false, nil
 			}
 			values[valueIndex] = base.NewBoundValue(encryptedData, base.BindBinary)
+
+		// TODO(ilammy, 2020-10-14): implement support for base.BindText format
+		// We should parse and decode the data, encrypt it, and then either force binary format,
+		// or reencode the data back into text.
+
 		default:
-			// Not supported at the moment.
+			logrus.WithFields(logrus.Fields{"encoding": encoding, "index": valueIndex, "column": columnName}).
+				Warning("Parameter encoding not supported, skipping")
 		}
 	}
 

--- a/encryptor/queryDataEncryptor.go
+++ b/encryptor/queryDataEncryptor.go
@@ -374,14 +374,13 @@ func (encryptor *QueryDataEncryptor) encryptInsertValues(insert *sqlparser.Inser
 	//     INSERT INTO table(column...) VALUES ($1, $2, 'static value'...);
 	//
 	// That is, where placeholders uniquely identify the column and used directly
-	// as inserted values of a single row. We don't support functions, casts,
-	// inserting multiple values and query results, etc.
+	// as inserted values. We don't support functions, casts, inserting query results, etc.
 	//
 	// Walk through the query to find out which placeholders stand for which columns.
 	switch rows := insert.Rows.(type) {
 	case sqlparser.Values:
-		if len(rows) == 1 {
-			for i, value := range rows[0] {
+		for _, row := range rows {
+			for i, value := range row {
 				switch value := value.(type) {
 				case *sqlparser.SQLVal:
 					err := encryptor.updatePlaceholderMap(values, placeholders, value, columns[i])

--- a/tests/test.py
+++ b/tests/test.py
@@ -1340,7 +1340,7 @@ class HexFormatTest(BaseTestCase):
         self.assertEqual(row['empty'], b'')
 
 
-class BaseBinaryPostgreSQLMixin(BaseTestCase):
+class BaseBinaryPostgreSQLTestCase(BaseTestCase):
     """Setup test fixture for testing PostgreSQL extended protocol."""
 
     def checkSkip(self):
@@ -3575,7 +3575,7 @@ class TestPostgresqlTextPreparedStatementWholeCell(TestPostgresqlTextPreparedSta
     WHOLECELL_MODE = True
 
 
-class TestPostgresqlBinaryPreparedStatement(BaseBinaryPostgreSQLMixin, BasePrepareStatementMixin, BaseTestCase):
+class TestPostgresqlBinaryPreparedStatement(BaseBinaryPostgreSQLTestCase, BasePrepareStatementMixin):
 
     def executePreparedStatement(self, query):
         return self.executor1.execute_prepared_statement(query)
@@ -4750,7 +4750,7 @@ class TestTransparentEncryptionWithZone(TestTransparentEncryption):
         self.checkZoneIdEncryption(**context)
 
 
-class TestPostgresqlBinaryPreparedTransparentEncryption(BaseBinaryPostgreSQLMixin, TestTransparentEncryption):
+class TestPostgresqlBinaryPreparedTransparentEncryption(BaseBinaryPostgreSQLTestCase, TestTransparentEncryption):
     """Testing transparent encryption of prepared statements in PostgreSQL."""
 
     def filterContext(self, context):

--- a/tests/test.py
+++ b/tests/test.py
@@ -1364,7 +1364,7 @@ class BaseBinaryPostgreSQLMixin(BaseTestCase):
         self.executor1 = executor_with_port(self.CONNECTOR_PORT_1)
         self.executor2 = executor_with_port(self.CONNECTOR_PORT_2)
 
-    def compileQuery(self, query, parameters={}):
+    def compileQuery(self, query, parameters={}, literal_binds=False):
         """
         Compile SQLAlchemy query and parameter dictionary
         into SQL text and parameter list for the executor.
@@ -1372,7 +1372,8 @@ class BaseBinaryPostgreSQLMixin(BaseTestCase):
         # Ask SQLAlchemy to compile the query in database-agnostic SQL.
         # After that manually replace placeholders in text. Unfortunately,
         # passing "dialect=postgresql_dialect" does not seem to work :(
-        query = str(query.compile())
+        compile_kwargs = {"literal_binds": literal_binds}
+        query = str(query.compile(compile_kwargs=compile_kwargs))
         values = []
         for placeholder, value in parameters.items():
             # SQLAlchemy default dialect has placeholders of form ":name".


### PR DESCRIPTION
This PR adds transparent encryption of prepared statement parameters for PostgreSQL binary protocol. That is, when a **libpq** driver uses prepared statements, AcraServer will be encrypting not only the values given directly in the prepared SQL query text, but also the parameters passed during prepared statement execution.

Many drivers use the prepared statement protocol—technically called *extended query protocol*—for all queries, not just prepared ones. The extended protocol provides some *extended* flexibility. In this case the **Bind** messages are empty and don't carry any parameters. However, if the parameters *are* used, typically to implement actual prepared statements, AcraServer did not process them. Now it does.

Note that this **does not** add support for *textual* prepared queries (i.e., `PREPARE` and `EXECUTE` in SQL). This will come later as prepared statements are more often used by database drivers implicitly rather than explicitly spelled in SQL. There's also "text" format of parameter values in PostgreSQL protocol, but I was not able to trigger it in tests. This will be implemented later too.

<details>

### Accessing Bind message data

Add `OnBind()` method to the `QueryObserver` interface used for transparent encryption processing. This will allow to implement transparent encryption for prepared statement parameters. The parameters refer to the query but the query cannot be changed, only the parameters may be.

Parameter values are encapsulated in the `BoundValue` interface, similar to `OnQueryObject` interface for the `OnQuery()` method of `QueryObserver`.

`BindPacket` gets `GetParameters()` and `SetParameters()` accessors operating on the parameter values. The values are stored in the packet in a particular manner which must be respected. See [PostgreSQL docs](https://www.postgresql.org/docs/current/protocol-message-formats.html) for more details on the layout.

### Handling Bind packets 

Now we're ready to handle the Bind packets. This is performed similar to Parse packets, but now we need to retrieve an extra context: the prepared statement for which the bind is performed. After we have it, we can inspect the prepared statement values.

Note that in case of client error *we* have to deal with an invalid Bind packets, such as referring to a nonexistent prepared statement. In such cases we simply let the packets pass to the database unchanged. Then the database is likely to return an error response and this won't go anywhere.

Also note that the parameter count after processing might be different from the original input provided by the client. This is why OnBind() has the interface is has: instead of in-place modifications of values, it returns a new list of possibly modified values. Right now we won't be using this capability, but in the future this should allow us to handle queries like this:

    INSERT INTO table(col1, col2) VALUES ($1, $1);

by encrypting `col1` and `col2` values separately, into two different values. For that we may need to rewrite the query into

    INSERT INTO table(col1, col2) VALUES ($1, $2);

and when the client sends a Bind with one parameter, rewrite that too into a Bind with two parameters.

### Test transparent encryption of bound values

Add a new test to verify transparent encryption of bound values in prepared statements. Inherit from existing transparent encryption test to keep the coverage. However, now make sure that prepared statements are used to insert and update values in the database instead of using SQLAlchemy for that.

Unfortunately, I could not find a way to get SQLAlchemy to compile queries into proper prepared statement syntax, therefore the tests 'compile' the necessary SQL manually.

### Transparent encryption of INSERT and UPDATE parameters

Implement transparent encryption of INSERT parameters. For example, if the user prepares the following query:

    INSERT INTO table(col1, col2, col3) VALUES ($1, $2, 'user');

then we should encrypt the values of `$1` and `$2` parameters. However, we should not and cannot encrypt the 'user' string when processing bound parameters. That value should have been encrypted when the statement had been prepared.

In order to perform transparent encryption we need to map the parameter placeholders (`$1`, `$2`...) onto the table columns. That way we can consult the database schema from AcraServer configuration file and see whether a column needs to be encrypted and in what way.

We gather this information by analyzing the query. Note that not all queries are supported for transparent encryption. Only those that are simple enough for Acra to analyze will be encrypted. Other queries will be passed to the database unchanged. Or rather, the parameters of such queries will not be encrypted.

Just like with INSERT, AcraServer supports only a simple enough subset of queries which are direct updates of the table:

    UPDATE table SET col1 = $1, col2 = $2, col3 = 'fixed value';

We don't support more complex ones. This might come later, or might not be possible at all (e.g., queries updating table from another table).

</details>

Remaining tasks:

- [x] I'd like to reduce code duplication in INSERT and UPDATE handling a bit. It's too much copypasta there.

Expected review:

- [x] @Lagovas
- [x] @iamnotacake