### PR TITLE
Handle certificate validation flags in single place

### DIFF
--- a/cmd/acra-connector/acra-connector.go
+++ b/cmd/acra-connector/acra-connector.go
@@ -229,19 +229,7 @@ func main() {
 	tlsCert := flag.String("tls_cert", "", "Path to certificate")
 	tlsAcraserverSNI := flag.String("tls_acraserver_sni", "", "Expected Server Name (SNI) from AcraServer")
 	tlsAuthType := flag.Int("tls_auth", int(tls.RequireAndVerifyClientCert), "Set authentication mode that will be used in TLS connection with AcraServer/AcraTranslator. Values in range 0-4 that set auth type (https://golang.org/pkg/crypto/tls/#ClientAuthType). Default is tls.RequireAndVerifyClientCert")
-	tlsOcspURL := flag.String("tls_ocsp_url", "", "OCSP service URL")
-	tlsOcspRequired := flag.String("tls_ocsp_required", network.OcspRequiredDenyUnknownStr,
-		fmt.Sprintf("How to treat certificates unknown to OCSP: <%s>", strings.Join(network.OcspRequiredValuesList, "|")))
-	tlsOcspFromCert := flag.String("tls_ocsp_from_cert", network.OcspFromCertPreferStr,
-		fmt.Sprintf("How to treat OCSP server described in certificate itself: <%s>", strings.Join(network.OcspFromCertValuesList, "|")))
-	tlsOcspCheckOnlyLeafCertificate := flag.Bool("tls_ocsp_check_only_leaf_certificate", false, "Put 'true' to check only final/last certificate, or 'false' to check the whole certificate chain using OCSP")
-	tlsCrlURL := flag.String("tls_crl_url", "", "URL of the Certificate Revocation List (CRL) to use")
-	tlsCrlFromCert := flag.String("tls_crl_from_cert", network.CrlFromCertPreferStr,
-		fmt.Sprintf("How to treat CRL URL described in certificate itself: <%s>", strings.Join(network.CrlFromCertValuesList, "|")))
-	tlsCrlCheckOnlyLeafCertificate := flag.Bool("tls_crl_check_only_leaf_certificate", false, "Put 'true' to check only final/last certificate, or 'false' to check the whole certificate chain using CRL")
-	tlsCrlCacheSize := flag.Uint("tls_crl_cache_size", network.CrlDefaultCacheSize, "How many CRLs to cache in memory (use 0 to disable caching)")
-	tlsCrlCacheTime := flag.Uint("tls_crl_cache_time", network.CrlDisableCacheTime,
-		fmt.Sprintf("How long to keep CRLs cached, in seconds (use 0 to disable caching, maximum: %d s)", network.CrlCacheTimeMax))
+	network.RegisterCertVerifierArgs(false)
 	noEncryptionTransport := flag.Bool("acraserver_transport_encryption_disable", false, "Enable this flag to omit AcraConnector and connect client app to AcraServer directly using raw transport (tcp/unix socket). From security perspective please use at least TLS encryption (over tcp socket) between AcraServer and client app.")
 	connectionString := flag.String("incoming_connection_string", network.BuildConnectionString(cmd.DefaultAcraConnectorConnectionProtocol, cmd.DefaultAcraConnectorHost, cmd.DefaultAcraConnectorPort, ""), "Connection string like tcp://x.x.x.x:yyyy or unix:///path/to/socket")
 	connectionAPIString := flag.String("incoming_connection_api_string", network.BuildConnectionString(cmd.DefaultAcraConnectorConnectionProtocol, cmd.DefaultAcraConnectorHost, cmd.DefaultAcraConnectorAPIPort, ""), "Connection string like tcp://x.x.x.x:yyyy or unix:///path/to/socket")
@@ -411,23 +399,11 @@ func main() {
 		if *useTLS {
 			log.Infof("Selecting transport: use TLS transport wrapper")
 
-			ocspConfig, err := network.NewOCSPConfig(*tlsOcspURL, *tlsOcspRequired, *tlsOcspFromCert, *tlsOcspCheckOnlyLeafCertificate)
+			certVerifier, err := network.NewCertVerifierFromArgs()
 			if err != nil {
 				log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorWrongConfiguration).
-					Errorln("Configuration error: invalid OCSP config")
+					Errorln("Cannot create certificate verifier")
 				os.Exit(1)
-			}
-
-			crlConfig, err := network.NewCRLConfig(*tlsCrlURL, *tlsCrlFromCert, *tlsCrlCheckOnlyLeafCertificate, *tlsCrlCacheSize, *tlsCrlCacheTime)
-			if err != nil {
-				log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorWrongConfiguration).
-					Errorln("Configuration error: invalid CRL config")
-				os.Exit(1)
-			}
-
-			certVerifier, err := network.NewCertVerifierFromConfigs(ocspConfig, crlConfig)
-			if err != nil {
-				log.WithError(err).Fatalln("Cannot create client certificate verifier")
 			}
 
 			tlsConfig, err := network.NewTLSConfig(network.SNIOrHostname(*tlsAcraserverSNI, *acraServerHost), *tlsCA, *tlsKey, *tlsCert, tls.ClientAuthType(*tlsAuthType), certVerifier)

--- a/cmd/acra-connector/acra-connector.go
+++ b/cmd/acra-connector/acra-connector.go
@@ -229,7 +229,7 @@ func main() {
 	tlsCert := flag.String("tls_cert", "", "Path to certificate")
 	tlsAcraserverSNI := flag.String("tls_acraserver_sni", "", "Expected Server Name (SNI) from AcraServer")
 	tlsAuthType := flag.Int("tls_auth", int(tls.RequireAndVerifyClientCert), "Set authentication mode that will be used in TLS connection with AcraServer/AcraTranslator. Values in range 0-4 that set auth type (https://golang.org/pkg/crypto/tls/#ClientAuthType). Default is tls.RequireAndVerifyClientCert")
-	network.RegisterCertVerifierArgs(false)
+	network.RegisterCertVerifierArgs()
 	noEncryptionTransport := flag.Bool("acraserver_transport_encryption_disable", false, "Enable this flag to omit AcraConnector and connect client app to AcraServer directly using raw transport (tcp/unix socket). From security perspective please use at least TLS encryption (over tcp socket) between AcraServer and client app.")
 	connectionString := flag.String("incoming_connection_string", network.BuildConnectionString(cmd.DefaultAcraConnectorConnectionProtocol, cmd.DefaultAcraConnectorHost, cmd.DefaultAcraConnectorPort, ""), "Connection string like tcp://x.x.x.x:yyyy or unix:///path/to/socket")
 	connectionAPIString := flag.String("incoming_connection_api_string", network.BuildConnectionString(cmd.DefaultAcraConnectorConnectionProtocol, cmd.DefaultAcraConnectorHost, cmd.DefaultAcraConnectorAPIPort, ""), "Connection string like tcp://x.x.x.x:yyyy or unix:///path/to/socket")
@@ -399,7 +399,7 @@ func main() {
 		if *useTLS {
 			log.Infof("Selecting transport: use TLS transport wrapper")
 
-			certVerifier, err := network.NewCertVerifierFromArgs()
+			certVerifier, err := network.NewCertVerifier()
 			if err != nil {
 				log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorWrongConfiguration).
 					Errorln("Cannot create certificate verifier")

--- a/cmd/acra-server/acra-server.go
+++ b/cmd/acra-server/acra-server.go
@@ -127,23 +127,7 @@ func main() {
 	tlsDbKey := flag.String("tls_database_key", "", "Path to private key of the TLS certificate used to connect to database (see \"tls_database_cert\")")
 	tlsUseClientIDFromCertificate := flag.Bool("tls_client_id_from_cert", false, "Extract clientID from TLS certificate. Take TLS certificate from AcraConnector's connection if acraconnector_tls_transport_enable is TRUE; otherwise take TLS certificate from application's connection if acraconnector_transport_encryption_disable is TRUE")
 	tlsIdentifierExtractorType := flag.String("tls_identifier_extractor_type", network.IdentifierExtractorTypeDistinguishedName, fmt.Sprintf("Decide which field of TLS certificate to use as ClientID (%s)", strings.Join(network.IdentifierExtractorTypesList, "|")))
-	tlsOcspURL := flag.String("tls_ocsp_url", "", "OCSP service URL")
-	tlsOcspClientURL := flag.String("tls_ocsp_client_url", "", "OCSP service URL, for client/connector certificates only")
-	tlsOcspDbURL := flag.String("tls_ocsp_database_url", "", "OCSP service URL, for database certificates only")
-	tlsOcspRequired := flag.String("tls_ocsp_required", network.OcspRequiredDenyUnknownStr,
-		fmt.Sprintf("How to treat certificates unknown to OCSP: <%s>", strings.Join(network.OcspRequiredValuesList, "|")))
-	tlsOcspFromCert := flag.String("tls_ocsp_from_cert", network.OcspFromCertPreferStr,
-		fmt.Sprintf("How to treat OCSP server described in certificate itself: <%s>", strings.Join(network.OcspFromCertValuesList, "|")))
-	tlsOcspCheckOnlyLeafCertificate := flag.Bool("tls_ocsp_check_only_leaf_certificate", false, "Put 'true' to check only final/last certificate, or 'false' to check the whole certificate chain using OCSP")
-	tlsCrlURL := flag.String("tls_crl_url", "", "URL of the Certificate Revocation List (CRL) to use")
-	tlsCrlClientURL := flag.String("tls_crl_client_url", "", "URL of the Certificate Revocation List (CRL) to use, for client/connector certificates only")
-	tlsCrlDbURL := flag.String("tls_crl_database_url", "", "URL of the Certificate Revocation List (CRL) to use, for database certificates only")
-	tlsCrlFromCert := flag.String("tls_crl_from_cert", network.CrlFromCertPreferStr,
-		fmt.Sprintf("How to treat CRL URL described in certificate itself: <%s>", strings.Join(network.CrlFromCertValuesList, "|")))
-	tlsCrlCheckOnlyLeafCertificate := flag.Bool("tls_crl_check_only_leaf_certificate", false, "Put 'true' to check only final/last certificate, or 'false' to check the whole certificate chain using CRL")
-	tlsCrlCacheSize := flag.Uint("tls_crl_cache_size", network.CrlDefaultCacheSize, "How many CRLs to cache in memory (use 0 to disable caching)")
-	tlsCrlCacheTime := flag.Uint("tls_crl_cache_time", network.CrlDisableCacheTime,
-		fmt.Sprintf("How long to keep CRLs cached, in seconds (use 0 to disable caching, maximum: %d s)", network.CrlCacheTimeMax))
+	network.RegisterCertVerifierArgs(true)
 	noEncryptionTransport := flag.Bool("acraconnector_transport_encryption_disable", false, "Use raw transport (tcp/unix socket) between AcraServer and AcraConnector/client (don't use this flag if you not connect to database with SSL/TLS")
 	clientID := flag.String("client_id", "", "Expected client ID of AcraConnector in mode without encryption")
 	acraConnectionString := flag.String("incoming_connection_string", network.BuildConnectionString(cmd.DefaultAcraServerConnectionProtocol, cmd.DefaultAcraServerHost, cmd.DefaultAcraServerPort, ""), "Connection string like tcp://x.x.x.x:yyyy or unix:///path/to/socket")
@@ -266,35 +250,11 @@ func main() {
 			*tlsClientKey = *tlsKey
 		}
 
-		var ocspClientConfig *network.OCSPConfig
-		if *tlsOcspClientURL != "" {
-			ocspClientConfig, err = network.NewOCSPConfig(*tlsOcspClientURL, *tlsOcspRequired, *tlsOcspFromCert, *tlsOcspCheckOnlyLeafCertificate)
-		} else {
-			ocspClientConfig, err = network.NewOCSPConfig(*tlsOcspURL, *tlsOcspRequired, *tlsOcspFromCert, *tlsOcspCheckOnlyLeafCertificate)
-		}
+		certClientVerifier, err := network.NewClientCertVerifierFromArgs(*tlsAuthType)
 		if err != nil {
 			log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorWrongConfiguration).
-				Errorln("Configuration error: invalid OCSP config")
+				Errorln("Cannot create client certificate verifier")
 			os.Exit(1)
-		}
-		ocspClientConfig.ClientAuthType = tls.ClientAuthType(*tlsClientAuthType)
-
-		var crlClientConfig *network.CRLConfig
-		if *tlsCrlClientURL != "" {
-			crlClientConfig, err = network.NewCRLConfig(*tlsCrlClientURL, *tlsCrlFromCert, *tlsCrlCheckOnlyLeafCertificate, *tlsCrlCacheSize, *tlsCrlCacheTime)
-		} else {
-			crlClientConfig, err = network.NewCRLConfig(*tlsCrlURL, *tlsCrlFromCert, *tlsCrlCheckOnlyLeafCertificate, *tlsCrlCacheSize, *tlsCrlCacheTime)
-		}
-		if err != nil {
-			log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorWrongConfiguration).
-				Errorln("Configuration error: invalid CRL config")
-			os.Exit(1)
-		}
-		crlClientConfig.ClientAuthType = tls.ClientAuthType(*tlsClientAuthType)
-
-		certClientVerifier, err := network.NewCertVerifierFromConfigs(ocspClientConfig, crlClientConfig)
-		if err != nil {
-			log.WithError(err).Fatalln("Cannot create client certificate verifier")
 		}
 
 		clientTLSConfig, err = network.NewTLSConfig("", *tlsClientCA, *tlsClientKey, *tlsClientCert, tls.ClientAuthType(*tlsClientAuthType), certClientVerifier)
@@ -321,33 +281,11 @@ func main() {
 			*tlsDbKey = *tlsKey
 		}
 
-		var ocspDbConfig *network.OCSPConfig
-		if *tlsOcspDbURL != "" {
-			ocspDbConfig, err = network.NewOCSPConfig(*tlsOcspDbURL, *tlsOcspRequired, *tlsOcspFromCert, *tlsOcspCheckOnlyLeafCertificate)
-		} else {
-			ocspDbConfig, err = network.NewOCSPConfig(*tlsOcspURL, *tlsOcspRequired, *tlsOcspFromCert, *tlsOcspCheckOnlyLeafCertificate)
-		}
+		certDbVerifier, err := network.NewDatabaseCertVerifierFromArgs()
 		if err != nil {
 			log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorWrongConfiguration).
-				Errorln("Configuration error: invalid OCSP config")
+				Errorln("Cannot create database certificate verifier")
 			os.Exit(1)
-		}
-
-		var crlDbConfig *network.CRLConfig
-		if *tlsCrlDbURL != "" {
-			crlDbConfig, err = network.NewCRLConfig(*tlsCrlDbURL, *tlsCrlFromCert, *tlsCrlCheckOnlyLeafCertificate, *tlsCrlCacheSize, *tlsCrlCacheTime)
-		} else {
-			crlDbConfig, err = network.NewCRLConfig(*tlsCrlURL, *tlsCrlFromCert, *tlsCrlCheckOnlyLeafCertificate, *tlsCrlCacheSize, *tlsCrlCacheTime)
-		}
-		if err != nil {
-			log.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorWrongConfiguration).
-				Errorln("Configuration error: invalid CRL config")
-			os.Exit(1)
-		}
-
-		certDbVerifier, err := network.NewCertVerifierFromConfigs(ocspDbConfig, crlDbConfig)
-		if err != nil {
-			log.WithError(err).Fatalln("Cannot create database certificate verifier")
 		}
 
 		dbTLSConfig, err = network.NewTLSConfig(network.SNIOrHostname(*tlsDbSNI, *dbHost), *tlsDbCA, *tlsDbKey, *tlsDbCert, tls.ClientAuthType(*tlsDbAuthType), certDbVerifier)

--- a/network/cert_verifier.go
+++ b/network/cert_verifier.go
@@ -17,9 +17,13 @@ limitations under the License.
 package network
 
 import (
+	"crypto/tls"
 	"crypto/x509"
 	"errors"
+	"flag"
+	"fmt"
 	log "github.com/sirupsen/logrus"
+	"strings"
 )
 
 // Errors common for OCSP and CRL verifiers
@@ -28,14 +32,137 @@ var (
 	ErrEmptyCertChain = errors.New("empty verified certificates chain")
 )
 
+var (
+	tlsOcspURL                      string
+	tlsOcspClientURL                string
+	tlsOcspDbURL                    string
+	tlsOcspRequired                 string
+	tlsOcspFromCert                 string
+	tlsOcspCheckOnlyLeafCertificate bool
+	tlsCrlURL                       string
+	tlsCrlClientURL                 string
+	tlsCrlDbURL                     string
+	tlsCrlFromCert                  string
+	tlsCrlCheckOnlyLeafCertificate  bool
+	tlsCrlCacheSize                 uint
+	tlsCrlCacheTime                 uint
+)
+
+// RegisterCertVerifierArgs register CLI args tls_ocsp_url|tls_ocsp_client_url|tls_ocsp_database_url|tls_ocsp_required|tls_ocsp_from_cert|tls_ocsp_check_only_leaf_certificate|tls_crl_url|tls_crl_client_url|tls_crl_database_url|tls_crl_from_cert|tls_crl_check_only_leaf_certificate|tls_crl_cache_size|tls_crl_cache_time which allow to get CertVerifier by NewCertVerifierFromArgs|NewClientCertVerifierFromArgs|NewDatabaseCertVerifierFromArgs functions
+func RegisterCertVerifierArgs(separate_client_db_urls bool) {
+	flag.StringVar(&tlsOcspURL, "tls_ocsp_url", "", "OCSP service URL")
+	if separate_client_db_urls {
+		flag.StringVar(&tlsOcspClientURL, "tls_ocsp_client_url", "", "OCSP service URL, for client/connector certificates only")
+		flag.StringVar(&tlsOcspDbURL, "tls_ocsp_database_url", "", "OCSP service URL, for database certificates only")
+	}
+	flag.StringVar(&tlsOcspRequired, "tls_ocsp_required", OcspRequiredDenyUnknownStr,
+		fmt.Sprintf("How to treat certificates unknown to OCSP: <%s>", strings.Join(OcspRequiredValuesList, "|")))
+	flag.StringVar(&tlsOcspFromCert, "tls_ocsp_from_cert", OcspFromCertPreferStr,
+		fmt.Sprintf("How to treat OCSP server described in certificate itself: <%s>", strings.Join(OcspFromCertValuesList, "|")))
+	flag.BoolVar(&tlsOcspCheckOnlyLeafCertificate, "tls_ocsp_check_only_leaf_certificate", false,
+		"Put 'true' to check only final/last certificate, or 'false' to check the whole certificate chain using OCSP")
+	flag.StringVar(&tlsCrlURL, "tls_crl_url", "", "URL of the Certificate Revocation List (CRL) to use")
+	if separate_client_db_urls {
+		flag.StringVar(&tlsCrlClientURL, "tls_crl_client_url", "", "URL of the Certificate Revocation List (CRL) to use, for client/connector certificates only")
+		flag.StringVar(&tlsCrlDbURL, "tls_crl_database_url", "", "URL of the Certificate Revocation List (CRL) to use, for database certificates only")
+	}
+	flag.StringVar(&tlsCrlFromCert, "tls_crl_from_cert", CrlFromCertPreferStr,
+		fmt.Sprintf("How to treat CRL URL described in certificate itself: <%s>", strings.Join(CrlFromCertValuesList, "|")))
+	flag.BoolVar(&tlsCrlCheckOnlyLeafCertificate, "tls_crl_check_only_leaf_certificate", false,
+		"Put 'true' to check only final/last certificate, or 'false' to check the whole certificate chain using CRL")
+	flag.UintVar(&tlsCrlCacheSize, "tls_crl_cache_size", CrlDefaultCacheSize, "How many CRLs to cache in memory (use 0 to disable caching)")
+	flag.UintVar(&tlsCrlCacheTime, "tls_crl_cache_time", CrlDisableCacheTime,
+		fmt.Sprintf("How long to keep CRLs cached, in seconds (use 0 to disable caching, maximum: %d s)", CrlCacheTimeMax))
+}
+
 // CertVerifier is a generic certificate verifier
 type CertVerifier interface {
 	// Verify checks whether the certificate is revoked.
 	// The error is returned if:
 	// - the certificate was revoked
-	// - (for OCSP) the certificate is not known by OCSP server and we requested tls_ocsp_required == "yes" or "all"
-	// - (for OCSP) if we were unable to contact OCSP server(s) but we really need the response, tls_ocsp_required == "all"
+	// - (for OCSP) the certificate is not known by OCSP server and we requested tls_ocsp_required == "denyUnknown" or "requireGood"
+	// - (for OCSP) if we were unable to contact OCSP server(s) but we really need the response, tls_ocsp_required == "requireGood"
 	Verify(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error
+}
+
+// NewCertVerifierFromArgs creates a CertVerifier based on passed OCSP and CRL command line flags.
+// Ignores `--tls_{ocsp,crl}_{client,database}_url` flags, only uses `--tls_{ocsp,crl}_url` as URL source.
+func NewCertVerifierFromArgs() (CertVerifier, error) {
+	ocspConfig, err := NewOCSPConfig(tlsOcspURL, tlsOcspRequired, tlsOcspFromCert, tlsOcspCheckOnlyLeafCertificate)
+	if err != nil {
+		return nil, err
+	}
+
+	crlConfig, err := NewCRLConfig(tlsCrlURL, tlsCrlFromCert, tlsCrlCheckOnlyLeafCertificate, tlsCrlCacheSize, tlsCrlCacheTime)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewCertVerifierFromConfigs(ocspConfig, crlConfig)
+}
+
+// NewClientCertVerifierFromArgs creates a CertVerifier based on passed OCSP and CRL command line flags.
+// Prioritizes `--tls_{ocsp,crl}_client_url` over `--tls_{ocsp,crl}_url`, ignores `--tls_{ocsp,crl}_database_url`.
+// For usage on server side, to verify certificates that come from clients.
+func NewClientCertVerifierFromArgs(clientAuthType int) (CertVerifier, error) {
+	var ocspURL, crlURL string
+
+	if tlsOcspClientURL != "" {
+		ocspURL = tlsOcspClientURL
+	} else {
+		ocspURL = tlsOcspURL
+	}
+
+	if tlsCrlClientURL != "" {
+		crlURL = tlsCrlClientURL
+	} else {
+		crlURL = tlsCrlURL
+	}
+
+	ocspConfig, err := NewOCSPConfig(ocspURL, tlsOcspRequired, tlsOcspFromCert, tlsOcspCheckOnlyLeafCertificate)
+	if err != nil {
+		return nil, err
+	}
+	ocspConfig.ClientAuthType = tls.ClientAuthType(clientAuthType)
+
+	crlConfig, err := NewCRLConfig(crlURL, tlsCrlFromCert, tlsCrlCheckOnlyLeafCertificate, tlsCrlCacheSize, tlsCrlCacheTime)
+	if err != nil {
+		return nil, err
+	}
+	crlConfig.ClientAuthType = tls.ClientAuthType(clientAuthType)
+
+	return NewCertVerifierFromConfigs(ocspConfig, crlConfig)
+}
+
+// NewDatabaseCertVerifierFromArgs creates a CertVerifier based on passed OCSP and CRL command line flags.
+// Prioritizes `--tls_{ocsp,crl}_database_url` over `--tls_{ocsp,crl}_url`, ignores `--tls_{ocsp,crl}_client_url`.
+// For usage on client side, to verify certificates that come from servers (i.e. database).
+func NewDatabaseCertVerifierFromArgs() (CertVerifier, error) {
+	var ocspURL, crlURL string
+
+	if tlsOcspDbURL != "" {
+		ocspURL = tlsOcspDbURL
+	} else {
+		ocspURL = tlsOcspURL
+	}
+
+	if tlsCrlDbURL != "" {
+		crlURL = tlsCrlDbURL
+	} else {
+		crlURL = tlsCrlURL
+	}
+
+	ocspConfig, err := NewOCSPConfig(ocspURL, tlsOcspRequired, tlsOcspFromCert, tlsOcspCheckOnlyLeafCertificate)
+	if err != nil {
+		return nil, err
+	}
+
+	crlConfig, err := NewCRLConfig(crlURL, tlsCrlFromCert, tlsCrlCheckOnlyLeafCertificate, tlsCrlCacheSize, tlsCrlCacheTime)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewCertVerifierFromConfigs(ocspConfig, crlConfig)
 }
 
 // NewCertVerifierFromConfigs creates a CertVerifier based on passed OCSP and CRL configs

--- a/network/tls_wrapper.go
+++ b/network/tls_wrapper.go
@@ -22,12 +22,10 @@ import (
 	"crypto/x509"
 	"errors"
 	"flag"
-	"fmt"
 	"github.com/cossacklabs/acra/logging"
 	log "github.com/sirupsen/logrus"
 	"io/ioutil"
 	"net"
-	"strings"
 	"time"
 )
 
@@ -54,41 +52,20 @@ type TLSConnectionWrapper struct {
 var ErrEmptyTLSConfig = errors.New("empty TLS clientConfig")
 
 var (
-	tlsCA                           string
-	tlsKey                          string
-	tlsCert                         string
-	tlsAuthType                     int
-	tlsServerName                   string
-	tlsOcspURL                      string
-	tlsOcspRequired                 string
-	tlsOcspFromCert                 string
-	tlsOcspCheckOnlyLeafCertificate bool
-	tlsCrlURL                       string
-	tlsCrlFromCert                  string
-	tlsCrlCheckOnlyLeafCertificate  bool
-	tlsCrlCacheSize                 uint
-	tlsCrlCacheTime                 uint
+	tlsCA         string
+	tlsKey        string
+	tlsCert       string
+	tlsAuthType   int
+	tlsServerName string
 )
 
-// RegisterTLSBaseArgs register CLI args tls_ca|tls_key|tls_cert|tls_auth|tls_ocsp_url|tls_ocsp_required|tls_ocsp_from_cert|tls_ocsp_check_only_leaf_certificate|tls_crl_url|tls_crl_from_cert|tls_crl_check_only_leaf_certificate|tls_crl_cache_size|tls_crl_cache_time which allow to get tls.Config by NewTLSConfigFromBaseArgs function
+// RegisterTLSBaseArgs register CLI args tls_ca|tls_key|tls_cert|tls_auth which allow to get tls.Config by NewTLSConfigFromBaseArgs function
 func RegisterTLSBaseArgs() {
 	flag.StringVar(&tlsCA, "tls_ca", "", "Path to root certificate which will be used with system root certificates to validate peer's certificate")
 	flag.StringVar(&tlsKey, "tls_key", "", "Path to private key that will be used for TLS connections")
 	flag.StringVar(&tlsCert, "tls_cert", "", "Path to certificate")
 	flag.IntVar(&tlsAuthType, "tls_auth", int(tls.RequireAndVerifyClientCert), "Set authentication mode that will be used in TLS connection. Values in range 0-4 that set auth type (https://golang.org/pkg/crypto/tls/#ClientAuthType). Default is tls.RequireAndVerifyClientCert")
-	flag.StringVar(&tlsOcspURL, "tls_ocsp_url", "", "OCSP service URL")
-	flag.StringVar(&tlsOcspRequired, "tls_ocsp_required", OcspRequiredDenyUnknownStr,
-		fmt.Sprintf("How to treat certificates unknown to OCSP: <%s>", strings.Join(OcspRequiredValuesList, "|")))
-	flag.StringVar(&tlsOcspFromCert, "tls_ocsp_from_cert", OcspFromCertPreferStr,
-		fmt.Sprintf("How to treat OCSP server described in certificate itself: <%s>", strings.Join(OcspFromCertValuesList, "|")))
-	flag.BoolVar(&tlsOcspCheckOnlyLeafCertificate, "tls_ocsp_check_only_leaf_certificate", false, "Put 'true' to check only final/last certificate, or 'false' to check the whole certificate chain using OCSP")
-	flag.StringVar(&tlsCrlURL, "tls_crl_url", "", "URL of the Certificate Revocation List (CRL) to use")
-	flag.StringVar(&tlsCrlFromCert, "tls_crl_from_cert", CrlFromCertPreferStr,
-		fmt.Sprintf("How to treat CRL URL described in certificate itself: <%s>", strings.Join(CrlFromCertValuesList, "|")))
-	flag.BoolVar(&tlsCrlCheckOnlyLeafCertificate, "tls_crl_check_only_leaf_certificate", false, "Put 'true' to check only final/last certificate, or 'false' to check the whole certificate chain using CRL")
-	flag.UintVar(&tlsCrlCacheSize, "tls_crl_cache_size", CrlDefaultCacheSize, "How many CRLs to cache in memory (use 0 to disable caching)")
-	flag.UintVar(&tlsCrlCacheTime, "tls_crl_cache_time", CrlDisableCacheTime,
-		fmt.Sprintf("How long to keep CRLs cached, in seconds (use 0 to disable caching, maximum: %d s)", CrlCacheTimeMax))
+	RegisterCertVerifierArgs(false)
 }
 
 // RegisterTLSClientArgs register CLI args tls_server_sni used by TLS client's connection
@@ -98,17 +75,7 @@ func RegisterTLSClientArgs() {
 
 // NewTLSConfigFromBaseArgs return new tls clientConfig with params passed by cli params
 func NewTLSConfigFromBaseArgs() (*tls.Config, error) {
-	ocspConfig, err := NewOCSPConfig(tlsOcspURL, tlsOcspRequired, tlsOcspFromCert, tlsOcspCheckOnlyLeafCertificate)
-	if err != nil {
-		return nil, err
-	}
-
-	crlConfig, err := NewCRLConfig(tlsCrlURL, tlsCrlFromCert, tlsCrlCheckOnlyLeafCertificate, tlsCrlCacheSize, tlsCrlCacheTime)
-	if err != nil {
-		return nil, err
-	}
-
-	certVerifier, err := NewCertVerifierFromConfigs(ocspConfig, crlConfig)
+	certVerifier, err := NewCertVerifierFromArgs()
 	if err != nil {
 		return nil, err
 	}

--- a/network/tls_wrapper.go
+++ b/network/tls_wrapper.go
@@ -65,7 +65,7 @@ func RegisterTLSBaseArgs() {
 	flag.StringVar(&tlsKey, "tls_key", "", "Path to private key that will be used for TLS connections")
 	flag.StringVar(&tlsCert, "tls_cert", "", "Path to certificate")
 	flag.IntVar(&tlsAuthType, "tls_auth", int(tls.RequireAndVerifyClientCert), "Set authentication mode that will be used in TLS connection. Values in range 0-4 that set auth type (https://golang.org/pkg/crypto/tls/#ClientAuthType). Default is tls.RequireAndVerifyClientCert")
-	RegisterCertVerifierArgs(false)
+	RegisterCertVerifierArgs()
 }
 
 // RegisterTLSClientArgs register CLI args tls_server_sni used by TLS client's connection
@@ -75,7 +75,7 @@ func RegisterTLSClientArgs() {
 
 // NewTLSConfigFromBaseArgs return new tls clientConfig with params passed by cli params
 func NewTLSConfigFromBaseArgs() (*tls.Config, error) {
-	certVerifier, err := NewCertVerifierFromArgs()
+	certVerifier, err := NewCertVerifier()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Create a function `RegisterCertVerifierArgs()` which will now be responsible for handling OCSP- and CRL-related command line flags.
In acra-server and acra-connector, call it instead of describing all these flags (which are mostly duplicated).

Then, call one of
* `NewCertVerifierFromArgs()`
* `NewClientCertVerifierFromArgs()`
* `NewDatabaseCertVerifierFromArgs()`

which will use values generated by `RegisterCertVerifierArgs()` and create the CertVerifier under the hood.

All these changes will allow editing/adding/removing flags much easier since they will be in one place.
Also, adding cert verification functionality to different binaries in `cmd/` will require writing less code:
* one call to register flags,
* another one to get the verifier we can use in TLS wrapper.