### PR TITLE
Turn off poison detection by default for AS/AT

### DIFF
--- a/CHANGELOG_DEV.md
+++ b/CHANGELOG_DEV.md
@@ -1,3 +1,8 @@
+## 0.92.0 - 2022-02-02
+- Change default value for flag `--poison_detect_enable` from `true` to `false` for `acra-server` and `acra-translator`.
+- Add integration tests for `acra-translator` with poison record detection and refactored poison record tests.
+- Change default port for prometheus handler in integration tests to fix port collisions during local testing.
+
 ## 0.92.0 - 2022-02-01
 - `acra-connector` global removing from all its related components `acra-server`/`acra-translator`/`acra-keymaker`/`acra-keys`:
   - updated `acra-server` to use TLS as default connection configuration/ Themis Secure Session connection support removal/ 

--- a/CHANGELOG_DEV.md
+++ b/CHANGELOG_DEV.md
@@ -1,7 +1,7 @@
 ## 0.92.0 - 2022-02-02
-- Change default value for flag `--poison_detect_enable` from `true` to `false` for `acra-server` and `acra-translator`.
+- Change the default value for flag `--poison_detect_enable` from `true` to `false` for `acra-server` and `acra-translator`.
 - Add integration tests for `acra-translator` with poison record detection and refactored poison record tests.
-- Change default port for prometheus handler in integration tests to fix port collisions during local testing.
+- Change the default port for prometheus handler in integration tests to fix port collisions during local testing.
 
 ## 0.92.0 - 2022-02-01
 - `acra-connector` global removing from all its related components `acra-server`/`acra-translator`/`acra-keymaker`/`acra-keys`:

--- a/configs/acra-server.yaml
+++ b/configs/acra-server.yaml
@@ -99,7 +99,7 @@ pgsql_escape_bytea: false
 pgsql_hex_bytea: false
 
 # Turn on poison record detection, if server shutdown is disabled, AcraServer logs the poison record detection and returns decrypted data
-poison_detect_enable: true
+poison_detect_enable: false
 
 # On detecting poison record: log about poison record detection, execute script, return decrypted data
 poison_run_script_file: 

--- a/configs/acra-translator.yaml
+++ b/configs/acra-translator.yaml
@@ -57,7 +57,7 @@ log_to_file:
 logging_format: plaintext
 
 # Turn on poison record detection, if server shutdown is disabled, AcraTranslator logs the poison record detection and returns error
-poison_detect_enable: true
+poison_detect_enable: false
 
 # On detecting poison record: log about poison record detection, execute script, return decrypted data
 poison_run_script_file: 

--- a/logging/event_codes.go
+++ b/logging/event_codes.go
@@ -19,7 +19,8 @@ package logging
 // Event codes for different events in Acra services, splitted by groups and service.
 const (
 	// 100 .. 200 some events
-	EventCodeGeneral = 100
+	EventCodeGeneral                      = 100
+	EventCodePoisonRecordDetectionMessage = 101
 
 	// 500 .. 600 errors
 	EventCodeErrorGeneral         = 500

--- a/poison/callbacks.go
+++ b/poison/callbacks.go
@@ -19,6 +19,7 @@ package poison
 import (
 	"container/list"
 	"github.com/cossacklabs/acra/decryptor/base"
+	"github.com/cossacklabs/acra/logging"
 	log "github.com/sirupsen/logrus"
 	"os"
 	"os/exec"
@@ -38,9 +39,9 @@ type StopCallback struct{}
 
 // Call exists service with log
 func (*StopCallback) Call() error {
-	log.Warningln("detected poison record, exit")
+	log.WithField(logging.FieldKeyEventCode, logging.EventCodePoisonRecordDetectionMessage).Warningln("Detected poison record, exit")
 	os.Exit(1)
-	log.Errorln("executed code after os.Exit")
+	log.WithField(logging.FieldKeyEventCode, logging.EventCodePoisonRecordDetectionMessage).Errorln("executed code after os.Exit")
 	return nil
 }
 


### PR DESCRIPTION
* turned off poison record detection for server and translator
* added integration tests for translator with poison record detection (were only for server)
* added logging about turning on poison record detection at startup
* fixed failure of prometheus tests due to port collision (works on CI because we re-define ports for acra-server)
* changed a bit timeouts to use lower sleeps but same total timeout
* removed tests for whole cell mode with poison records because this option ignored far ago
* updated docs - https://github.com/cossacklabs/product-docs/pull/230

## Checklist

- [+] Change is covered by automated tests
- [+] The [coding guidelines] are followed
- [+] Public API has proper documentation in the [Acra documentation] site or has PR on [documentation repository] 
  with new changes
- [+] CHANGELOG.md is updated (in case of notable or breaking changes)
- [+] CHANGELOG_DEV.md is updated
- [+] Benchmark results are attached (if applicable)
- [+] [Example projects and code samples] are up-to-date (in case of API changes) 

[coding guidelines]: https://golang.org/doc/effective_go
[Example projects and code samples]: https://github.com/cossacklabs/acra-engineering-demo
[Acra documentation]: https://docs.cossacklabs.com/
[documentation repository]: https://github.com/cossacklabs/product-docs