### PR TITLE
[T2316] fix flaky acra-censor's tests

### DIFF
--- a/.circleci/integration.sh
+++ b/.circleci/integration.sh
@@ -49,9 +49,8 @@ for go_version in $GO_VERSIONS; do
     export TEST_CONNECTOR_PORT=$(expr ${TEST_CONNECTOR_PORT} + 1);
     export TEST_CONNECTOR_COMMAND_PORT=$(expr ${TEST_CONNECTOR_COMMAND_PORT} + 1);
 
-    # remove built packages with another golang version and force to rebuild
-    go clean -i -cache -testcache | true
-    go mod download
+    # download dependencies
+    go mod tidy
 
 
     echo "-------------------- Testing with TEST_TLS=${TEST_TLS}"

--- a/CHANGELOG_DEV.md
+++ b/CHANGELOG_DEV.md
@@ -1,3 +1,12 @@
+## 0.91.0 - 2021-11-25
+### Changed
+- `acra-censor's` query writer now can track amount of skipped queries and allows configuration of serialization 
+  frequency for tests. Fixed flaky tests related to not flushed data to a file before read.
+- Reduced time of tests by:
+  - removing redundant cache deletion 
+  - building base docker image with pre-downloaded golang dependencies
+  - increasing serialization frequency and decreasing `time.Sleep` time in `acra-censor's` tests
+
 ## 0.91.0 - 2021-11-12
 ### Removed
 - `acra-webconfig` package, related dockerfiles, updated docker-compose files.

--- a/docker/ci-py-go-themis.dockerfile
+++ b/docker/ci-py-go-themis.dockerfile
@@ -33,6 +33,7 @@ RUN set -o pipefail && \
 RUN mkdir /image.scripts
 COPY docker/_scripts/acra-build/install_go.sh /image.scripts/
 COPY docker/_scripts/acra-build/install_go.csums /image.scripts/
+COPY go.mod /image.scripts/
 RUN chmod +x /image.scripts/*.sh
 
 # Install Go
@@ -61,6 +62,9 @@ ENV PATH="$GOROOT/bin:/home/user/gopath/bin:/home/user/.local/bin:$PATH"
 RUN go get -u -v golang.org/x/lint/golint && \
     go get -u -v github.com/client9/misspell/cmd/misspell && \
     go get -u -v github.com/gordonklaus/ineffassign
+
+# download dependencies to avoid next downloads in tests
+RUN cp /image.scripts/go.mod . && go mod download && rm go.mod go.sum
 
 # Install Python tests dependencies
 


### PR DESCRIPTION
* Added `file.Sync` calls in tests before reading files to be sure that all data dumped
* A bit refactored `QueryWriter`'s time constants and changed them to variables. Now we can change them in our tests to reduce time of waiting (decreased from 6s to ~1s)
* Removed some cache deletion in our scripts. I checked that golang take care of invalidation result binaries with different golang versions. It detects that binary has been built by another compiler and rebuild it if need. 
* Added downloading golang sources of dependencies to our base docker image to reduce time of tests on CircleCi (and local too)


## Checklist

- [x] Change is covered by automated tests
- [x] The [coding guidelines] are followed
- [x] Public API has proper documentation in the [Acra documentation] site or has PR on [documentation repository] 
  with new changes
- [x] CHANGELOG.md is updated (in case of notable or breaking changes)
- [x] CHANGELOG_DEV.md is updated
- [x] Benchmark results are attached (if applicable)
- [x] [Example projects and code samples] are up-to-date (in case of API changes) 

[coding guidelines]: https://golang.org/doc/effective_go
[Example projects and code samples]: https://github.com/cossacklabs/acra-engineering-demo
[Acra documentation]: https://docs.cossacklabs.com/
[documentation repository]: https://github.com/cossacklabs/product-docs