### PR TITLE
CRL validation improvements

### DIFF
--- a/CHANGELOG_DEV.md
+++ b/CHANGELOG_DEV.md
@@ -1,4 +1,4 @@
-## 0.92.0 - 2022-01-19
+## 0.92.0 - 2022-01-20
 - Improve TLS certificate validation performance with larger CRLs, check is now O(1) ops instead of O(N)
 
 ## 0.92.0 - 2021-12-29

--- a/CHANGELOG_DEV.md
+++ b/CHANGELOG_DEV.md
@@ -1,3 +1,6 @@
+## 0.92.0 - 2022-01-19
+- Improve TLS certificate validation performance with larger CRLs, check is now O(1) ops instead of O(N)
+
 ## 0.92.0 - 2021-12-29
 - Improve sqlparser, support `null::text` type casts and avoid panics.
 

--- a/network/crl.go
+++ b/network/crl.go
@@ -108,6 +108,8 @@ type CRLConfig struct {
 const (
 	// CrlHTTPClientDefaultTimeout is default timeout for HTTP client used to fetch CRLs
 	CrlHTTPClientDefaultTimeout = time.Second * time.Duration(20)
+	// SerialEncodeBase is base in which certificate serial is encoded, for being a key in map of revoked certificates
+	SerialEncodeBase = 32
 )
 
 // NewCRLConfig creates new CRLConfig
@@ -341,7 +343,7 @@ func (v DefaultCRLVerifier) getCachedOrFetch(url string, allowLocal bool, issuer
 	// Cannot use big.Int as map key unfortunately, using string with hex-encoded serial instead
 	revokedCertificates := make(map[string]*pkix.RevokedCertificate, len(crl.TBSCertList.RevokedCertificates))
 	for _, cert := range crl.TBSCertList.RevokedCertificates {
-		revokedCertificates[cert.SerialNumber.Text(16)] = &cert
+		revokedCertificates[cert.SerialNumber.Text(SerialEncodeBase)] = &cert
 	}
 
 	// We don't need this array anymore as all revoked certificates are now inside the `revokedCertificates` map
@@ -395,7 +397,7 @@ func checkCertWithCRL(cert *x509.Certificate, cacheItem *CRLCacheItem) error {
 		}
 	}
 
-	revokedCertificate, ok := cacheItem.RevokedCertificates[cert.SerialNumber.Text(16)]
+	revokedCertificate, ok := cacheItem.RevokedCertificates[cert.SerialNumber.Text(SerialEncodeBase)]
 	if !ok {
 		return nil
 	}

--- a/network/crl.go
+++ b/network/crl.go
@@ -234,7 +234,7 @@ func (c DefaultCRLClient) Fetch(url string, allowLocal bool) ([]byte, error) {
 // CRLCacheItem is combination of fetched+parsed+verified CRL with fetch time
 type CRLCacheItem struct {
 	Fetched             time.Time                           // When this CRL was fetched and cached
-	CRL                 pkix.CertificateList                // Parsed CRL itself
+	CRL                 *pkix.CertificateList               // Parsed CRL itself
 	RevokedCertificates map[string]*pkix.RevokedCertificate // Copy of CRL.TBSCertList.RevokedCertificates with SerialNumber as key
 }
 
@@ -349,7 +349,7 @@ func (v DefaultCRLVerifier) getCachedOrFetch(url string, allowLocal bool, issuer
 
 	cacheItem := &CRLCacheItem{
 		Fetched:             time.Now(),
-		CRL:                 *crl,
+		CRL:                 crl,
 		RevokedCertificates: revokedCertificates,
 	}
 

--- a/network/crl_test.go
+++ b/network/crl_test.go
@@ -169,7 +169,7 @@ func getTestCRL(t *testing.T, filename string) ([]byte, *CRLCacheItem) {
 
 	revokedCertificates := make(map[string]*pkix.RevokedCertificate, len(crl.TBSCertList.RevokedCertificates))
 	for _, cert := range crl.TBSCertList.RevokedCertificates {
-		revokedCertificates[cert.SerialNumber.Text(16)] = &cert
+		revokedCertificates[cert.SerialNumber.Text(SerialEncodeBase)] = &cert
 	}
 
 	cacheItem := &CRLCacheItem{Fetched: time.Now(), CRL: crl, RevokedCertificates: revokedCertificates}
@@ -557,9 +557,8 @@ func TestCheckCertWithCRL(t *testing.T) {
 	// this behavior may be extended in future
 
 	setCertificateExtensions := func(cacheItem *CRLCacheItem, extensions []pkix.Extension) {
-		for serial, revokedCert := range cacheItem.RevokedCertificates {
+		for _, revokedCert := range cacheItem.RevokedCertificates {
 			revokedCert.Extensions = extensions
-			cacheItem.RevokedCertificates[serial] = revokedCert
 		}
 	}
 

--- a/network/crl_test.go
+++ b/network/crl_test.go
@@ -172,7 +172,7 @@ func getTestCRL(t *testing.T, filename string) ([]byte, *CRLCacheItem) {
 		revokedCertificates[cert.SerialNumber.Text(16)] = &cert
 	}
 
-	cacheItem := &CRLCacheItem{Fetched: time.Now(), CRL: *crl, RevokedCertificates: revokedCertificates}
+	cacheItem := &CRLCacheItem{Fetched: time.Now(), CRL: crl, RevokedCertificates: revokedCertificates}
 
 	return rawCRL, cacheItem
 }

--- a/network/crl_test.go
+++ b/network/crl_test.go
@@ -174,7 +174,7 @@ func getTestCRL(t *testing.T, filename string) ([]byte, *CRLCacheItem) {
 		revokedCertificates[cert.SerialNumber] = cert
 	}
 
-	cacheItem := &CRLCacheItem{Fetched: time.Now(), Extensions: crl.TBSCertList.Extensions, RevokedCertificates: revokedCertificates}
+	cacheItem := &CRLCacheItem{Fetched: time.Now(), CRL: *crl, RevokedCertificates: revokedCertificates}
 
 	return rawCRL, cacheItem
 }
@@ -558,63 +558,61 @@ func TestCheckCertWithCRL(t *testing.T) {
 	// thus, tested function should either return ErrCertWasRevoked or ErrUnknownCRLExtensionOID;
 	// this behavior may be extended in future
 
-	setCertificateExtensions := func(cacheItem *CRLCacheItem, extensions []pkix.Extension) {
-		for _, revokedCert := range cacheItem.RevokedCertificates {
-			revokedCert.Extensions = extensions
-		}
-	}
+	// setCertificateExtensions := func(cacheItem *CRLCacheItem, extensions []pkix.Extension) {
+	// 	for _, revokedCert := range cacheItem.RevokedCertificates {
+	// 		revokedCert.Extensions = extensions
+	// 	}
+	// }
 
-	expectOk := func(cert *x509.Certificate, cacheItem *CRLCacheItem) {
-		t.Logf("expectOk %v\n", cacheItem)
-		err := checkCertWithCRL(cert, cacheItem)
-		if err != ErrCertWasRevoked {
-			t.Logf("err=%v\n", err)
-			t.Fatal("Got unexpected error")
-		}
-	}
+	// expectOk := func(cert *x509.Certificate, cacheItem *CRLCacheItem) {
+	// 	t.Logf("expectOk %v\n", cacheItem)
+	// 	err := checkCertWithCRL(cert, cacheItem)
+	// 	if err != ErrCertWasRevoked {
+	// 		t.Logf("err=%v\n", err)
+	// 		t.Fatal("Got unexpected error")
+	// 	}
+	// }
+	//
+	// expectErr := func(cert *x509.Certificate, cacheItem *CRLCacheItem) {
+	// 	t.Logf("expectErr %v\n", cacheItem)
+	// 	err := checkCertWithCRL(cert, cacheItem)
+	// 	if err == ErrCertWasRevoked {
+	// 		t.Fatal("Got ErrCertWasRevoked, but expected error about extensions")
+	// 	} else {
+	// 		t.Logf("(Expected) err=%v\n", err)
+	// 	}
+	// }
 
-	expectErr := func(cert *x509.Certificate, cacheItem *CRLCacheItem) {
-		t.Logf("expectErr %v\n", cacheItem)
-		err := checkCertWithCRL(cert, cacheItem)
-		if err == ErrCertWasRevoked {
-			t.Fatal("Got ErrCertWasRevoked, but expected error about extensions")
-		} else {
-			t.Logf("(Expected) err=%v\n", err)
-		}
-	}
+	// certGroup := getTestCertGroup(t)
+	// cert := certGroup.invalidVerifiedChains[0][0]
+	// _, cacheItem := getTestCRL(t, path.Join(certGroup.prefix, certGroup.crl))
 
-	certGroup := getTestCertGroup(t)
-	cert := certGroup.invalidVerifiedChains[0][0]
-	_, cacheItem := getTestCRL(t, path.Join(certGroup.prefix, certGroup.crl))
-
-	t.Logf("cert %v\n", cert)
-
-	// Test with empty extensions lists in CRL
-	cacheItem.Extensions = []pkix.Extension{}
-	expectOk(cert, cacheItem)
-
-	// Test with some known extension
-	cacheItem.Extensions = []pkix.Extension{
-		{Id: []int{2, 5, 29, 35}, Critical: true, Value: []byte{}},
-	}
-	expectOk(cert, cacheItem)
-
-	// Test with some unknown critical extension
-	cacheItem.Extensions = []pkix.Extension{
-		{Id: []int{25, 100, 41}, Critical: true, Value: []byte{}},
-	}
-	expectErr(cert, cacheItem)
-
+	// // Test with empty extensions lists in CRL
+	// cacheItem.CRL.TBSCertList.Extensions = []pkix.Extension{}
+	// expectOk(cert, cacheItem)
+	//
+	// // Test with some known extension
+	// cacheItem.CRL.TBSCertList.Extensions = []pkix.Extension{
+	// 	{Id: []int{2, 5, 29, 35}, Critical: true, Value: []byte{}},
+	// }
+	// expectOk(cert, cacheItem)
+	//
+	// // Test with some unknown critical extension
+	// cacheItem.CRL.TBSCertList.Extensions = []pkix.Extension{
+	// 	{Id: []int{25, 100, 41}, Critical: true, Value: []byte{}},
+	// }
+	// expectErr(cert, cacheItem)
+	//
 	// // Test with some unknown non-critical extension
 	// cacheItem.extensions = []pkix.Extension{
 	// 	{Id: []int{70, 1, 2, 3, 4}, Critical: false, Value: []byte{}},
 	// }
 	// expectOk(cert, cacheItem)
-
-	// Test with empty extensions lists in revoked certificates
-	setCertificateExtensions(cacheItem, []pkix.Extension{})
-	expectOk(cert, cacheItem)
-
+	//
+	// // Test with empty extensions lists in revoked certificates
+	// setCertificateExtensions(cacheItem, []pkix.Extension{})
+	// expectOk(cert, cacheItem)
+	//
 	// // Test with some known critical extension
 	// setCertificateExtensions(cacheItem, []pkix.Extension{
 	// 	{Id: []int{2, 5, 29, 15}, Critical: true, Value: []byte{}},


### PR DESCRIPTION
CRL contains revoked certificates as a simple list, which means validating certificates is O(N).
Most certificates will be valid which means validator would have to search through the whole list each time.
This improvement is about making verification O(1) operations thanks to `map` being used instead of plain array.

## Checklist

- [x] Change is covered by automated tests
- [x] The [coding guidelines] are followed
- [x] ~Public API has proper documentation in the [Acra documentation] site or has PR on [documentation repository] 
  with new changes~
- [x] ~CHANGELOG.md is updated (in case of notable or breaking changes)~
- [x] CHANGELOG_DEV.md is updated
- [x] ~Benchmark results are attached (if applicable)~
- [x] ~[Example projects and code samples] are up-to-date (in case of API changes)~

[coding guidelines]: https://golang.org/doc/effective_go
[Example projects and code samples]: https://github.com/cossacklabs/acra-engineering-demo
[Acra documentation]: https://docs.cossacklabs.com/
[documentation repository]: https://github.com/cossacklabs/product-docs