### PR TITLE
Add python example extended configs

### DIFF
--- a/examples/python/encryptor_config_with_zone.yaml
+++ b/examples/python/encryptor_config_with_zone.yaml
@@ -1,3 +1,6 @@
+defaults:
+  crypto_envelope: acrastruct
+
 schemas:
   - table: test
     columns:

--- a/examples/python/extended_encryptor_config_with_zone.yaml
+++ b/examples/python/extended_encryptor_config_with_zone.yaml
@@ -1,5 +1,5 @@
 defaults:
-  crypto_envelope: acrastruct
+  crypto_envelope: acrablock
 
 schemas:
   - table: test
@@ -14,25 +14,32 @@ schemas:
       - token_email
     encrypted:
       - column: data
+        zone_id: DDDDDDDDHHNqiSYFXkpxopYZ
       - column: masking
         masking: "xxxx"
         plaintext_length: 3
         plaintext_side: "left"
+        zone_id: DDDDDDDDHHNqiSYFXkpxopYZ
       - column: token_i32
         token_type: int32
         tokenized: true
+        zone_id: DDDDDDDDHHNqiSYFXkpxopYZ
       - column: token_i64
         token_type: int64
         tokenized: true
+        zone_id: DDDDDDDDHHNqiSYFXkpxopYZ
       - column: token_bytes
         token_type: bytes
         tokenized: true
+        zone_id: DDDDDDDDHHNqiSYFXkpxopYZ
       - column: token_str
         token_type: str
         tokenized: true
+        zone_id: DDDDDDDDHHNqiSYFXkpxopYZ
       - column: token_email
         token_type: email
         tokenized: true
+        zone_id: DDDDDDDDHHNqiSYFXkpxopYZ
 
   - table: users
     columns:

--- a/examples/python/extended_encryptor_config_without_zone.yaml
+++ b/examples/python/extended_encryptor_config_without_zone.yaml
@@ -1,5 +1,5 @@
 defaults:
-  crypto_envelope: acrastruct
+  crypto_envelope: acrablock
 
 schemas:
   - table: test


### PR DESCRIPTION
Adding extended pyhton encryptor configs. Need to support two different kind of encryptor configs with default envelope. Because different examples should use different configs.

## Checklist

- [X] Change is covered by automated tests
- [X] The [coding guidelines] are followed
- [X] Public API has proper documentation in the [Acra documentation] site or has PR on [documentation repository] 
  with new changes
- [X] CHANGELOG.md is updated (in case of notable or breaking changes)
- [X] CHANGELOG_DEV.md is updated
- [X] Benchmark results are attached (if applicable)
- [X] [Example projects and code samples] are up-to-date (in case of API changes) 

[coding guidelines]: https://golang.org/doc/effective_go
[Example projects and code samples]: https://github.com/cossacklabs/acra-engineering-demo
[Acra documentation]: https://docs.cossacklabs.com/
[documentation repository]: https://github.com/cossacklabs/product-docs