### PR TITLE
Merge identifier extractor and convertor

### DIFF
--- a/cmd/acra-server/acra-server.go
+++ b/cmd/acra-server/acra-server.go
@@ -366,7 +366,12 @@ func main() {
 			log.WithField("type", *tlsIdentifierExtractorType).WithError(err).Errorln("Can't initialize identifier extractor")
 			os.Exit(1)
 		}
-		tlsWrapper, err = network.NewTLSAuthenticationConnectionWrapper(dbTLSConfig, clientTLSConfig, identifierExtractor, idConverter)
+		clientIDExtractor, err := network.NewTLSClientIDExtractor(identifierExtractor, idConverter)
+		if err != nil {
+			log.WithError(err).Errorln("Can't initialize clientID extractor")
+			os.Exit(1)
+		}
+		tlsWrapper, err = network.NewTLSAuthenticationConnectionWrapper(dbTLSConfig, clientTLSConfig, clientIDExtractor)
 		if err != nil {
 			log.WithError(err).Errorln("Can't initialize TLS connection wrapper")
 			os.Exit(1)

--- a/network/tls_wrapper.go
+++ b/network/tls_wrapper.go
@@ -43,9 +43,9 @@ var allowedCipherSuits = []uint16{
 
 // TLSConnectionWrapper for wrapping connection into TLS encryption
 type TLSConnectionWrapper struct {
-	clientConfig *tls.Config
-	serverConfig *tls.Config
-	clientID     []byte
+	clientConfig      *tls.Config
+	serverConfig      *tls.Config
+	clientID          []byte
 	clientIDExtractor TLSClientIDExtractor
 }
 

--- a/network/tls_wrapper.go
+++ b/network/tls_wrapper.go
@@ -46,8 +46,7 @@ type TLSConnectionWrapper struct {
 	clientConfig *tls.Config
 	serverConfig *tls.Config
 	clientID     []byte
-	idExtractor  CertificateIdentifierExtractor
-	idConverter  IdentifierConverter
+	clientIDExtractor TLSClientIDExtractor
 }
 
 // ErrEmptyTLSConfig if not TLS clientConfig found
@@ -178,8 +177,8 @@ func NewTLSConnectionWrapper(clientID []byte, config *tls.Config) (*TLSConnectio
 
 // NewTLSAuthenticationConnectionWrapper returns new TLSConnectionWrapper which use separate TLS configs for each side. Client's identifier will be fetched
 // with idExtractor and converter with idConverter
-func NewTLSAuthenticationConnectionWrapper(clientConfig, serverConfig *tls.Config, idExtractor CertificateIdentifierExtractor, idConverter IdentifierConverter) (*TLSConnectionWrapper, error) {
-	return &TLSConnectionWrapper{clientConfig: clientConfig, serverConfig: serverConfig, idExtractor: idExtractor, idConverter: idConverter}, nil
+func NewTLSAuthenticationConnectionWrapper(clientConfig, serverConfig *tls.Config, extractor TLSClientIDExtractor) (*TLSConnectionWrapper, error) {
+	return &TLSConnectionWrapper{clientConfig: clientConfig, serverConfig: serverConfig, clientIDExtractor: extractor}, nil
 }
 
 // WrapClient wraps client connection into TLS
@@ -196,12 +195,7 @@ func (wrapper *TLSConnectionWrapper) WrapClient(ctx context.Context, conn net.Co
 }
 
 func (wrapper *TLSConnectionWrapper) getClientIDFromCertificate(certificate *x509.Certificate) ([]byte, error) {
-	identifier, err := wrapper.idExtractor.GetCertificateIdentifier(certificate)
-	if err != nil {
-		return nil, err
-	}
-	log.WithField("identifier", string(identifier)).Debugln("ID from certificate")
-	clientID, err := wrapper.idConverter.Convert(identifier)
+	clientID, err := wrapper.clientIDExtractor.ExtractClientID(certificate)
 	if err != nil {
 		return nil, err
 	}

--- a/network/tls_wrapper_test.go
+++ b/network/tls_wrapper_test.go
@@ -92,11 +92,15 @@ func TestTLSWrapperWithCertificateAuthentication(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	serverWrapper, err := NewTLSAuthenticationConnectionWrapper(nil, serverConfig, DistinguishedNameExtractor{}, converter)
+	extractor, err := NewTLSClientIDExtractor(DistinguishedNameExtractor{}, converter)
 	if err != nil {
 		t.Fatal(err)
 	}
-	clientWrapper, err := NewTLSAuthenticationConnectionWrapper(clientConfig, nil, nil, nil)
+	serverWrapper, err := NewTLSAuthenticationConnectionWrapper(nil, serverConfig, extractor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	clientWrapper, err := NewTLSAuthenticationConnectionWrapper(clientConfig, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -126,11 +130,15 @@ func BenchmarkTLSWrapper(t *testing.B) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	serverWrapper, err := NewTLSAuthenticationConnectionWrapper(nil, serverConfig, DistinguishedNameExtractor{}, converter)
+	extractor, err := NewTLSClientIDExtractor(DistinguishedNameExtractor{}, converter)
 	if err != nil {
 		t.Fatal(err)
 	}
-	clientWrapper, err := NewTLSAuthenticationConnectionWrapper(clientConfig, nil, nil, nil)
+	serverWrapper, err := NewTLSAuthenticationConnectionWrapper(nil, serverConfig, extractor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	clientWrapper, err := NewTLSAuthenticationConnectionWrapper(clientConfig, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -149,11 +157,15 @@ func TestTLSConfigWeakCipherSuitDeny(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	serverWrapper, err := NewTLSAuthenticationConnectionWrapper(nil, serverConfig, DistinguishedNameExtractor{}, converter)
+	extractor, err := NewTLSClientIDExtractor(DistinguishedNameExtractor{}, converter)
 	if err != nil {
 		t.Fatal(err)
 	}
-	clientWrapper, err := NewTLSAuthenticationConnectionWrapper(clientConfig, nil, nil, nil)
+	serverWrapper, err := NewTLSAuthenticationConnectionWrapper(nil, serverConfig, extractor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	clientWrapper, err := NewTLSAuthenticationConnectionWrapper(clientConfig, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -286,11 +298,15 @@ func TestTLSCertificateAuthenticationByCommonName(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	serverWrapper, err := NewTLSAuthenticationConnectionWrapper(nil, serverConfig, DistinguishedNameExtractor{}, converter)
+	extractor, err := NewTLSClientIDExtractor(DistinguishedNameExtractor{}, converter)
 	if err != nil {
 		t.Fatal(err)
 	}
-	clientWrapper, err := NewTLSAuthenticationConnectionWrapper(clientConfig, nil, nil, nil)
+	serverWrapper, err := NewTLSAuthenticationConnectionWrapper(nil, serverConfig, extractor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	clientWrapper, err := NewTLSAuthenticationConnectionWrapper(clientConfig, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -303,11 +319,15 @@ func TestTLSCertificateAuthenticationBySerialNumber(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	serverWrapper, err := NewTLSAuthenticationConnectionWrapper(nil, serverConfig, SerialNumberExtractor{}, converter)
+	extractor, err := NewTLSClientIDExtractor(SerialNumberExtractor{}, converter)
 	if err != nil {
 		t.Fatal(err)
 	}
-	clientWrapper, err := NewTLSAuthenticationConnectionWrapper(clientConfig, nil, nil, nil)
+	serverWrapper, err := NewTLSAuthenticationConnectionWrapper(nil, serverConfig, extractor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	clientWrapper, err := NewTLSAuthenticationConnectionWrapper(clientConfig, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -327,14 +347,18 @@ func TestEmptyCertificateChain(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	serverWrapper, err := NewTLSAuthenticationConnectionWrapper(nil, serverConfig, DistinguishedNameExtractor{}, converter)
+	extractor, err := NewTLSClientIDExtractor(DistinguishedNameExtractor{}, converter)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serverWrapper, err := NewTLSAuthenticationConnectionWrapper(nil, serverConfig, extractor)
 	if err != nil {
 		t.Fatal(err)
 	}
 	// remove client's CA to not pass verification to check that empty VerifiedChain not pass
 	serverWrapper.serverConfig.ClientCAs = x509.NewCertPool()
 	serverWrapper.serverConfig.ClientAuth = tls.RequireAnyClientCert
-	clientWrapper, err := NewTLSAuthenticationConnectionWrapper(clientConfig, nil, nil, nil)
+	clientWrapper, err := NewTLSAuthenticationConnectionWrapper(clientConfig, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -378,7 +402,7 @@ func TestClientsCertificateDenyOnValidation(t *testing.T) {
 	}
 	serverConfig.ClientCAs.AddCert(caCrt)
 
-	clientWrapper, err := NewTLSAuthenticationConnectionWrapper(clientConfig, nil, nil, nil)
+	clientWrapper, err := NewTLSAuthenticationConnectionWrapper(clientConfig, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -387,7 +411,11 @@ func TestClientsCertificateDenyOnValidation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	serverWrapper, err := NewTLSAuthenticationConnectionWrapper(nil, serverConfig, DistinguishedNameExtractor{}, converter)
+	extractor, err := NewTLSClientIDExtractor(DistinguishedNameExtractor{}, converter)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serverWrapper, err := NewTLSAuthenticationConnectionWrapper(nil, serverConfig, extractor)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -425,7 +453,7 @@ func (e testExtractor) GetCertificateIdentifier(certificate *x509.Certificate) (
 
 func TestClientsCertificateDenyOnClientIDExtraction(t *testing.T) {
 	clientConfig, serverConfig := getTLSConfigs(t)
-	clientWrapper, err := NewTLSAuthenticationConnectionWrapper(clientConfig, nil, nil, nil)
+	clientWrapper, err := NewTLSAuthenticationConnectionWrapper(clientConfig, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -433,7 +461,11 @@ func TestClientsCertificateDenyOnClientIDExtraction(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	serverWrapper, err := NewTLSAuthenticationConnectionWrapper(nil, serverConfig, DistinguishedNameExtractor{}, converter)
+	extractor, err := NewTLSClientIDExtractor(DistinguishedNameExtractor{}, converter)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serverWrapper, err := NewTLSAuthenticationConnectionWrapper(nil, serverConfig, extractor)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -449,7 +481,11 @@ func TestClientsCertificateDenyOnClientIDExtraction(t *testing.T) {
 
 	// override extractor which will always return err
 	expectedErr := errors.New("test error")
-	serverWrapper.idExtractor = testExtractor{err: expectedErr}
+	testExtractor, err := NewTLSClientIDExtractor(testExtractor{err: expectedErr}, converter)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serverWrapper.clientIDExtractor = testExtractor
 
 	tested := false
 	mutex := sync.Mutex{}
@@ -476,7 +512,7 @@ func (t testConvertor) Convert(identifier []byte) ([]byte, error) {
 
 func TestClientsCertificateDenyOnClientIDConvertation(t *testing.T) {
 	clientConfig, serverConfig := getTLSConfigs(t)
-	clientWrapper, err := NewTLSAuthenticationConnectionWrapper(clientConfig, nil, nil, nil)
+	clientWrapper, err := NewTLSAuthenticationConnectionWrapper(clientConfig, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -484,7 +520,11 @@ func TestClientsCertificateDenyOnClientIDConvertation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	serverWrapper, err := NewTLSAuthenticationConnectionWrapper(nil, serverConfig, DistinguishedNameExtractor{}, converter)
+	extractor, err := NewTLSClientIDExtractor(DistinguishedNameExtractor{}, converter)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serverWrapper, err := NewTLSAuthenticationConnectionWrapper(nil, serverConfig, extractor)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -500,7 +540,11 @@ func TestClientsCertificateDenyOnClientIDConvertation(t *testing.T) {
 
 	// override convertor which will always return err
 	expectedErr := errors.New("test error")
-	serverWrapper.idConverter = testConvertor{err: expectedErr}
+	testExtractor, err := NewTLSClientIDExtractor(DistinguishedNameExtractor{}, testConvertor{err: expectedErr})
+	if err != nil {
+		t.Fatal(err)
+	}
+	serverWrapper.clientIDExtractor = testExtractor
 
 	tested := false
 	mutex := sync.Mutex{}


### PR DESCRIPTION
To encapsulate calls order of identifier extractor and convertor into one component, I added TLSClientIDExtractor which aggregate and encapsulate that logic and simplify re-usage in parts which don't need to wrap connections to TLS, only extract info from already established connection and TLS state (acra-translator), plus it will simplify code re-usage in acra-ee