### PR TITLE
add missing parameter --client_id according to same file without zone mode

### DIFF
--- a/docker/docker-compose.mysql-nossl-server-ssl-connector_zonemode.yml
+++ b/docker/docker-compose.mysql-nossl-server-ssl-connector_zonemode.yml
@@ -110,6 +110,7 @@ services:
             --db_host=mysql
             --db_port=3306
             --keys_dir=/keys
+            --client_id=${ACRA_CLIENT_ID:-testclientid}
             --auth_keys=/keys/httpauth.accounts
             --http_api_enable
             --incoming_connection_api_string=tcp://0.0.0.0:9090

--- a/docker/docker-compose.pgsql-ssl-server-ssl-connector_zonemode.yml
+++ b/docker/docker-compose.pgsql-ssl-server-ssl-connector_zonemode.yml
@@ -111,6 +111,7 @@ services:
             --zonemode_enable
             --db_host=postgresql
             --keys_dir=/keys
+            --client_id=${ACRA_CLIENT_ID:-testclientid}
             --auth_keys=/keys/httpauth.accounts
             --http_api_enable
             --incoming_connection_api_string=tcp://0.0.0.0:9090


### PR DESCRIPTION
has run all docker-compose files and tried to connect to be sure that acra-server/acra-connector up and accept connections, and found 2 files with missing parameter that fail hinders acra-server startup.

<!-- Describe your changes here -->

## Checklist

- [+] Change is covered by automated tests
- [+] The [coding guidelines] are followed
- [+] Public API has proper documentation in the [Acra documentation] site or has PR on [documentation repository] 
  with new changes
- [+] CHANGELOG.md is updated (in case of notable or breaking changes)
- [+] CHANGELOG_DEV.md is updated
- [+] Benchmark results are attached (if applicable)
- [+] [Example projects and code samples] are up-to-date (in case of API changes) 

[coding guidelines]: https://golang.org/doc/effective_go
[Example projects and code samples]: https://github.com/cossacklabs/acra-engineering-demo
[Acra documentation]: https://docs.cossacklabs.com/
[documentation repository]: https://github.com/cossacklabs/product-docs