### PR TITLE
Additional unit tests for certificate verifier

### DIFF
--- a/network/crl.go
+++ b/network/crl.go
@@ -350,7 +350,10 @@ func checkCertWithCRL(cert *x509.Certificate, crl *pkix.CertificateList) error {
 	for _, extension := range crl.TBSCertList.Extensions {
 		// For CRL v2 (RFC 5280 section 5.2), CRL issuers are REQUIRED to include
 		// the authority key identifier (Section 5.2.1) and the CRL number (Section 5.2.3).
-		// This means we also have to handle these extensions.
+		// TODO handle all these extensions; this will require some refactoring:
+		//      create DB with revoked certificates, update it from delta CRL or rewrite from usual CRL;
+		//      these extensions cannot exist in older CRL v1 though
+		//      (like the one generated with `openssl ca -gencrl ...` without `-crlexts` option)
 		switch extension.Id.String() {
 		case "2.5.29.35":
 			// section 5.2.1 (4.2.1.1), id-ce-authorityKeyIdentifier

--- a/network/crl.go
+++ b/network/crl.go
@@ -478,7 +478,7 @@ func (v DefaultCRLVerifier) Verify(rawCerts [][]byte, verifiedChains [][]*x509.C
 		if len(chain) == 0 {
 			switch v.Config.ClientAuthType {
 			case tls.NoClientCert, tls.RequestClientCert, tls.RequireAnyClientCert:
-				log.Infoln("OCSP: Empty verified certificates chain, nothing to do")
+				log.Infoln("CRL: Empty verified certificates chain, nothing to do")
 				return nil
 			default: // tls.VerifyClientCertIfGiven, tls.RequireAndVerifyClientCert
 				return ErrEmptyCertChain
@@ -495,7 +495,7 @@ func (v DefaultCRLVerifier) Verify(rawCerts [][]byte, verifiedChains [][]*x509.C
 			cert := chain[i]
 			issuer := chain[i+1]
 
-			// 3rd argument, useConfigURL, whether to use OCSP server URL from configuration (if set),
+			// 3rd argument, useConfigURL, whether to use CRL URL from configuration (if set),
 			// don't use it for other certificates except end one (i.e. don't use it when checking intermediate
 			// certificates because v.Config.checkOnlyLeafCertificate == false)
 			err := v.verifyCertWithIssuer(cert, issuer, i == 0)

--- a/network/ocsp.go
+++ b/network/ocsp.go
@@ -30,12 +30,12 @@ import (
 	"time"
 )
 
-// Errors returned by CRL verifier
+// Errors returned by OCSP verifier
 var (
 	ErrInvalidConfigOCSPRequired   = errors.New("invalid `ocsp_required` value")
 	ErrInvalidConfigOCSPFromCert   = errors.New("invalid `ocsp_from_cert` value")
-	ErrInvalidConfigAllRequiresURL = errors.New("when passing `--tls_ocsp_required=all`, URL is mandatory")
-	ErrOCSPRequiredAllButGotError  = errors.New("cannot query OCSP server, but --tls_ocsp_required=all was passed")
+	ErrInvalidConfigAllRequiresURL = errors.New("when passing `--tls_ocsp_required=" + OcspRequiredGoodStr + "`, URL is mandatory")
+	ErrOCSPRequiredAllButGotError  = errors.New("cannot query OCSP server, but --tls_ocsp_required=" + OcspRequiredGoodStr + " was passed")
 	ErrOCSPUnknownCertificate      = errors.New("OCSP server doesn't know about certificate")
 	ErrOCSPNoConfirms              = errors.New("none of OCSP servers confirmed the certificate")
 )

--- a/network/ocsp.go
+++ b/network/ocsp.go
@@ -236,7 +236,7 @@ func (c DefaultOCSPClient) Query(commonName string, clientCert, issuerCert *x509
 	if err != nil {
 		return nil, err
 	}
-	ocspResponse, err := ocsp.ParseResponse(output, issuerCert)
+	ocspResponse, err := ocsp.ParseResponseForCert(output, clientCert, issuerCert)
 	return ocspResponse, err
 }
 

--- a/network/ocsp_test.go
+++ b/network/ocsp_test.go
@@ -25,8 +25,10 @@ import (
 	"fmt"
 	"golang.org/x/crypto/ocsp"
 	"io/ioutil"
+	"math/big"
 	"net/http"
 	"path"
+	"strings"
 	"testing"
 	"time"
 )
@@ -82,6 +84,8 @@ type ocspServerConfig struct {
 	responderKey crypto.Signer
 	// List of known certificates
 	testCases []*ocspTestCase
+	// Whether to respond with serial different from what we were asked about
+	respondWithWrongSerial bool
 }
 
 func getTestOCSPServer(t *testing.T, config ocspServerConfig) (*http.Server, string) {
@@ -125,6 +129,10 @@ func getTestOCSPServer(t *testing.T, config ocspServerConfig) (*http.Server, str
 			Status:       ocsp.Unknown,
 			SerialNumber: ocspRequest.SerialNumber,
 			IssuerHash:   crypto.SHA256,
+		}
+
+		if config.respondWithWrongSerial {
+			template.SerialNumber.Xor(ocspRequest.SerialNumber, big.NewInt(1))
 		}
 
 		// TODO check whether ocspRequest.IssuerKeyHash matches config.issuerCert.PublicKey somehow,
@@ -253,17 +261,25 @@ func TestOCSPConfig(t *testing.T) {
 	expectErr("", OcspRequiredGoodStr, "invalid value", false)
 }
 
-func testDefaultOCSPClientWithGroup(t *testing.T, certGroup TestCertGroup) {
+func getIssuerForTestChain(t *testing.T, verifiedChains [][]*x509.Certificate) *x509.Certificate {
+	var issuer *x509.Certificate
+	if len(verifiedChains[0]) > 1 {
+		issuer = verifiedChains[0][1]
+	} else {
+		issuer = verifiedChains[0][0]
+		if issuer.CheckSignatureFrom(issuer) != nil {
+			t.Logf("serial: %v, subject: %v\n", issuer.SerialNumber, issuer.Subject.String())
+			t.Fatal("Test verified chain consists of only one certificate that is not a self-signed cert")
+		}
+	}
+	return issuer
+}
+
+func testDefaultOCSPClientWithGroupValid(t *testing.T, certGroup TestCertGroup) {
 	goodData := &ocspTestCase{
 		cert:           certGroup.validVerifiedChains[0][0],
-		issuer:         certGroup.validVerifiedChains[0][1],
+		issuer:         getIssuerForTestChain(t, certGroup.validVerifiedChains),
 		expectedStatus: ocsp.Good,
-	}
-
-	revokedData := &ocspTestCase{
-		cert:           certGroup.invalidVerifiedChains[0][0],
-		issuer:         certGroup.invalidVerifiedChains[0][1],
-		expectedStatus: ocsp.Revoked,
 	}
 
 	ocspCertificate, ocspSigningKey := getTestOCSPCertAndKey(t, certGroup.prefix, certGroup.ocspCert, certGroup.ocspKey)
@@ -272,10 +288,7 @@ func testDefaultOCSPClientWithGroup(t *testing.T, certGroup TestCertGroup) {
 		issuerCert:    goodData.issuer,
 		responderCert: ocspCertificate,
 		responderKey:  ocspSigningKey,
-		testCases: []*ocspTestCase{
-			goodData,
-			revokedData,
-		},
+		testCases:     []*ocspTestCase{goodData},
 	}
 
 	ocspServer, addr := getTestOCSPServer(t, ocspServerConfig)
@@ -302,14 +315,100 @@ func testDefaultOCSPClientWithGroup(t *testing.T, certGroup TestCertGroup) {
 
 	// Test with valid certificate
 	checkCase(t, goodData)
+}
+
+func testDefaultOCSPClientWithGroupRevoked(t *testing.T, certGroup TestCertGroup) {
+	revokedData := &ocspTestCase{
+		cert:           certGroup.invalidVerifiedChains[0][0],
+		issuer:         getIssuerForTestChain(t, certGroup.invalidVerifiedChains),
+		expectedStatus: ocsp.Revoked,
+	}
+
+	ocspCertificate, ocspSigningKey := getTestOCSPCertAndKey(t, certGroup.prefix, certGroup.ocspCert, certGroup.ocspKey)
+
+	ocspServerConfig := ocspServerConfig{
+		issuerCert:    revokedData.issuer,
+		responderCert: ocspCertificate,
+		responderKey:  ocspSigningKey,
+		testCases:     []*ocspTestCase{revokedData},
+	}
+
+	ocspServer, addr := getTestOCSPServer(t, ocspServerConfig)
+	defer ocspServer.Close()
+
+	ocspClient := NewDefaultOCSPClient()
+
+	url := fmt.Sprintf("http://%s", addr)
+
+	checkCase := func(t *testing.T, data *ocspTestCase) {
+		ocspResponse, err := ocspClient.Query(data.cert.Subject.CommonName, data.cert, ocspServerConfig.issuerCert, url)
+		if err != nil {
+			t.Fatalf("Unexpected error during reading %s: %v\n", url, err)
+		}
+
+		if data.cert.SerialNumber.Cmp(ocspResponse.SerialNumber) != 0 {
+			t.Fatalf("OCSPClient returned response with wrong certificate S/N\n")
+		}
+
+		if ocspResponse.Status != data.expectedStatus {
+			t.Fatalf("Expected status %d, received %d\n", data.expectedStatus, ocspResponse.Status)
+		}
+	}
 
 	// Test with revoked certificate
 	checkCase(t, revokedData)
 }
 
+func testDefaultOCSPClientWrongResponse(t *testing.T, certGroup TestCertGroup) {
+	revokedData := &ocspTestCase{
+		cert:           certGroup.invalidVerifiedChains[0][0],
+		issuer:         getIssuerForTestChain(t, certGroup.invalidVerifiedChains),
+		expectedStatus: ocsp.Revoked,
+	}
+
+	ocspCertificate, ocspSigningKey := getTestOCSPCertAndKey(t, certGroup.prefix, certGroup.ocspCert, certGroup.ocspKey)
+
+	ocspServerConfig := ocspServerConfig{
+		issuerCert:             revokedData.issuer,
+		responderCert:          ocspCertificate,
+		responderKey:           ocspSigningKey,
+		testCases:              []*ocspTestCase{revokedData},
+		respondWithWrongSerial: true,
+	}
+
+	ocspServer, addr := getTestOCSPServer(t, ocspServerConfig)
+	defer ocspServer.Close()
+
+	ocspClient := NewDefaultOCSPClient()
+
+	url := fmt.Sprintf("http://%s", addr)
+
+	checkCase := func(t *testing.T, data *ocspTestCase) {
+		ocspResponse, err := ocspClient.Query(data.cert.Subject.CommonName, data.cert, ocspServerConfig.issuerCert, url)
+		if err == nil {
+			t.Logf("OCSP response: %v\n", ocspResponse)
+			t.Fatalf("Unexpected success during reading response with wrong serial\n")
+		}
+
+		if !strings.Contains(err.Error(), "no response matching the supplied certificate") {
+			t.Fatalf("Expected \"no response matching the supplied certificate\", got %v\n", err)
+		}
+	}
+
+	// Test with revoked certificate, but OCSP server will respond with different serial, gotta catch this as error
+	checkCase(t, revokedData)
+}
+
+func testDefaultOCSPClientWithGroup(t *testing.T, certGroup TestCertGroup) {
+	testDefaultOCSPClientWithGroupValid(t, certGroup)
+	testDefaultOCSPClientWithGroupRevoked(t, certGroup)
+}
+
 func TestDefaultOCSPClient(t *testing.T) {
 	testDefaultOCSPClientWithGroup(t, getTestCertGroup(t))
 	testDefaultOCSPClientWithGroup(t, getTestCertGroup3(t))
+	testDefaultOCSPClientWithGroup(t, getTestCertGroupOnlyRoot(t))
+	testDefaultOCSPClientWrongResponse(t, getTestCertGroup(t))
 }
 
 func testWithConfigAndValidChain(t *testing.T, ocspConfig *OCSPConfig, rawCerts [][]byte, verifiedChains [][]*x509.Certificate) {
@@ -340,20 +439,9 @@ func testWithConfigAndRevokedChain(t *testing.T, ocspConfig *OCSPConfig, rawCert
 }
 
 func testDefaultOCSPVerifierWithGroupValid(t *testing.T, certGroup TestCertGroup) {
-	var issuer *x509.Certificate
-	if len(certGroup.validVerifiedChains[0]) > 1 {
-		issuer = certGroup.validVerifiedChains[0][1]
-	} else {
-		issuer = certGroup.validVerifiedChains[0][0]
-		if issuer.CheckSignatureFrom(issuer) != nil {
-			t.Logf("serial: %v, subject: %v\n", issuer.SerialNumber, issuer.Subject.String())
-			t.Fatal("Test verified chain consists of only one certificate that is not a self-signed cert")
-		}
-	}
-
 	goodData := &ocspTestCase{
 		cert:           certGroup.validVerifiedChains[0][0],
-		issuer:         issuer,
+		issuer:         getIssuerForTestChain(t, certGroup.validVerifiedChains),
 		expectedStatus: ocsp.Good,
 	}
 
@@ -399,20 +487,9 @@ func testDefaultOCSPVerifierWithGroupValid(t *testing.T, certGroup TestCertGroup
 }
 
 func testDefaultOCSPVerifierWithGroupRevoked(t *testing.T, certGroup TestCertGroup) {
-	var issuer *x509.Certificate
-	if len(certGroup.invalidVerifiedChains[0]) > 1 {
-		issuer = certGroup.invalidVerifiedChains[0][1]
-	} else {
-		issuer = certGroup.invalidVerifiedChains[0][0]
-		if issuer.CheckSignatureFrom(issuer) != nil {
-			t.Logf("serial: %v, subject: %v\n", issuer.SerialNumber, issuer.Subject.String())
-			t.Fatal("Test verified chain consists of only one certificate that is not a self-signed cert")
-		}
-	}
-
 	revokedData := &ocspTestCase{
 		cert:           certGroup.invalidVerifiedChains[0][0],
-		issuer:         issuer,
+		issuer:         getIssuerForTestChain(t, certGroup.invalidVerifiedChains),
 		expectedStatus: ocsp.Revoked,
 	}
 


### PR DESCRIPTION
Additional unit tests for better coverage of OCSP client & verifier behavior.

Small bugfix where OCSPClient did not check whether response was related to asked certificate, now it will return error if mismatched.