### PR TITLE
zhars/fix_acra_keys_with_redis

### DIFF
--- a/cmd/acra-keys/keys/keystore.go
+++ b/cmd/acra-keys/keys/keystore.go
@@ -19,6 +19,7 @@ package keys
 import (
 	"errors"
 	"flag"
+	filesystemV2 "github.com/cossacklabs/acra/keystore/v2/keystore/filesystem"
 
 	"github.com/cossacklabs/acra/cmd"
 	"github.com/cossacklabs/acra/keystore"
@@ -27,7 +28,6 @@ import (
 	"github.com/cossacklabs/acra/keystore/keyloader/hashicorp"
 	keystoreV2 "github.com/cossacklabs/acra/keystore/v2/keystore"
 	"github.com/cossacklabs/acra/keystore/v2/keystore/api"
-	filesystemV2 "github.com/cossacklabs/acra/keystore/v2/keystore/filesystem"
 	filesystemBackendV2 "github.com/cossacklabs/acra/keystore/v2/keystore/filesystem/backend"
 
 	"github.com/go-redis/redis/v7"
@@ -119,7 +119,7 @@ func OpenKeyStoreForReading(params KeyStoreParameters) (keystore.ServerKeyStore,
 		return nil, err
 	}
 
-	if filesystemV2.IsKeyDirectory(params.KeyDir()) {
+	if IsKeyDirectory(params) {
 		return openKeyStoreV2(params, keyLoader)
 	}
 	return openKeyStoreV1(params, keyLoader)
@@ -132,7 +132,7 @@ func OpenKeyStoreForWriting(params KeyStoreParameters) (keyStore keystore.KeyMak
 		return nil, err
 	}
 
-	if filesystemV2.IsKeyDirectory(params.KeyDir()) {
+	if IsKeyDirectory(params) {
 		return openKeyStoreV2(params, keyLoader)
 	}
 	return openKeyStoreV1(params, keyLoader)
@@ -145,7 +145,7 @@ func OpenKeyStoreForExport(params KeyStoreParameters) (api.KeyStore, error) {
 		return nil, err
 	}
 
-	if filesystemV2.IsKeyDirectory(params.KeyDir()) {
+	if IsKeyDirectory(params) {
 		return openKeyStoreV2(params, keyLoader)
 	}
 	// Export from keystore v1 is not supported right now
@@ -159,7 +159,7 @@ func OpenKeyStoreForImport(params KeyStoreParameters) (api.MutableKeyStore, erro
 		return nil, err
 	}
 
-	if filesystemV2.IsKeyDirectory(params.KeyDir()) {
+	if IsKeyDirectory(params) {
 		return openKeyStoreV2(params, keyLoader)
 	}
 	// Export from keystore v1 is not supported right now
@@ -244,4 +244,28 @@ func openKeyStoreV2(params KeyStoreParameters, loader keyloader.MasterKeyLoader)
 		return nil, err
 	}
 	return keystoreV2.NewServerKeyStore(keyDirectory), nil
+}
+
+// IsKeyDirectory checks if the directory contains a keystore version 2 from KeyStoreParameters
+func IsKeyDirectory(params KeyStoreParameters) bool {
+	redisOption := params.RedisOptions()
+	if params.RedisConfigured() {
+		redisClient, err := filesystemBackendV2.OpenRedisBackend(&filesystemBackendV2.RedisConfig{
+			RootDir: params.KeyDir(),
+			Options: &redis.Options{
+				Addr:     redisOption.Addr,
+				Password: redisOption.Password,
+				DB:       redisOption.DB,
+			},
+		})
+		if err != nil {
+			log.WithError(err).Debug("Failed to find keystore v2 in Redis")
+			return false
+		}
+		// If the keystore has been opened successfully, it definitely exists.
+		redisClient.Close()
+		return true
+	}
+	// Otherwise, check the local filesystem storage provided by Acra CE.
+	return filesystemBackendV2.CheckDirectoryVersion(params.KeyDir()) == nil
 }

--- a/cmd/acra-keys/keys/read-keys_test.go
+++ b/cmd/acra-keys/keys/read-keys_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2020, Cossack Labs Limited
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package keys
+
+import (
+	"encoding/base64"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	keystoreV2 "github.com/cossacklabs/acra/keystore/v2/keystore"
+
+	"github.com/cossacklabs/acra/cmd"
+	"github.com/cossacklabs/acra/keystore"
+	"github.com/cossacklabs/acra/keystore/keyloader"
+	"github.com/cossacklabs/acra/pseudonymization/storage"
+)
+
+func TestReadCMD_Redis_V2(t *testing.T) {
+	client, err := storage.NewRedisClient("127.0.0.1:6379", "", 0, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.FlushAll()
+
+	clientID := []byte("testclientid")
+	keyLoader := keyloader.NewEnvLoader(keystore.AcraMasterKeyVarName)
+
+	masterKey, err := keystoreV2.NewSerializedMasterKeys()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	os.Setenv(keystore.AcraMasterKeyVarName, base64.StdEncoding.EncodeToString(masterKey))
+
+	readCmd := &ReadKeySubcommand{
+		CommonKeyStoreParameters: CommonKeyStoreParameters{
+			redisOptions: cmd.RedisOptions{
+				HostPort: "127.0.0.1:6379",
+			},
+		},
+		contextID:   clientID,
+		readKeyKind: KeyStoragePublic,
+	}
+
+	store, err := openKeyStoreV2(readCmd, keyLoader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = store.GenerateDataEncryptionKeys(clientID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	readCmd.Execute()
+}
+
+func TestReadCMD_Redis_V1(t *testing.T) {
+	client, err := storage.NewRedisClient("127.0.0.1:6379", "", 0, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.FlushAll()
+
+	clientID := []byte("testclientid")
+	keyLoader := keyloader.NewEnvLoader(keystore.AcraMasterKeyVarName)
+
+	masterKey, err := keystore.GenerateSymmetricKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	os.Setenv(keystore.AcraMasterKeyVarName, base64.StdEncoding.EncodeToString(masterKey))
+
+	dirName, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dirName)
+
+	readCmd := &ReadKeySubcommand{
+		CommonKeyStoreParameters: CommonKeyStoreParameters{
+			redisOptions: cmd.RedisOptions{
+				HostPort: "127.0.0.1:6379",
+			},
+			keyDir: dirName,
+		},
+		contextID:   clientID,
+		readKeyKind: KeyStoragePublic,
+	}
+
+	store, err := openKeyStoreV1(readCmd, keyLoader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = store.GenerateDataEncryptionKeys(clientID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	readCmd.Execute()
+}


### PR DESCRIPTION
Fixed `acra-keys` read command to Redis communication. Previously it was used global var redisOption from keystore package to check passed redis parameters, but all `acra-keys` commands have its own RedisOption object, locally stored inside struct, so new function `IsKeyDirectory` was introduced which get RedisOptions from KeyStoreParameters interface.

## Checklist

- [ ] Change is covered by automated tests
- [ ] The [coding guidelines] are followed
- [ ] Public API has proper documentation in the [Acra documentation] site or has PR on [documentation repository] 
  with new changes
- [ ] CHANGELOG.md is updated (in case of notable or breaking changes)
- [ ] CHANGELOG_DEV.md is updated
- [ ] Benchmark results are attached (if applicable)
- [ ] [Example projects and code samples] are up-to-date (in case of API changes) 

[coding guidelines]: https://golang.org/doc/effective_go
[Example projects and code samples]: https://github.com/cossacklabs/acra-engineering-demo
[Acra documentation]: https://docs.cossacklabs.com/
[documentation repository]: https://github.com/cossacklabs/product-docs