### PR TITLE
Fixed acra-keymaker  sym key generation into uncreated dir

### DIFF
--- a/CHANGELOG_DEV.md
+++ b/CHANGELOG_DEV.md
@@ -3,6 +3,7 @@
 - Add integration tests for `acra-translator` with poison record detection and refactored poison record tests.
 - Change the default port for prometheus handler in integration tests to fix port collisions during local testing.
 - Use AcraBlocks as default crypto envelope;
+- `acra-keymaker` fix ability to generate sym key into uncreated dir via `generate_symmetric_storage_key` flag;
 
 ## 0.92.0 - 2022-02-01
 - `acra-connector` global removing from all its related components `acra-server`/`acra-translator`/`acra-keymaker`/`acra-keys`:

--- a/keystore/filesystem/server_keystore.go
+++ b/keystore/filesystem/server_keystore.go
@@ -729,11 +729,6 @@ func (store *KeyStore) GetPoisonSymmetricKeys() ([][]byte, error) {
 	if !poisonKeyExists {
 		log.Debugln("Generate poison symmetric key")
 
-		if err := store.fs.MkdirAll(filepath.Dir(store.GetPrivateKeyFilePath(keyFileName)), keyDirMode); err != nil {
-			log.Debug("Can't generate .poison_key directory")
-			return nil, err
-		}
-
 		err := store.generateAndSaveSymmetricKey([]byte(keyFileName), store.GetPrivateKeyFilePath(keyFileName))
 		if err != nil {
 			log.Debug("Can't generate new poison sym key")
@@ -948,9 +943,7 @@ func (store *KeyStore) GeneratePoisonRecordSymmetricKey() error {
 	if exists {
 		return nil
 	}
-	if err := store.fs.MkdirAll(filepath.Dir(store.GetPrivateKeyFilePath(keyName)), keyDirMode); err != nil {
-		return err
-	}
+
 	return store.generateAndSaveSymmetricKey([]byte(keyName), store.GetPrivateKeyFilePath(keyName))
 }
 

--- a/keystore/filesystem/server_keystore.go
+++ b/keystore/filesystem/server_keystore.go
@@ -298,6 +298,10 @@ func (store *KeyStore) ReadKeyFile(filename string) ([]byte, error) {
 
 // WriteKeyFile updates key data, creating a new file if necessary.
 func (store *KeyStore) WriteKeyFile(filename string, data []byte, mode os.FileMode) error {
+	if err := store.fs.MkdirAll(filepath.Dir(filename), keyDirMode); err != nil {
+		return err
+	}
+
 	// We do quite a few filesystem manipulations to maintain old key data. Ensure that
 	// no data is lost due to errors or power faults. "filename" must contain either
 	// new key data on success, or old key data on error.

--- a/keystore/filesystem/server_keystore_test.go
+++ b/keystore/filesystem/server_keystore_test.go
@@ -126,40 +126,40 @@ func checkPath(store *KeyStore, path string, t *testing.T) {
 }
 
 func testGenerateSymKeyUncreatedDir(store *KeyStore, t *testing.T) {
-	dir, err := ioutil.TempFile("/tmp", "keys")
+	dir, err := ioutil.TempDir("/tmp", "keys")
 	if err != nil {
 		t.Fatal(err)
 	}
 	// ensure we delete dir
-	if err := os.Remove(dir.Name()); err != nil {
+	if err := os.Remove(dir); err != nil {
 		t.Fatal(err)
 	}
 
-	err = store.generateAndSaveSymmetricKey([]byte("key"), fmt.Sprintf("%s/%s", dir.Name(), "test_id_sym"))
+	err = store.generateAndSaveSymmetricKey([]byte("key"), fmt.Sprintf("%s/%s", dir, "test_id_sym"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = os.Stat(dir.Name())
+	_, err = os.Stat(dir)
 	if os.IsNotExist(err) {
 		t.Fatal("dir should be created")
 	}
 }
 
 func testWriteKeyFileUncreatedDir(store *KeyStore, t *testing.T) {
-	dir, err := ioutil.TempFile("/tmp", "keys")
+	dir, err := ioutil.TempDir("/tmp", "keys")
 	if err != nil {
 		t.Fatal(err)
 	}
 	// ensure we delete dir
-	if err := os.Remove(dir.Name()); err != nil {
+	if err := os.Remove(dir); err != nil {
 		t.Fatal(err)
 	}
 
-	err = store.WriteKeyFile(fmt.Sprintf("%s/%s", dir.Name(), "test_id_sym"), []byte("key"), PrivateFileMode)
+	err = store.WriteKeyFile(fmt.Sprintf("%s/%s", dir, "test_id_sym"), []byte("key"), PrivateFileMode)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = os.Stat(dir.Name())
+	_, err = os.Stat(dir)
 	if os.IsNotExist(err) {
 		t.Fatal("dir should be created")
 	}

--- a/keystore/filesystem/server_keystore_test.go
+++ b/keystore/filesystem/server_keystore_test.go
@@ -125,6 +125,20 @@ func checkPath(store *KeyStore, path string, t *testing.T) {
 	}
 }
 
+func testGenerateSymKeyUncreatedDir(store *KeyStore, t *testing.T) {
+	keyFileDir := "/tmp/.testkeys"
+	defer os.RemoveAll(keyFileDir)
+
+	err := store.generateAndSaveSymmetricKey([]byte("key"), fmt.Sprintf("%s/%s", keyFileDir, "test_id_sym"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = os.Stat(keyFileDir)
+	if os.IsNotExist(err) {
+		t.Fatal("dir should be created")
+	}
+}
+
 func testGenerateServerKeys(store *KeyStore, t *testing.T) {
 	testID := []byte("test id")
 	err := store.GenerateServerKeys(testID)
@@ -277,6 +291,7 @@ func testFilesystemKeyStoreBasic(storage Storage, t *testing.T) {
 		testSaveKeypairs(store, t)
 		resetKeyFolders()
 		testGetZonePublicKey(store, t)
+		testGenerateSymKeyUncreatedDir(store, t)
 		testGetClientIDEncryptionPublicKey(store, t)
 	}
 }

--- a/tests/test.py
+++ b/tests/test.py
@@ -967,6 +967,16 @@ class KeyMakerTest(unittest.TestCase):
                  '--generate_log_key',
                  '--keys_public_output_dir={}'.format(folder)])
 
+            #check that keymaker will no fail on case of not created directory
+            subprocess.check_output(
+                ['./acra-keymaker',
+                 '--client_id=',
+                 '--tls_cert={}'.format(TEST_TLS_CLIENT_CERT),
+                 '--keystore={}'.format(KEYSTORE_VERSION),
+                 '--generate_symmetric_storage_key',
+                 '--keys_output_dir={}'.format('/tmp/.testkeys')])
+            shutil.rmtree('/tmp/.testkeys')
+
 
 class PrometheusMixin(object):
     _prometheus_addresses_field_name = 'prometheus_addresses'


### PR DESCRIPTION
Just added MkdirAll to KeyStore.WriteKeyFile() to create dir preliminarily.

<!-- Describe your changes here -->

## Checklist

- [x] Change is covered by automated tests
- [x] The [coding guidelines] are followed
- [x] Public API has proper documentation in the [Acra documentation] site or has PR on [documentation repository] 
  with new changes
- [x] CHANGELOG.md is updated (in case of notable or breaking changes)
- [x] CHANGELOG_DEV.md is updated
- [x] Benchmark results are attached (if applicable)
- [x] [Example projects and code samples] are up-to-date (in case of API changes) 

[coding guidelines]: https://golang.org/doc/effective_go
[Example projects and code samples]: https://github.com/cossacklabs/acra-engineering-demo
[Acra documentation]: https://docs.cossacklabs.com/
[documentation repository]: https://github.com/cossacklabs/product-docs