### PR TITLE
Third approach to fix failure censor's test

### DIFF
--- a/acra-censor/acra-censor_test.go
+++ b/acra-censor/acra-censor_test.go
@@ -1697,7 +1697,7 @@ func waitQueryProcessing(expectedCount int, writer *common.QueryWriter, t testin
 		default:
 			break
 		}
-		if len(writer.Queries) == expectedCount {
+		if len(writer.GetQueries()) == expectedCount {
 			return
 		}
 		// give some time to process channel

--- a/acra-censor/acra-censor_test.go
+++ b/acra-censor/acra-censor_test.go
@@ -1687,11 +1687,40 @@ func TestIgnoringQueryParseErrors(t *testing.T) {
 	// check when censor with two handlers and each one will return query parse error
 	checkHandler([]QueryHandlerInterface{whitelist, blacklist}, nil)
 }
+
+func waitQueryProcessing(expectedCount int, writer *common.QueryWriter, t testing.TB) {
+	timeout := time.NewTimer(time.Second*5)
+	for {
+		select {
+		case <-timeout.C:
+			t.Fatal("Haven't waited expected amount of queries")
+		default:
+			break
+		}
+		if len(writer.Queries) == expectedCount{
+			return
+		}
+		// give some time to process channel
+		time.Sleep(common.DefaultSerializationTimeout)
+	}
+}
+
 func TestLogUnparsedQueries(t *testing.T) {
-	var err error
+	tmpFile, err := ioutil.TempFile("", "censor_log")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := os.Remove(tmpFile.Name()); err != nil {
+			t.Fatal(err)
+		}
+	}()
+	if err = tmpFile.Close(); err != nil {
+		t.Fatal(err)
+	}
 	configuration := fmt.Sprintf(`ignore_parse_error: true
 version: %s
-parse_errors_log: unparsed_queries.log
+parse_errors_log: %s
 handlers:
   - handler: deny
     queries:
@@ -1701,15 +1730,11 @@ handlers:
       - EMPLOYEE_TBL
       - Customers
     patterns:
-      - SELECT EMP_ID, LAST_NAME FROM EMPLOYEE %%%%WHERE%%%%;`, MinimalCensorConfigVersion)
+      - SELECT EMP_ID, LAST_NAME FROM EMPLOYEE %%%%WHERE%%%%;`, MinimalCensorConfigVersion, tmpFile.Name())
 
 	acraCensor := NewAcraCensor()
 	defer func() {
 		acraCensor.ReleaseAll()
-		err = os.Remove("unparsed_queries.log")
-		if err != nil {
-			t.Fatal(err)
-		}
 	}()
 	err = acraCensor.LoadConfiguration([]byte(configuration))
 	if err != nil {
@@ -1726,9 +1751,10 @@ handlers:
 			t.Fatal(err)
 		}
 	}
+	waitQueryProcessing(len(testQueries), acraCensor.unparsedQueriesWriter, t)
 	//wait until goroutine handles complex serialization
-	time.Sleep(common.DefaultSerializationTimeout + 200*time.Millisecond)
-	bufferBytes, err := ioutil.ReadFile("unparsed_queries.log")
+	time.Sleep(common.DefaultSerializationTimeout * 2)
+	bufferBytes, err := ioutil.ReadFile(tmpFile.Name())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/acra-censor/acra-censor_test.go
+++ b/acra-censor/acra-censor_test.go
@@ -1689,7 +1689,7 @@ func TestIgnoringQueryParseErrors(t *testing.T) {
 }
 
 func waitQueryProcessing(expectedCount int, writer *common.QueryWriter, t testing.TB) {
-	timeout := time.NewTimer(time.Second*5)
+	timeout := time.NewTimer(time.Second * 5)
 	for {
 		select {
 		case <-timeout.C:
@@ -1697,7 +1697,7 @@ func waitQueryProcessing(expectedCount int, writer *common.QueryWriter, t testin
 		default:
 			break
 		}
-		if len(writer.Queries) == expectedCount{
+		if len(writer.Queries) == expectedCount {
 			return
 		}
 		// give some time to process channel

--- a/acra-censor/common/file_log_storage.go
+++ b/acra-censor/common/file_log_storage.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"io"
 	"io/ioutil"
 	"os"
 	"sync"
@@ -44,9 +45,12 @@ func (storage *FileLogStorage) WriteAll(p []byte) error {
 func (storage *FileLogStorage) Append(p []byte) error {
 	storage.mutex.Lock()
 	defer storage.mutex.Unlock()
-	_, err := storage.file.Write(p)
+	n, err := storage.file.Write(p)
 	if err != nil {
 		return err
+	}
+	if n != len(p) {
+		return io.ErrShortWrite
 	}
 	return nil
 }

--- a/acra-censor/common/logging_logic.go
+++ b/acra-censor/common/logging_logic.go
@@ -233,7 +233,7 @@ func (queryWriter *QueryWriter) serializeQueries(queries []*QueryInfo) []byte {
 
 func (queryWriter *QueryWriter) captureQuery(query string) {
 	queryWriter.mutex.Lock()
-	defer func(){
+	defer func() {
 		queryWriter.mutex.Unlock()
 	}()
 	//skip already captured queries

--- a/acra-censor/common/logging_logic.go
+++ b/acra-censor/common/logging_logic.go
@@ -46,7 +46,6 @@ type QueryWriter struct {
 	logStorage           LogStorage
 	queryIndex           int
 	mutex                sync.RWMutex
-	signalBackgroundExit chan bool
 	signalWriteQuery     chan string
 	signalShutdown       chan os.Signal
 	serializationTimeout time.Duration
@@ -64,7 +63,6 @@ func NewFileQueryWriter(filePath string) (*QueryWriter, error) {
 		serializationTimeout: DefaultSerializationTimeout,
 		serializationTicker:  time.NewTicker(DefaultSerializationTimeout),
 		logger:               log.WithField("internal_object", "querywriter"),
-		signalBackgroundExit: make(chan bool),
 		signalWriteQuery:     make(chan string, DefaultWriteQueryChannelSize),
 		signalShutdown:       make(chan os.Signal, 2),
 	}
@@ -101,21 +99,21 @@ func (queryWriter *QueryWriter) WalkQueries(visitor func(query *QueryInfo) error
 
 // DumpQueries writes all queries into file
 func (queryWriter *QueryWriter) DumpQueries() error {
-	queryWriter.mutex.RLock()
+	queryWriter.mutex.Lock()
+	defer queryWriter.mutex.Unlock()
 	rawData := queryWriter.serializeQueries(queryWriter.Queries)
-	queryWriter.mutex.RUnlock()
+
 	if err := queryWriter.logStorage.WriteAll(rawData); err != nil {
 		queryWriter.logger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCensorIOError).Errorln("Can't dump queries to storage")
 		return err
 	}
+	queryWriter.queryIndex = len(queryWriter.Queries)
 	return nil
 }
 
-// Free dumps all Captured queries to file and resets captured queries list
+// Free dumps all Captured queries to file, and stops background processing. QueryWriter mustn't be used after that
 func (queryWriter *QueryWriter) Free() {
-	queryWriter.DumpQueries()
-	queryWriter.signalBackgroundExit <- true
-	queryWriter.reset()
+	queryWriter.signalShutdown <- os.Interrupt
 }
 
 // Start starts background logging of input queries. Should be called in separate goroutine
@@ -130,24 +128,17 @@ func (queryWriter *QueryWriter) Start() {
 			if err != nil {
 				queryWriter.logger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCensorIOError).Errorln("Can't dump buffered queries")
 			}
-			queryWriter.serializationTicker.Stop()
-			queryWriter.serializationTicker = time.NewTicker(queryWriter.serializationTimeout)
 			break
-		case <-queryWriter.signalBackgroundExit:
-			queryWriter.serializationTicker.Stop()
-			queryWriter.DumpQueries()
-			err := queryWriter.logStorage.Close()
-			if err != nil {
-				queryWriter.logger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCensorIOError).Errorln("Error occurred on exit QueryWriter instance")
-			}
-			return
 		case <-queryWriter.signalShutdown:
 			queryWriter.serializationTicker.Stop()
-			queryWriter.DumpQueries()
+			if err := queryWriter.DumpQueries(); err != nil {
+				queryWriter.logger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCensorIOError).Errorln("Error occurred on DumpQueries")
+			}
 			err := queryWriter.logStorage.Close()
 			if err != nil {
 				queryWriter.logger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCensorIOError).Errorln("Error occurred on shutdown QueryWriter instance")
 			}
+			queryWriter.reset()
 			return
 		default:
 			//do nothing. This means that channel has no data to read yet
@@ -188,8 +179,8 @@ func (queryWriter *QueryWriter) readStoredQueries() error {
 }
 
 func (queryWriter *QueryWriter) dumpBufferedQueries() error {
-	queryWriter.mutex.RLock()
-	defer queryWriter.mutex.RUnlock()
+	queryWriter.mutex.Lock()
+	defer queryWriter.mutex.Unlock()
 
 	if len(queryWriter.Queries) != 0 {
 		partialRawData := queryWriter.serializeQueries(queryWriter.Queries[queryWriter.queryIndex:])
@@ -242,7 +233,9 @@ func (queryWriter *QueryWriter) serializeQueries(queries []*QueryInfo) []byte {
 
 func (queryWriter *QueryWriter) captureQuery(query string) {
 	queryWriter.mutex.Lock()
-	defer queryWriter.mutex.Unlock()
+	defer func(){
+		queryWriter.mutex.Unlock()
+	}()
 	//skip already captured queries
 	for _, queryInfo := range queryWriter.Queries {
 		if strings.EqualFold(queryInfo.RawQuery, query) {

--- a/acra-censor/common/logging_logic.go
+++ b/acra-censor/common/logging_logic.go
@@ -85,6 +85,14 @@ func NewFileQueryWriter(filePath string) (*QueryWriter, error) {
 	return writer, nil
 }
 
+// GetQueries return cached queries
+func (queryWriter *QueryWriter) GetQueries() []*QueryInfo {
+	queryWriter.mutex.RLock()
+	result := queryWriter.Queries
+	queryWriter.mutex.RUnlock()
+	return result
+}
+
 // WalkQueries walks through each query and perform some action on it
 func (queryWriter *QueryWriter) WalkQueries(visitor func(query *QueryInfo) error) error {
 	queryWriter.mutex.RLock()
@@ -233,9 +241,8 @@ func (queryWriter *QueryWriter) serializeQueries(queries []*QueryInfo) []byte {
 
 func (queryWriter *QueryWriter) captureQuery(query string) {
 	queryWriter.mutex.Lock()
-	defer func() {
-		queryWriter.mutex.Unlock()
-	}()
+	defer queryWriter.mutex.Unlock()
+
 	//skip already captured queries
 	for _, queryInfo := range queryWriter.Queries {
 		if strings.EqualFold(queryInfo.RawQuery, query) {

--- a/acra-censor/common/logging_logic_test.go
+++ b/acra-censor/common/logging_logic_test.go
@@ -431,6 +431,9 @@ func TestConcurrentQueryWrite(t *testing.T) {
 		t.Log(lines)
 		t.Fatalf("Incorrect amount of queries, %v != %v\n", len(lines), expectedCount)
 	}
+	if lines[len(lines)-1] != "" {
+		t.Fatal("Incorrect last line")
+	}
 }
 
 func waitQueryProcessing(expectedCount int, writer *QueryWriter, t testing.TB) {

--- a/acra-censor/common/logging_logic_test.go
+++ b/acra-censor/common/logging_logic_test.go
@@ -445,7 +445,7 @@ func waitQueryProcessing(expectedCount int, writer *QueryWriter, t testing.TB) {
 		default:
 			break
 		}
-		if len(writer.Queries) == expectedCount {
+		if len(writer.GetQueries()) == expectedCount {
 			return
 		}
 		// give some time to process channel

--- a/acra-censor/common/logging_logic_test.go
+++ b/acra-censor/common/logging_logic_test.go
@@ -70,7 +70,7 @@ func TestSerializationOnUniqueQueries(t *testing.T) {
 		writer.captureQuery(queryWithHiddenValues)
 	}
 	// wait serializationTicker and dumpBufferedQueries call
-	time.Sleep(DefaultSerializationTimeout+extraWaitTime)
+	time.Sleep(DefaultSerializationTimeout + extraWaitTime)
 	if len(writer.Queries) != len(testQueries) {
 		t.Fatal("Expected: " + strings.Join(testQueries, " | ") + "\nGot: " + strings.Join(rawStrings(writer.Queries), " | "))
 	}
@@ -198,7 +198,7 @@ func TestSerializationOnSameQueries(t *testing.T) {
 		writer.captureQuery(queryWithHiddenValues)
 	}
 	// wait serializationTicker and dumpBufferedQueries call
-	time.Sleep(DefaultSerializationTimeout+extraWaitTime)
+	time.Sleep(DefaultSerializationTimeout + extraWaitTime)
 	if len(writer.Queries) != numOfUniqueQueries {
 		t.Fatal("Expected to have " + fmt.Sprint(numOfUniqueQueries) + " unique queries. \n Got:" + strings.Join(rawStrings(writer.Queries), " | "))
 	}
@@ -263,7 +263,7 @@ func TestQueryCaptureOnDuplicates(t *testing.T) {
 		t.Fatal("Detected unexpected skipping queries")
 	}
 	// wait serializationTicker and dumpBufferedQueries call
-	time.Sleep(DefaultSerializationTimeout+extraWaitTime)
+	time.Sleep(DefaultSerializationTimeout + extraWaitTime)
 
 	result, err := ioutil.ReadFile(tmpFile.Name())
 	if err != nil {
@@ -282,7 +282,7 @@ func TestQueryCaptureOnDuplicates(t *testing.T) {
 		t.Fatal("Detected unexpected skipping queries")
 	}
 	// wait serializationTicker and dumpBufferedQueries call
-	time.Sleep(DefaultSerializationTimeout+extraWaitTime)
+	time.Sleep(DefaultSerializationTimeout + extraWaitTime)
 
 	result, err = ioutil.ReadFile(tmpFile.Name())
 	if err != nil {
@@ -300,7 +300,7 @@ func TestQueryCaptureOnDuplicates(t *testing.T) {
 	}
 	//wait until serialization completes
 	// wait serializationTicker and dumpBufferedQueries call
-	time.Sleep(DefaultSerializationTimeout+extraWaitTime)
+	time.Sleep(DefaultSerializationTimeout + extraWaitTime)
 	result, err = ioutil.ReadFile(tmpFile.Name())
 	if err != nil {
 		t.Fatal(err)
@@ -405,7 +405,7 @@ func TestConcurrentQueryWrite(t *testing.T) {
 		t.Fatal("Detected unexpected skipping queries")
 	}
 	// wait when background goroutine dump all queries to the file
-	time.Sleep(DefaultSerializationTimeout+extraWaitTime)
+	time.Sleep(DefaultSerializationTimeout + extraWaitTime)
 	if err := writer.dumpBufferedQueries(); err != nil {
 		t.Fatal(err)
 	}

--- a/acra-censor/common/logging_logic_test.go
+++ b/acra-censor/common/logging_logic_test.go
@@ -437,7 +437,7 @@ func TestConcurrentQueryWrite(t *testing.T) {
 }
 
 func waitQueryProcessing(expectedCount int, writer *QueryWriter, t testing.TB) {
-	timeout := time.NewTimer(time.Second*5)
+	timeout := time.NewTimer(time.Second * 5)
 	for {
 		select {
 		case <-timeout.C:
@@ -445,7 +445,7 @@ func waitQueryProcessing(expectedCount int, writer *QueryWriter, t testing.TB) {
 		default:
 			break
 		}
-		if len(writer.Queries) == expectedCount{
+		if len(writer.Queries) == expectedCount {
 			return
 		}
 		// give some time to process channel

--- a/cmd/acra-translator/http_api/service.go
+++ b/cmd/acra-translator/http_api/service.go
@@ -393,6 +393,7 @@ func callOperationImplementation(ctx *gin.Context, f func(*gin.Context, []byte) 
 		RespondWithError(ctx, NewHTTPError(http.StatusBadRequest, "invalid request body"))
 		return
 	}
+	defer ctx.Request.Body.Close()
 	response, httpErr := f(ctx, data)
 	if !httpErr.Empty() {
 		RespondWithError(ctx, httpErr)

--- a/network/connection_wrapper_test.go
+++ b/network/connection_wrapper_test.go
@@ -82,7 +82,6 @@ func testWrapper(clientWrapper, serverWrapper ConnectionWrapper, expectedClientI
 	testWrapperWithSpecifiedProtocol(tcpListener, tcpConnection, clientWrapper, serverWrapper, expectedClientID, iterations, onError, t)
 }
 
-
 func testWrapperWithError(clientWrapper, serverWrapper ConnectionWrapper, expectedClientID []byte, iterations int, onError func(error, testing.TB), t testing.TB) {
 	unixListener, unixConnection := getUnixListenerAndConnection(t)
 	testWrapperWithSpecifiedProtocol(unixListener, unixConnection, clientWrapper, serverWrapper, expectedClientID, iterations, onError, t)

--- a/network/connection_wrapper_test.go
+++ b/network/connection_wrapper_test.go
@@ -22,41 +22,82 @@ import (
 	"errors"
 	"github.com/cossacklabs/acra/keystore"
 	"io/ioutil"
+	math_rand "math/rand"
 	"net"
 	"os"
 	"testing"
+	"time"
 )
 
 // wrapperCommunicationIterations base iterations count which may be used in a communication loop using client/server wrappers
 const wrapperCommunicationIterations = 10
 
+func getUnixListenerAndConnection(t testing.TB) (net.Listener, net.Conn) {
+	f, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = os.Remove(f.Name()); err != nil {
+		t.Fatal(err)
+	}
+	socket := f.Name()
+	listener, err := net.Listen("unix", socket)
+	if err != nil {
+		t.Fatal(err)
+	}
+	connection, err := net.Dial("unix", socket)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		connection.Close()
+		os.Remove(f.Name())
+		listener.Close()
+	})
+	return listener, connection
+}
+
+func getTCPListenerAndConnection(t testing.TB) (net.Listener, net.Conn) {
+	listener, err := net.ListenTCP("tcp", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn, err := net.Dial("tcp", listener.Addr().String())
+	if err != nil {
+		t.Fatal()
+	}
+	t.Cleanup(func() {
+		listener.Close()
+		conn.Close()
+	})
+	return listener, conn
+}
+
 // testWrapper wrapper over testWrapperWithError with onError callback which call t.Fatal on err value
 func testWrapper(clientWrapper, serverWrapper ConnectionWrapper, expectedClientID []byte, iterations int, t testing.TB) {
 	onError := func(err error, t testing.TB) { t.Fatal(err) }
-	testWrapperWithError(clientWrapper, serverWrapper, expectedClientID, iterations, onError, t)
+	unixListener, unixConnection := getUnixListenerAndConnection(t)
+	testWrapperWithSpecifiedProtocol(unixListener, unixConnection, clientWrapper, serverWrapper, expectedClientID, iterations, onError, t)
+	tcpListener, tcpConnection := getTCPListenerAndConnection(t)
+	testWrapperWithSpecifiedProtocol(tcpListener, tcpConnection, clientWrapper, serverWrapper, expectedClientID, iterations, onError, t)
 }
 
-// testWrapperWithError create unix socket, wrap it using clientWrapper and serverWrapper, verify received clientID on server side with expected
-// and exchange some data iterations times. On any unexpected error call onError callback
+
 func testWrapperWithError(clientWrapper, serverWrapper ConnectionWrapper, expectedClientID []byte, iterations int, onError func(error, testing.TB), t testing.TB) {
-	f, err := ioutil.TempFile("", "")
-	if err != nil {
-		onError(err, t)
-	}
-	if err = os.Remove(f.Name()); err != nil {
-		onError(err, t)
-	}
-	socket := f.Name()
+	unixListener, unixConnection := getUnixListenerAndConnection(t)
+	testWrapperWithSpecifiedProtocol(unixListener, unixConnection, clientWrapper, serverWrapper, expectedClientID, iterations, onError, t)
+}
+
+// testWrapperWithSpecifiedProtocol use provided listener and connection, wrap them using clientWrapper and serverWrapper,
+// verify received clientID on server side with expected and exchange some data iterations times.
+// On any unexpected error call onError callback
+func testWrapperWithSpecifiedProtocol(listener net.Listener, connection net.Conn, clientWrapper, serverWrapper ConnectionWrapper, expectedClientID []byte, iterations int, onError func(error, testing.TB), t testing.TB) {
 	// use ctx to force background listener in goroutine wait finishing this function
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	listener, err := net.Listen("unix", socket)
-	if err != nil {
-		onError(err, t)
-	}
+
 	const bufSize = 1024
-	defer listener.Close()
-	defer os.Remove(f.Name())
+
 	go func(ctx context.Context) {
 		buf := make([]byte, bufSize)
 		conn, err := listener.Accept()
@@ -90,12 +131,7 @@ func testWrapperWithError(clientWrapper, serverWrapper ConnectionWrapper, expect
 		}
 		<-ctx.Done()
 	}(ctx)
-
-	connection, err := net.Dial("unix", socket)
-	if err != nil {
-		onError(err, t)
-	}
-	defer connection.Close()
+	var err error
 	connection, err = clientWrapper.WrapClient(context.TODO(), connection)
 	if err != nil {
 		onError(err, t)
@@ -103,22 +139,25 @@ func testWrapperWithError(clientWrapper, serverWrapper ConnectionWrapper, expect
 
 	clientBuf := make([]byte, bufSize)
 	dataBuf := make([]byte, bufSize)
+	math_rand.Seed(time.Now().UnixNano())
 	for i := 0; i < iterations; i++ {
-		_, err := rand.Read(dataBuf)
+		// always write different amount of data
+		dataLength := 1 + (math_rand.Int31() % (bufSize - 1))
+		_, err := rand.Read(dataBuf[:dataLength])
 		if err != nil {
 			onError(err, t)
 		}
-		_, err = connection.Write(dataBuf)
-		if err != nil {
-			connection.Close()
-			onError(err, t)
-		}
-		_, err = connection.Read(clientBuf)
+		_, err = connection.Write(dataBuf[:dataLength])
 		if err != nil {
 			connection.Close()
 			onError(err, t)
 		}
-		if result := bytes.Compare(clientBuf, dataBuf); result != 0 {
+		n, err := connection.Read(clientBuf)
+		if err != nil {
+			connection.Close()
+			onError(err, t)
+		}
+		if result := bytes.Compare(clientBuf[:n], dataBuf[:dataLength]); result != 0 {
 			connection.Close()
 			onError(errors.New("data not equal"), t)
 		}


### PR DESCRIPTION
* added help function that wait until all sent queries processed in background goroutine of querywriter and then validate results 
  in tests. it helps to not depend on golang's scheduler and provided time for background goroutine
* updated censor's test with unparsed queries, where changed hardcoded file path to temporary file. It allows to run a lot of 
  tests at once
* configured HTTP client to not re-use connections in AT tests with secure session that also make tests flaky. we decided to ignore this issue due to future removing acra-connector and secure session, and don't spend time on it
* when tried to fix SS issue, also extended connection wrapper tests, to run them with TCP connections too, not only unix sockets synchronized and buffered by OS. OS may divide big packets differently in case of TCP or UNIX connections

## Checklist

- [x] Change is covered by automated tests
- [x] The [coding guidelines] are followed
- [x] Public API has proper documentation in the [Acra documentation] site or has PR on [documentation repository] 
  with new changes
- [x] CHANGELOG.md is updated (in case of notable or breaking changes)
- [x] CHANGELOG_DEV.md is updated
- [x] Benchmark results are attached (if applicable)
- [x] [Example projects and code samples] are up-to-date (in case of API changes) 

[coding guidelines]: https://golang.org/doc/effective_go
[Example projects and code samples]: https://github.com/cossacklabs/acra-engineering-demo
[Acra documentation]: https://docs.cossacklabs.com/
[documentation repository]: https://github.com/cossacklabs/product-docs