### PR TITLE
Handle null::text casts in postgresql dialect, fix panics

### DIFF
--- a/CHANGELOG_DEV.md
+++ b/CHANGELOG_DEV.md
@@ -1,3 +1,6 @@
+## 0.92.0 - 2021-12-29
+- Improve sqlparser, support `null::text` type casts and avoid panics.
+
 ## 0.92.0 - 2021-12-22
 - Extend python examples, add mysql support
 - Generate certificates with service names as additional SAN for docker-compose files. Extend bash script to support several

--- a/sqlparser/ast_methods.go
+++ b/sqlparser/ast_methods.go
@@ -1339,6 +1339,8 @@ func (node *SQLVal) Format(buf *TrackedBuffer) {
 		buf.Myprintf("E'%s'", sqltypes.EncodeBytesSQLWithoutQuotes(node.Val))
 	case PgPlaceholder:
 		buf.Myprintf("%s", []byte(node.Val))
+	case UnknownVal:
+		node.unknown.Format(buf)
 	default:
 		panic("unexpected")
 	}

--- a/sqlparser/ast_test.go
+++ b/sqlparser/ast_test.go
@@ -679,3 +679,30 @@ func TestEmptyQuery(t *testing.T) {
 		}
 	}
 }
+
+func TestUnknownCastVal(t *testing.T) {
+	type testcase struct {
+		expr      Expr
+		castType  []byte
+		resultVal []byte
+	}
+	testcases := []testcase{
+		{
+			expr:      &NullVal{},
+			castType:  []byte(`::text`),
+			resultVal: nil,
+		},
+	}
+	for _, tcase := range testcases {
+		value := NewCastVal(tcase.expr, tcase.castType)
+		if value.unknown != tcase.expr {
+			t.Fatal("Unknown value != source expression")
+		}
+		if !bytes.Equal(value.Val, tcase.resultVal) {
+			t.Fatal("SQLVal.Val != expected value")
+		}
+		if !bytes.Equal(value.CastType, tcase.castType) {
+			t.Fatal("SQLVal.CastType != expected cast type")
+		}
+	}
+}

--- a/sqlparser/parse_test.go
+++ b/sqlparser/parse_test.go
@@ -1315,6 +1315,9 @@ var (
 	}, {
 		input:  "drop database if exists test_db",
 		output: "drop database test_db",
+	}, {
+		input:  "select NULL::text from dual",
+		output: "select null::text from dual",
 	}}
 )
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -8762,15 +8762,6 @@ class TestInvalidCryptoEnvelope(unittest.TestCase):
         self.assertTrue(found, "Not found any expected exception")
 
 
-class TestPanicRecover(AcraCatchLogsMixin, BaseTestCase):
-    def testRecovering(self):
-        with self.assertRaises(DatabaseError):
-            # call unsupported query by sqlparser
-            self.engine1.execute('select null::text from dual;')
-
-        self.assertIn('panic in connection processing, close connection', self.read_log(self.acra).lower())
-
-
 class TestRegressionInvalidOctalEncoding(BaseTokenizationWithBinaryPostgreSQL):
     def testOctalIntegerValue(self):
         default_client_id_table = sa.Table(


### PR DESCRIPTION
Due to using sqlparser that targeted to MySQL, it didn't use to support postgresql's type castings, especially `null::text`.
Previously we extended SQLVal to support `::<type>` type casts, to avoid a lot of refactorings and re-use existing code that depends on SQLVal (for example our transparent encryption). But it's simplest way to support such type casts. Harder is to refactor `sql.y` and used SQL's grammar, and propagate casts to all kinds of lexical rules related to SQL values (`select expr`, `functions`, etc). 
But Acra works with simple SQL value literals and don't support complicated SQL values like functions or `(select 1)::text`, so for now we don't need to do it and can leave it for later (probably we will switch to another parser earlier than meet real case where it need:)

So here all complicated SQL expressions will be stored in `unknown` field of `SQLVal` to reuse existing code and just serialize/deserialize when it need as is.

## Checklist

- [X] Change is covered by automated tests
- [X] The [coding guidelines] are followed
- [X] Public API has proper documentation in the [Acra documentation] site or has PR on [documentation repository] 
  with new changes
- [X] CHANGELOG.md is updated (in case of notable or breaking changes)
- [X] CHANGELOG_DEV.md is updated
- [X] Benchmark results are attached (if applicable)
- [X] [Example projects and code samples] are up-to-date (in case of API changes) 

[coding guidelines]: https://golang.org/doc/effective_go
[Example projects and code samples]: https://github.com/cossacklabs/acra-engineering-demo
[Acra documentation]: https://docs.cossacklabs.com/
[documentation repository]: https://github.com/cossacklabs/product-docs