### PR TITLE
Remove connector variable from python examples

### DIFF
--- a/examples/python/example_with_zone.py
+++ b/examples/python/example_with_zone.py
@@ -35,7 +35,7 @@ def get_zone():
     """make http response to AcraServer api to generate new zone and return tuple
     of zone id and public key
     """
-    response = urlopen('{}/getNewZone'.format(ACRA_CONNECTOR_API_ADDRESS))
+    response = urlopen('{}/getNewZone'.format(ACRA_SERVER_API_ADDRESS))
     json_data = response.read().decode('utf-8')
     zone_data = json.loads(json_data)
     return zone_data['id'], b64decode(zone_data['public_key'])
@@ -129,8 +129,8 @@ if __name__ == '__main__':
                         help="Use mysql driver")
     args = parser.parse_args()
 
-    ACRA_CONNECTOR_API_ADDRESS = get_default(
-        'acra_connector_api_address', 'http://127.0.0.1:9191')
+    ACRA_SERVER_API_ADDRESS = get_default(
+        'acra_server_api_address', 'http://127.0.0.1:9191')
     # default driver
     driver = 'postgresql'
     ssl_args = {

--- a/examples/python/extended_example_with_zone.py
+++ b/examples/python/extended_example_with_zone.py
@@ -48,7 +48,7 @@ def get_zone():
     """make http response to AcraServer api to generate new zone and return tuple
     of zone id and public key
     """
-    response = urlopen('{}/getNewZone'.format(ACRA_CONNECTOR_API_ADDRESS))
+    response = urlopen('{}/getNewZone'.format(ACRA_SERVER_API_ADDRESS))
     json_data = response.read().decode('utf-8')
     zone_data = json.loads(json_data)
     return zone_data['id'], zone_data['public_key']
@@ -162,8 +162,8 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
 
-    ACRA_CONNECTOR_API_ADDRESS = get_default(
-        'acra_connector_api_address', 'http://127.0.0.1:9191')
+    ACRA_SERVER_API_ADDRESS = get_default(
+        'acra_server_api_address', 'http://127.0.0.1:9191')
     # default driver
     driver = 'postgresql'
     ssl_args = {


### PR DESCRIPTION
Removed `acra-connector` related variable from python examples

## Checklist

- [x] Change is covered by automated tests
- [x] The [coding guidelines] are followed
- [x] Public API has proper documentation in the [Acra documentation] site or has PR on [documentation repository] 
  with new changes
- [x] CHANGELOG.md is updated (in case of notable or breaking changes)
- [x] CHANGELOG_DEV.md is updated
- [x] Benchmark results are attached (if applicable)
- [x] [Example projects and code samples] are up-to-date (in case of API changes) 

[coding guidelines]: https://golang.org/doc/effective_go
[Example projects and code samples]: https://github.com/cossacklabs/acra-engineering-demo
[Acra documentation]: https://docs.cossacklabs.com/
[documentation repository]: https://github.com/cossacklabs/product-docs