### PR TITLE
Use absolute path for files in tests

### DIFF
--- a/network/cert_verifier.go
+++ b/network/cert_verifier.go
@@ -49,9 +49,9 @@ var (
 )
 
 // registerCertVerifierArgs register CLI args tls_ocsp_url|tls_ocsp_client_url|tls_ocsp_database_url|tls_ocsp_required|tls_ocsp_from_cert|tls_ocsp_check_only_leaf_certificate|tls_crl_url|tls_crl_client_url|tls_crl_database_url|tls_crl_from_cert|tls_crl_check_only_leaf_certificate|tls_crl_cache_size|tls_crl_cache_time which allow to get CertVerifier by NewCertVerifier|NewClientCertVerifier|NewDatabaseCertVerifier functions
-func registerCertVerifierArgs(separate_client_db_urls bool) {
+func registerCertVerifierArgs(separateClientDBUrls bool) {
 	flag.StringVar(&tlsOcspURL, "tls_ocsp_url", "", "OCSP service URL")
-	if separate_client_db_urls {
+	if separateClientDBUrls {
 		flag.StringVar(&tlsOcspClientURL, "tls_ocsp_client_url", "", "OCSP service URL, for client/connector certificates only")
 		flag.StringVar(&tlsOcspDbURL, "tls_ocsp_database_url", "", "OCSP service URL, for database certificates only")
 	}
@@ -62,7 +62,7 @@ func registerCertVerifierArgs(separate_client_db_urls bool) {
 	flag.BoolVar(&tlsOcspCheckOnlyLeafCertificate, "tls_ocsp_check_only_leaf_certificate", false,
 		"Put 'true' to check only final/last certificate, or 'false' to check the whole certificate chain using OCSP")
 	flag.StringVar(&tlsCrlURL, "tls_crl_url", "", "URL of the Certificate Revocation List (CRL) to use")
-	if separate_client_db_urls {
+	if separateClientDBUrls {
 		flag.StringVar(&tlsCrlClientURL, "tls_crl_client_url", "", "URL of the Certificate Revocation List (CRL) to use, for client/connector certificates only")
 		flag.StringVar(&tlsCrlDbURL, "tls_crl_database_url", "", "URL of the Certificate Revocation List (CRL) to use, for database certificates only")
 	}

--- a/network/crl.go
+++ b/network/crl.go
@@ -104,8 +104,8 @@ type CRLConfig struct {
 }
 
 const (
-	// CrlHttpClientDefaultTimeout is default timeout for HTTP client used to fetch CRLs
-	CrlHttpClientDefaultTimeout = time.Second * time.Duration(20)
+	// CrlHTTPClientDefaultTimeout is default timeout for HTTP client used to fetch CRLs
+	CrlHTTPClientDefaultTimeout = time.Second * time.Duration(20)
 )
 
 // NewCRLConfig creates new CRLConfig
@@ -176,7 +176,7 @@ type DefaultCRLClient struct {
 // NewDefaultCRLClient creates new DefaultCRLClient
 func NewDefaultCRLClient() DefaultCRLClient {
 	return DefaultCRLClient{httpClient: &http.Client{
-		Timeout: CrlHttpClientDefaultTimeout,
+		Timeout: CrlHTTPClientDefaultTimeout,
 	}}
 }
 

--- a/network/ocsp.go
+++ b/network/ocsp.go
@@ -120,8 +120,8 @@ type OCSPConfig struct {
 }
 
 const (
-	// OcspHttpClientDefaultTimeout is default timeout for HTTP client used to perform OCSP queries
-	OcspHttpClientDefaultTimeout = time.Second * time.Duration(15)
+	// OcspHTTPClientDefaultTimeout is default timeout for HTTP client used to perform OCSP queries
+	OcspHTTPClientDefaultTimeout = time.Second * time.Duration(15)
 )
 
 // NewOCSPConfig creates new OCSPConfig
@@ -205,7 +205,7 @@ type DefaultOCSPClient struct {
 // NewDefaultOCSPClient creates new DefaultOCSPClient
 func NewDefaultOCSPClient() DefaultOCSPClient {
 	return DefaultOCSPClient{httpClient: &http.Client{
-		Timeout: OcspHttpClientDefaultTimeout,
+		Timeout: OcspHTTPClientDefaultTimeout,
 	}}
 }
 

--- a/network/tls_authentication.go
+++ b/network/tls_authentication.go
@@ -114,7 +114,7 @@ type tlsClientIDExtractor struct {
 }
 
 // NewTLSClientIDExtractor create new TLSClientIDExtractor implementation which use idExtractor and idConvertor to extract clientID
-func NewTLSClientIDExtractor(idExtractor CertificateIdentifierExtractor, idConverter IdentifierConverter) (*tlsClientIDExtractor, error) {
+func NewTLSClientIDExtractor(idExtractor CertificateIdentifierExtractor, idConverter IdentifierConverter) (TLSClientIDExtractor, error) {
 	return &tlsClientIDExtractor{idExtractor, idConverter}, nil
 }
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -21,7 +21,7 @@ import logging
 import http
 import tempfile
 import time
-import os
+import os, os.path
 import random
 import subprocess
 import traceback
@@ -94,19 +94,19 @@ DB_NAME = os.environ.get('TEST_DB_NAME', 'postgres')
 DB_PORT = os.environ.get('TEST_DB_PORT', 5432)
 
 TEST_TLS_CA = abs_path(os.environ.get('TEST_TLS_CA', 'tests/ssl/ca/ca.crt'))
-TEST_TLS_SERVER_CERT = abs_path(os.environ.get('TEST_TLS_SERVER_CERT', 'tests/ssl/acra-server/acra-server.crt'))
-TEST_TLS_SERVER_KEY = abs_path(os.environ.get('TEST_TLS_SERVER_KEY', 'tests/ssl/acra-server/acra-server.key'))
+TEST_TLS_SERVER_CERT = abs_path(os.environ.get('TEST_TLS_SERVER_CERT', os.path.join(os.path.dirname(__file__), 'ssl/acra-server/acra-server.crt')))
+TEST_TLS_SERVER_KEY = abs_path(os.environ.get('TEST_TLS_SERVER_KEY', os.path.join(os.path.dirname(__file__), 'ssl/acra-server/acra-server.key')))
 # keys copied to tests/* with modified rights to 0400 because keys in docker/ssl/ has access from groups/other but some
 # db drivers prevent usage of keys with global rights
-TEST_TLS_CLIENT_CERT = abs_path(os.environ.get('TEST_TLS_CLIENT_CERT', 'tests/ssl/acra-writer/acra-writer.crt'))
-TEST_TLS_CLIENT_KEY = abs_path(os.environ.get('TEST_TLS_CLIENT_KEY', 'tests/ssl/acra-writer/acra-writer.key'))
-TEST_TLS_CLIENT_2_CERT = abs_path(os.environ.get('TEST_TLS_CLIENT_CERT', 'tests/ssl/acra-writer-2/acra-writer-2.crt'))
-TEST_TLS_CLIENT_2_KEY = abs_path(os.environ.get('TEST_TLS_CLIENT_KEY', 'tests/ssl/acra-writer-2/acra-writer-2.key'))
-TEST_TLS_OCSP_CA = abs_path(os.environ.get('TEST_TLS_OCSP_CA', 'tests/ssl/ca/ca.crt'))
-TEST_TLS_OCSP_CERT = abs_path(os.environ.get('TEST_TLS_OCSP_CERT', 'tests/ssl/ocsp-responder/ocsp-responder.crt'))
-TEST_TLS_OCSP_KEY = abs_path(os.environ.get('TEST_TLS_OCSP_KEY', 'tests/ssl/ocsp-responder/ocsp-responder.key'))
-TEST_TLS_OCSP_INDEX = abs_path(os.environ.get('TEST_TLS_OCSP_INDEX', 'tests/ssl/ca/index.txt'))
-TEST_TLS_CRL_PATH = abs_path(os.environ.get('TEST_TLS_CRL_PATH', 'tests/ssl/ca'))
+TEST_TLS_CLIENT_CERT = abs_path(os.environ.get('TEST_TLS_CLIENT_CERT', os.path.join(os.path.dirname(__file__), 'ssl/acra-writer/acra-writer.crt')))
+TEST_TLS_CLIENT_KEY = abs_path(os.environ.get('TEST_TLS_CLIENT_KEY', os.path.join(os.path.dirname(__file__), 'ssl/acra-writer/acra-writer.key')))
+TEST_TLS_CLIENT_2_CERT = abs_path(os.environ.get('TEST_TLS_CLIENT_CERT', os.path.join(os.path.dirname(__file__), 'ssl/acra-writer-2/acra-writer-2.crt')))
+TEST_TLS_CLIENT_2_KEY = abs_path(os.environ.get('TEST_TLS_CLIENT_KEY', os.path.join(os.path.dirname(__file__), 'ssl/acra-writer-2/acra-writer-2.key')))
+TEST_TLS_OCSP_CA = abs_path(os.environ.get('TEST_TLS_OCSP_CA', os.path.join(os.path.dirname(__file__), 'ssl/ca/ca.crt')))
+TEST_TLS_OCSP_CERT = abs_path(os.environ.get('TEST_TLS_OCSP_CERT', os.path.join(os.path.dirname(__file__), 'ssl/ocsp-responder/ocsp-responder.crt')))
+TEST_TLS_OCSP_KEY = abs_path(os.environ.get('TEST_TLS_OCSP_KEY', os.path.join(os.path.dirname(__file__), 'ssl/ocsp-responder/ocsp-responder.key')))
+TEST_TLS_OCSP_INDEX = abs_path(os.environ.get('TEST_TLS_OCSP_INDEX', os.path.join(os.path.dirname(__file__), 'ssl/ca/index.txt')))
+TEST_TLS_CRL_PATH = abs_path(os.environ.get('TEST_TLS_CRL_PATH', os.path.join(os.path.dirname(__file__), 'ssl/ca')))
 TEST_WITH_TLS = os.environ.get('TEST_TLS', 'off').lower() == 'on'
 
 TEST_WITH_TRACING = os.environ.get('TEST_TRACE', 'off').lower() == 'on'
@@ -5347,7 +5347,7 @@ class TLSAuthenticationByDistinguishedNameMixin(object):
 
     def get_valid_certificate_identifier(self):
         # converted data from certificate "CN=Test leaf certificate (acra-writer),OU=IT,O=Global Security,L=London,ST=London,C=GB"
-        with open('tests/ssl/acra-writer/acra-writer.crt', 'rb') as f:
+        with open(TEST_TLS_CLIENT_CERT, 'rb') as f:
             pem = f.read()
         cert = x509.load_pem_x509_certificate(pem, default_backend())
         sha512 = hashlib.sha512()
@@ -5361,7 +5361,7 @@ class TLSAuthenticationBySerialNumberMixin(TLSAuthenticationByDistinguishedNameM
 
     def get_valid_certificate_identifier(self):
         # converted data from certificate "CN=Test leaf certificate (acra-writer),OU=IT,O=Global Security,L=London,ST=London,C=GB"
-        with open('tests/ssl/acra-writer/acra-writer.crt', 'rb') as f:
+        with open(TEST_TLS_CLIENT_CERT, 'rb') as f:
             pem = f.read()
         cert = x509.load_pem_x509_certificate(pem, default_backend())
         sha512 = hashlib.sha512()


### PR DESCRIPTION
When we run acra-ce tests with binaries from acra-ee, working directory used from acra-ee environment, where not exists `tests/ssl/*` folders and files. So to avoid errors, we should rely on abs paths in acra-ce tests and calculate them relative to files in acra-ce.

p.s. also fixed some naming issues to pass linter's checks