### PR TITLE
Basic support of text format for parameters

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -4784,7 +4784,8 @@ class TestTransparentEncryptionWithZone(TestTransparentEncryption):
 
 
 class TestPostgresqlBinaryPreparedTransparentEncryption(BaseBinaryPostgreSQLTestCase, TestTransparentEncryption):
-    """Testing transparent encryption of prepared statements in PostgreSQL."""
+    """Testing transparent encryption of prepared statements in PostgreSQL (binary format)."""
+    FORMAT = AsyncpgExecutor.BinaryFormat
 
     def filterContext(self, context):
         # Context contains some extra fields which do not correspond
@@ -4812,6 +4813,11 @@ class TestPostgresqlBinaryPreparedTransparentEncryption(BaseBinaryPostgreSQLTest
             context,
         )
         self.executor2.execute_prepared_statement(query, parameters)
+
+
+class TestPostgresqlTextPreparedTransparentEncryption(TestPostgresqlBinaryPreparedTransparentEncryption):
+    """Testing transparent encryption of prepared statements in PostgreSQL (text format)."""
+    FORMAT = AsyncpgExecutor.TextFormat
 
 
 class TestSetupCustomApiPort(BaseTestCase):

--- a/tests/test.py
+++ b/tests/test.py
@@ -713,6 +713,10 @@ class MysqlExecutor(QueryExecutor):
 
 
 class AsyncpgExecutor(QueryExecutor):
+
+    TextFormat = 'text'
+    BinaryFormat = 'binary'
+
     def _connect(self, loop):
         return loop.run_until_complete(
             asyncpg.connect(
@@ -746,7 +750,7 @@ class AsyncpgExecutor(QueryExecutor):
             args = []
         loop = asyncio.get_event_loop()
         conn = self._connect(loop)
-        if self.connection_args.format == 'text':
+        if self.connection_args.format == self.TextFormat:
             self._set_text_format(conn)
         try:
             stmt = loop.run_until_complete(
@@ -762,7 +766,7 @@ class AsyncpgExecutor(QueryExecutor):
             args = []
         loop = asyncio.get_event_loop()
         conn = self._connect(loop)
-        if self.connection_args.format == 'text':
+        if self.connection_args.format == self.TextFormat:
             self._set_text_format(conn)
         try:
             result = loop.run_until_complete(
@@ -1374,7 +1378,7 @@ class BaseBinaryPostgreSQLTestCase(BaseTestCase):
         if not TEST_POSTGRESQL:
             self.skipTest("test only PostgreSQL")
 
-    FORMAT = 'binary'
+    FORMAT = AsyncpgExecutor.BinaryFormat
 
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
It turns out that clients don't really use text formats for data types which are interesting to Acra CE's transparent encryption. It works only with byte arrays which are typically using binary format.

Text format may be occasionally used for types interesting to Acra EE: currently integers and floats. However, Acra EE's encryptors *expect* such data in text format in the first place.

Therefore, for text format of parameters we need to pass them as is. It's the binary format which requires more attention. If the parameter is integer – it still must be encoded as text for the encryptor, even if the parameter is binary.  We'll need to know what type the parameter has and then possibly decode and reencode it after encryption. Right now that's not possible. We continue passing binary data as is.

Passing through text parameters lets Acra EE's encryptors work correctly when text formats are used for interesting data types. Let's add this part at first and then get back to binary parameter recoding.

#### Text format support for "asyncpg" executor

Teach `AsyncpgExecutor` to use text format for some types of prepared statement parameters (integers and floats). This can be controlled with a new optional field `format` in the `ConnectionArgs`. Set it to `"text"` to request a text format. The default is to use binary format.

`BaseBinaryPostgreSQLTestCase` supports a class variable `FORMAT` which is the format passed to `AsyncpgExecutors` it creates. By default it uses binary format, but you can set it to `"text"` per test case.

Acra CE currently does not use this functionality, but Acra EE uses the base class from Acra CE and needs this.

**asyncpg** does not seem to support text format natively for anything other than strings. The current implementation is arguably a hack, but well, it works for our needs.

### Final notes

Required reviews:

- [ ] @Lagovas
- [ ] @iamnotacake (not blocker)