### PR TITLE
use Get*SymmetricKey API instead of Get*SymmetricKeys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Acra ChangeLog
 
-## [0.92.0](https://github.com/cossacklabs/acra/releases/tag/0.92.0), February 18th 2021
+## [0.92.0](https://github.com/cossacklabs/acra/releases/tag/0.92.0), February 21th 2021
 
 This release brings stability and performance fixes to AcraServer and AcraTranslator. It officially deprecates usage 
 of AcraConnector in favour of TLS everywhere. Some default configuration params are changed in favour of more secure & 

--- a/CHANGELOG_DEV.md
+++ b/CHANGELOG_DEV.md
@@ -1,3 +1,6 @@
+## 0.92.0 - 2022-02-21
+- Adapt python integration tests for python3.6 for tests on centos 7/8
+
 ## 0.92.0 - 2022-02-17
 - Extend KeyStore interface to allow fetching single latest symmetric key for encryption purposes
 

--- a/acrablock/dataEncryptor.go
+++ b/acrablock/dataEncryptor.go
@@ -56,14 +56,11 @@ func (d *DataEncryptor) EncryptWithZoneID(zoneID, data []byte, setting config.Co
 			data = decrypted
 		}
 	}
-	keys, err := d.keyStore.GetZoneIDSymmetricKeys(zoneID)
+	key, err := d.keyStore.GetZoneIDSymmetricKey(zoneID)
 	if err != nil {
 		return data, err
 	}
-	if len(keys) == 0 {
-		return data, keystore.ErrKeysNotFound
-	}
-	return CreateAcraBlock(data, keys[0], zoneID)
+	return CreateAcraBlock(data, key, zoneID)
 }
 
 // EncryptWithClientID encrypt data using AcraBlock
@@ -88,12 +85,9 @@ func (d *DataEncryptor) EncryptWithClientID(clientID, data []byte, setting confi
 			data = decrypted
 		}
 	}
-	keys, err := d.keyStore.GetClientIDSymmetricKeys(clientID)
+	keys, err := d.keyStore.GetClientIDSymmetricKey(clientID)
 	if err != nil {
 		return data, err
 	}
-	if len(keys) == 0 {
-		return data, keystore.ErrKeysNotFound
-	}
-	return CreateAcraBlock(data, keys[0], nil)
+	return CreateAcraBlock(data, keys, nil)
 }

--- a/acrablock/dataEncryptor_test.go
+++ b/acrablock/dataEncryptor_test.go
@@ -19,9 +19,9 @@ func TestSuccessDataEncryptionWithClientID(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	symKey := [][]byte{[]byte(`some key`)}
+	symKey := []byte(`some key`)
 	clientID := []byte(`clientid`)
-	keyStore.On("GetClientIDSymmetricKeys", clientID).Return(symKey, nil)
+	keyStore.On("GetClientIDSymmetricKey", clientID).Return(symKey, nil)
 	envelopeType := config.CryptoEnvelopeTypeAcraBlock
 	setting := &config.BasicColumnEncryptionSetting{CryptoEnvelope: &envelopeType}
 	testData := []byte(`test data`)
@@ -42,7 +42,7 @@ func TestSuccessDataEncryptionWithClientID(t *testing.T) {
 	if n != len(acraBlock) {
 		t.Fatal("Took invalid AcraBlock with extra data")
 	}
-	decrypted, err := acraBlock.Decrypt(symKey, nil)
+	decrypted, err := acraBlock.Decrypt([][]byte{symKey}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -66,9 +66,10 @@ func TestSuccessAcraStructReEncryptionWithClientID(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	symKey := [][]byte{[]byte(`some key`)}
+	symKey := []byte(`some key`)
 	clientID := []byte(`clientid`)
-	keyStore.On("GetClientIDSymmetricKeys", clientID).Return(symKey, nil)
+	keyStore.On("GetClientIDSymmetricKeys", clientID).Return([][]byte{symKey}, nil)
+	keyStore.On("GetClientIDSymmetricKey", clientID).Return(symKey, nil)
 	keyStore.On("GetServerDecryptionPrivateKeys", clientID).Return([]*keys.PrivateKey{keyPair.Private}, nil)
 
 	envelopeType := config.CryptoEnvelopeTypeAcraBlock
@@ -91,7 +92,7 @@ func TestSuccessAcraStructReEncryptionWithClientID(t *testing.T) {
 	if n != len(acraBlock) {
 		t.Fatal("Took invalid AcraBlock with extra data")
 	}
-	decrypted, err := acraBlock.Decrypt(symKey, nil)
+	decrypted, err := acraBlock.Decrypt([][]byte{symKey}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -115,9 +116,10 @@ func TestSuccessIgnoringAcraStructReEncryptionWithClientID(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	symKey := [][]byte{[]byte(`some key`)}
+	symKey := []byte(`some key`)
 	clientID := []byte(`clientid`)
-	keyStore.On("GetClientIDSymmetricKeys", clientID).Return(symKey, nil)
+	keyStore.On("GetClientIDSymmetricKeys", clientID).Return([][]byte{symKey}, nil)
+	keyStore.On("GetClientIDSymmetricKey", clientID).Return(symKey, nil)
 	keyStore.On("GetServerDecryptionPrivateKeys", clientID).Return([]*keys.PrivateKey{keyPair.Private}, nil)
 
 	envelopeType := config.CryptoEnvelopeTypeAcraBlock
@@ -140,7 +142,7 @@ func TestSuccessIgnoringAcraStructReEncryptionWithClientID(t *testing.T) {
 	if n != len(acraBlock) {
 		t.Fatal("Took invalid AcraBlock with extra data")
 	}
-	decrypted, err := acraBlock.Decrypt(symKey, nil)
+	decrypted, err := acraBlock.Decrypt([][]byte{symKey}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -190,9 +192,10 @@ func TestSuccessDataEncryptionWithZoneID(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	symKey := [][]byte{[]byte(`some key`)}
+	symKey := []byte(`some key`)
 	zoneID := zone.GenerateZoneID()
-	keyStore.On("GetZoneIDSymmetricKeys", zoneID).Return(symKey, nil)
+	keyStore.On("GetZoneIDSymmetricKeys", zoneID).Return([][]byte{symKey}, nil)
+	keyStore.On("GetZoneIDSymmetricKey", zoneID).Return(symKey, nil)
 	envelopeType := config.CryptoEnvelopeTypeAcraBlock
 	setting := &config.BasicColumnEncryptionSetting{CryptoEnvelope: &envelopeType}
 	testData := []byte(`test data`)
@@ -215,7 +218,7 @@ func TestSuccessDataEncryptionWithZoneID(t *testing.T) {
 		t.Fatal("Took invalid AcraBlock with extra data")
 	}
 
-	decrypted, err := acraBlock.Decrypt(symKey, zoneID)
+	decrypted, err := acraBlock.Decrypt([][]byte{symKey}, zoneID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -241,8 +244,9 @@ func TestSuccessAcraStructReEncryptionWithZoneID(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	symKey := [][]byte{[]byte(`some key`)}
-	keyStore.On("GetZoneIDSymmetricKeys", zoneID).Return(symKey, nil)
+	symKey := []byte(`some key`)
+	keyStore.On("GetZoneIDSymmetricKeys", zoneID).Return([][]byte{symKey}, nil)
+	keyStore.On("GetZoneIDSymmetricKey", zoneID).Return(symKey, nil)
 	keyStore.On("GetZonePrivateKeys", zoneID).Return([]*keys.PrivateKey{keyPair.Private}, nil)
 	envelopeType := config.CryptoEnvelopeTypeAcraBlock
 	reEncrypt := true
@@ -266,7 +270,7 @@ func TestSuccessAcraStructReEncryptionWithZoneID(t *testing.T) {
 		t.Fatal("Took invalid AcraBlock with extra data")
 	}
 
-	decrypted, err := acraBlock.Decrypt(symKey, zoneID)
+	decrypted, err := acraBlock.Decrypt([][]byte{symKey}, zoneID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -292,8 +296,9 @@ func TestSuccessIgnoringAcraStructReEncryptionWithZoneID(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	symKey := [][]byte{[]byte(`some key`)}
-	keyStore.On("GetZoneIDSymmetricKeys", zoneID).Return(symKey, nil)
+	symKey := []byte(`some key`)
+	keyStore.On("GetZoneIDSymmetricKeys", zoneID).Return([][]byte{symKey}, nil)
+	keyStore.On("GetZoneIDSymmetricKey", zoneID).Return(symKey, nil)
 	keyStore.On("GetZonePrivateKeys", zoneID).Return([]*keys.PrivateKey{keyPair.Private}, nil)
 	envelopeType := config.CryptoEnvelopeTypeAcraBlock
 	reEncrypt := false
@@ -317,7 +322,7 @@ func TestSuccessIgnoringAcraStructReEncryptionWithZoneID(t *testing.T) {
 		t.Fatal("Took invalid AcraBlock with extra data")
 	}
 
-	decrypted, err := acraBlock.Decrypt(symKey, zoneID)
+	decrypted, err := acraBlock.Decrypt([][]byte{symKey}, zoneID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -436,8 +441,8 @@ func TestFailedDataEncryptionWithErrorFromKeystore(t *testing.T) {
 	expectedError := errors.New("some error")
 	zoneID := zone.GenerateZoneID()
 	clientID := []byte(`clientid`)
-	keyStore.On("GetZoneIDSymmetricKeys", zoneID).Return(nil, expectedError)
-	keyStore.On("GetClientIDSymmetricKeys", clientID).Return(nil, expectedError)
+	keyStore.On("GetZoneIDSymmetricKey", zoneID).Return(nil, expectedError)
+	keyStore.On("GetClientIDSymmetricKey", clientID).Return(nil, expectedError)
 	envelopeType := config.CryptoEnvelopeTypeAcraBlock
 	setting := &config.BasicColumnEncryptionSetting{CryptoEnvelope: &envelopeType}
 	testData := []byte(`test data`)
@@ -468,8 +473,8 @@ func TestFailedDataEncryptionOnEmptyKeys(t *testing.T) {
 	}
 	zoneID := zone.GenerateZoneID()
 	clientID := []byte(`clientid`)
-	keyStore.On("GetZoneIDSymmetricKeys", zoneID).Return(nil, nil)
-	keyStore.On("GetClientIDSymmetricKeys", clientID).Return(nil, nil)
+	keyStore.On("GetZoneIDSymmetricKey", zoneID).Return(nil, keystore.ErrKeysNotFound)
+	keyStore.On("GetClientIDSymmetricKey", clientID).Return(nil, keystore.ErrKeysNotFound)
 	envelopeType := config.CryptoEnvelopeTypeAcraBlock
 	setting := &config.BasicColumnEncryptionSetting{CryptoEnvelope: &envelopeType}
 	testData := []byte(`test data`)

--- a/cmd/acra-keys/keys/read-key.go
+++ b/cmd/acra-keys/keys/read-key.go
@@ -244,28 +244,20 @@ func ReadKeyBytes(params ReadKeyParams, keyStore keystore.ServerKeyStore) ([]byt
 		return key.Value, nil
 
 	case KeySymmetric:
-		keys, err := keyStore.GetClientIDSymmetricKeys(params.ClientID())
+		key, err := keyStore.GetClientIDSymmetricKey(params.ClientID())
 		if err != nil {
 			log.WithError(err).Error("Cannot read client symmetric key")
 			return nil, err
 		}
-		if len(keys) == 0 {
-			log.WithError(err).Error("Empty symmetric keys list")
-			return nil, keystore.ErrKeysNotFound
-		}
-		return keys[0], nil
+		return key, nil
 
 	case KeyZoneSymmetric:
-		keys, err := keyStore.GetZoneIDSymmetricKeys(params.ZoneID())
+		key, err := keyStore.GetZoneIDSymmetricKey(params.ZoneID())
 		if err != nil {
 			log.WithError(err).Error("Cannot read client symmetric key")
 			return nil, err
 		}
-		if len(keys) == 0 {
-			log.WithError(err).Error("Empty symmetric keys list")
-			return nil, keystore.ErrKeysNotFound
-		}
-		return keys[0], nil
+		return key, nil
 
 	default:
 		log.WithField("expected", SupportedReadKeyKinds).Errorf("Unknown key kind: %s", kind)

--- a/cmd/acra-translator/grpc_api/service.go
+++ b/cmd/acra-translator/grpc_api/service.go
@@ -253,21 +253,19 @@ func (service *TranslatorService) EncryptSymSearchable(ctx context.Context, requ
 		logger.Errorln("Empty ClientID")
 		return nil, ErrEmptyClientID
 	}
-	var symKeys [][]byte
+	var symKey []byte
 	var err error
 	logger.Debugln("Load encryption symmetric key from KeyStore")
 	if request.ZoneId != nil {
-		symKeys, err = service.data.Keystorage.GetZoneIDSymmetricKeys(request.ZoneId)
+		symKey, err = service.data.Keystorage.GetZoneIDSymmetricKey(request.ZoneId)
 	} else {
-		symKeys, err = service.data.Keystorage.GetClientIDSymmetricKeys(request.ClientId)
+		symKey, err = service.data.Keystorage.GetClientIDSymmetricKey(request.ClientId)
 	}
 	if err != nil {
 		logger.WithError(err).Errorln("Can't load symmetric keys")
 		return nil, ErrKeysNotFound
 	}
-	if len(symKeys) == 0 {
-		return nil, ErrKeysNotFound
-	}
+
 	logger.Debugln("Load secret key for HMAC from KeyStore")
 	hmacKey, err := service.data.Keystorage.GetHMACSecretKey(request.ClientId)
 	if err != nil {
@@ -277,7 +275,7 @@ func (service *TranslatorService) EncryptSymSearchable(ctx context.Context, requ
 	logger.Debugln("Generate HMAC")
 	dataHash := hmac.GenerateHMAC(hmacKey, request.Data)
 	logger.Debugln("Create AcraBlock")
-	acrastruct, err := acrablock.CreateAcraBlock(request.Data, symKeys[0], request.ZoneId)
+	acrastruct, err := acrablock.CreateAcraBlock(request.Data, symKey, request.ZoneId)
 	if err != nil {
 		logger.WithError(err).Errorln("Can't create AcraBlock")
 		return nil, ErrEncryptionFailed

--- a/cmd/acra-translator/grpc_api/service_test.go
+++ b/cmd/acra-translator/grpc_api/service_test.go
@@ -279,9 +279,19 @@ func TestTranslatorService_SearchSym(t *testing.T) {
 			return [][]byte{append([]byte{}, zoneIDSymKey...)}
 		},
 		nil)
+	keystore.On("GetZoneIDSymmetricKey", mock.MatchedBy(func([]byte) bool { return true })).Return(
+		func([]byte) []byte {
+			return append([]byte{}, zoneIDSymKey...)
+		},
+		nil)
 	keystore.On("GetClientIDSymmetricKeys", mock.MatchedBy(func([]byte) bool { return true })).Return(
 		func([]byte) [][]byte {
 			return [][]byte{append([]byte{}, clientIDSymKey...)}
+		},
+		nil)
+	keystore.On("GetClientIDSymmetricKey", mock.MatchedBy(func([]byte) bool { return true })).Return(
+		func([]byte) []byte {
+			return append([]byte{}, clientIDSymKey...)
 		},
 		nil)
 
@@ -369,6 +379,7 @@ func TestTranslatorService_DecryptionPoisonRecord(t *testing.T) {
 	keyStorage := &mocks.ServerKeyStore{}
 	// everytime return copy of value because it will be zeroized after each call
 	keyStorage.On("GetPoisonSymmetricKeys").Return(func() [][]byte { return [][]byte{append([]byte{}, poisonSymKey...)} }, nil)
+	keyStorage.On("GetPoisonSymmetricKey").Return(func() []byte { return append([]byte{}, poisonSymKey...) }, nil)
 	callbackStorage := poison.NewCallbackStorage()
 	callback := &testPoisonCallback{}
 	callbackStorage.AddCallback(callback)
@@ -394,15 +405,26 @@ func TestTranslatorService_DecryptionPoisonRecord(t *testing.T) {
 		// reset all .On registered callbacks
 		keyStorage.ExpectedCalls = nil
 		keyStorage.On("GetPoisonSymmetricKeys").Return(func() [][]byte { return [][]byte{append([]byte{}, poisonSymKey...)} }, nil)
+		keyStorage.On("GetPoisonSymmetricKey").Return(func() []byte { return append([]byte{}, poisonSymKey...) }, nil)
 		keyStorage.On("GetHMACSecretKey", mock.MatchedBy(func([]byte) bool { return true })).Return(func([]byte) []byte { return append([]byte{}, hmacKey...) }, nil)
 		keyStorage.On("GetZoneIDSymmetricKeys", mock.MatchedBy(func([]byte) bool { return true })).Return(
 			func([]byte) [][]byte {
 				return [][]byte{append([]byte{}, someSymKey...)}
 			},
 			nil)
+		keyStorage.On("GetZoneIDSymmetricKey", mock.MatchedBy(func([]byte) bool { return true })).Return(
+			func([]byte) []byte {
+				return append([]byte{}, someSymKey...)
+			},
+			nil)
 		keyStorage.On("GetClientIDSymmetricKeys", mock.MatchedBy(func([]byte) bool { return true })).Return(
 			func([]byte) [][]byte {
 				return [][]byte{append([]byte{}, someSymKey...)}
+			},
+			nil)
+		keyStorage.On("GetClientIDSymmetricKey", mock.MatchedBy(func([]byte) bool { return true })).Return(
+			func([]byte) []byte {
+				return append([]byte{}, someSymKey...)
 			},
 			nil)
 		for _, tcase := range testCases {
@@ -424,14 +446,25 @@ func TestTranslatorService_DecryptionPoisonRecord(t *testing.T) {
 		// reset all .On registered callbacks
 		keyStorage.ExpectedCalls = nil
 		keyStorage.On("GetPoisonSymmetricKeys").Return(func() [][]byte { return [][]byte{append([]byte{}, poisonSymKey...)} }, nil)
+		keyStorage.On("GetPoisonSymmetricKey").Return(func() []byte { return append([]byte{}, poisonSymKey...) }, nil)
 		keyStorage.On("GetZoneIDSymmetricKeys", mock.MatchedBy(func([]byte) bool { return true })).Return(
 			func([]byte) [][]byte {
 				return [][]byte{append([]byte{}, someSymKey...)}
 			},
 			nil)
+		keyStorage.On("GetZoneIDSymmetricKey", mock.MatchedBy(func([]byte) bool { return true })).Return(
+			func([]byte) []byte {
+				return append([]byte{}, someSymKey...)
+			},
+			nil)
 		keyStorage.On("GetClientIDSymmetricKeys", mock.MatchedBy(func([]byte) bool { return true })).Return(
 			func([]byte) [][]byte {
 				return [][]byte{append([]byte{}, someSymKey...)}
+			},
+			nil)
+		keyStorage.On("GetClientIDSymmetricKey", mock.MatchedBy(func([]byte) bool { return true })).Return(
+			func([]byte) []byte {
+				return append([]byte{}, someSymKey...)
 			},
 			nil)
 		for _, tcase := range testCases {
@@ -612,6 +645,11 @@ func testgRPCServiceFlow(ctx context.Context, expectedClientID []byte, conn *grp
 	keystorage.On("GetClientIDSymmetricKeys", mock.Anything).Return(
 		func([]byte) [][]byte {
 			return [][]byte{append([]byte{}, testSymmetricKey...)}
+		},
+		nil)
+	keystorage.On("GetClientIDSymmetricKey", mock.Anything).Return(
+		func([]byte) []byte {
+			return append([]byte{}, testSymmetricKey...)
 		},
 		nil)
 	symWriterClient := NewWriterSymClient(conn)

--- a/cmd/acra-translator/http_api/service_test.go
+++ b/cmd/acra-translator/http_api/service_test.go
@@ -131,6 +131,9 @@ func initKeyStore(clientID, zoneID []byte, keyStorage *mocks.ServerKeyStore, t *
 	keyStorage.On("GetClientIDSymmetricKeys", mock.MatchedBy(func(id []byte) bool {
 		return bytes.Equal(id, clientID)
 	})).Return(func([]byte) [][]byte { return [][]byte{append([]byte{}, acraBlockSymKey...)} }, nil)
+	keyStorage.On("GetClientIDSymmetricKey", mock.MatchedBy(func(id []byte) bool {
+		return bytes.Equal(id, clientID)
+	})).Return(func([]byte) []byte { return append([]byte{}, acraBlockSymKey...) }, nil)
 	keyStorage.On("GetHMACSecretKey", mock.MatchedBy(func(id []byte) bool {
 		return bytes.Equal(id, clientID)
 	})).Return(func([]byte) []byte { return append([]byte{}, hmacSymKey...) }, nil)
@@ -146,6 +149,9 @@ func initKeyStore(clientID, zoneID []byte, keyStorage *mocks.ServerKeyStore, t *
 	keyStorage.On("GetZoneIDSymmetricKeys", mock.MatchedBy(func(id []byte) bool {
 		return bytes.Equal(id, zoneID)
 	})).Return(func([]byte) [][]byte { return [][]byte{append([]byte{}, acraBlockZoneKey...)} }, nil)
+	keyStorage.On("GetZoneIDSymmetricKey", mock.MatchedBy(func(id []byte) bool {
+		return bytes.Equal(id, zoneID)
+	})).Return(func([]byte) []byte { return append([]byte{}, acraBlockZoneKey...) }, nil)
 	keyStorage.On("GetClientIDEncryptionPublicKey", mock.MatchedBy(func(id []byte) bool {
 		return bytes.Equal(id, clientID)
 	})).Return(AcraStructKeyPair.Public, nil)

--- a/crypto/acrablock.go
+++ b/crypto/acrablock.go
@@ -7,7 +7,6 @@ import (
 	"github.com/cossacklabs/acra/decryptor/base"
 	"github.com/cossacklabs/acra/encryptor"
 	"github.com/cossacklabs/acra/encryptor/config"
-	"github.com/cossacklabs/acra/keystore"
 	"github.com/cossacklabs/acra/logging"
 	"github.com/cossacklabs/acra/utils"
 	"github.com/sirupsen/logrus"
@@ -91,16 +90,13 @@ func (handler AcraBlockHandler) EncryptWithClientID(clientID, data []byte, conte
 	if _, _, err := acrablock.ExtractAcraBlockFromData(data); err == nil {
 		return data, nil
 	}
-	keys, err := context.Keystore.GetClientIDSymmetricKeys(clientID)
+	key, err := context.Keystore.GetClientIDSymmetricKey(clientID)
 	if err != nil {
 		return data, fmt.Errorf("can't read private key for matched client_id to encrypt with AcraBlock: %w", err)
 	}
-	defer utils.ZeroizeSymmetricKeys(keys)
+	defer utils.ZeroizeSymmetricKey(key)
 
-	if len(keys) == 0 {
-		return data, keystore.ErrKeysNotFound
-	}
-	return acrablock.CreateAcraBlock(data, keys[0], nil)
+	return acrablock.CreateAcraBlock(data, key, nil)
 }
 
 // EncryptWithZoneID implementation of ContainerHandler method
@@ -108,14 +104,11 @@ func (handler AcraBlockHandler) EncryptWithZoneID(zoneID, data []byte, context *
 	if _, _, err := acrablock.ExtractAcraBlockFromData(data); err == nil {
 		return data, nil
 	}
-	keys, err := context.Keystore.GetZoneIDSymmetricKeys(zoneID)
+	key, err := context.Keystore.GetZoneIDSymmetricKey(zoneID)
 	if err != nil {
 		return data, fmt.Errorf("can't read private key for matched zone_id to encrypt with AcraBlock: %w", err)
 	}
-	defer utils.ZeroizeSymmetricKeys(keys)
+	defer utils.ZeroizeSymmetricKey(key)
 
-	if len(keys) == 0 {
-		return data, keystore.ErrKeysNotFound
-	}
-	return acrablock.CreateAcraBlock(data, keys[0], zoneID)
+	return acrablock.CreateAcraBlock(data, key, zoneID)
 }

--- a/crypto/encryptor_test.go
+++ b/crypto/encryptor_test.go
@@ -41,6 +41,7 @@ func TestEncryptHandler(t *testing.T) {
 			},
 			nil)
 		keystore.On("GetClientIDSymmetricKeys", clientID).Return([][]byte{[]byte(`some key`)}, nil)
+		keystore.On("GetClientIDSymmetricKey", clientID).Return([]byte(`some key`), nil)
 
 		t.Run("AcraStruct encryption success", func(t *testing.T) {
 			result, err := encryptor.EncryptWithClientID(clientID, []byte(rawData), &config.BasicColumnEncryptionSetting{
@@ -110,6 +111,7 @@ func TestEncryptHandler(t *testing.T) {
 		keystore.On("GetZonePublicKey", zoneID).Return(zoneIDKeypair.Public, nil)
 
 		keystore.On("GetZoneIDSymmetricKeys", zoneID).Return([][]byte{[]byte(`some key`)}, nil)
+		keystore.On("GetZoneIDSymmetricKey", zoneID).Return([]byte(`some key`), nil)
 
 		t.Run("AcraStruct encryption success", func(t *testing.T) {
 			result, err := encryptor.EncryptWithZoneID(zoneID, []byte(rawData), &config.BasicColumnEncryptionSetting{

--- a/crypto/matcher_test.go
+++ b/crypto/matcher_test.go
@@ -41,6 +41,9 @@ func TestEnvelopeMatcher(t *testing.T) {
 	keyStore.On("GetClientIDSymmetricKeys", clientID).Return(func([]byte) [][]byte {
 		return [][]byte{append([]byte{}, symKey...)}
 	}, nil)
+	keyStore.On("GetClientIDSymmetricKey", clientID).Return(func([]byte) []byte {
+		return append([]byte{}, symKey...)
+	}, nil)
 	keyStore.On("GetClientIDEncryptionPublicKey", clientID).Return(func([]byte) *keys.PublicKey {
 		return &keys.PublicKey{Value: keypair.Public.Value}
 	}, nil)

--- a/crypto/reencryptor_test.go
+++ b/crypto/reencryptor_test.go
@@ -41,6 +41,7 @@ func TestReEncryptHandler(t *testing.T) {
 
 		keystore.On("GetServerDecryptionPrivateKeys", clientID).Return([]*keys.PrivateKey{keypair.Private}, nil)
 		keystore.On("GetClientIDSymmetricKeys", clientID).Return([][]byte{[]byte(`some key`)}, nil)
+		keystore.On("GetClientIDSymmetricKey", clientID).Return([]byte(`some key`), nil)
 
 		t.Run("AcraStruct reEncryption Success ", func(t *testing.T) {
 			result, err := reEncryptor.EncryptWithClientID(clientID, rawAcraStruct, &config.BasicColumnEncryptionSetting{
@@ -86,9 +87,10 @@ func TestReEncryptHandler(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-
+		symKey := []byte(`some key`)
 		keystore.On("GetZonePrivateKeys", zoneID).Return([]*keys.PrivateKey{keypair.Private}, nil)
-		keystore.On("GetZoneIDSymmetricKeys", zoneID).Return([][]byte{[]byte(`some key`)}, nil)
+		keystore.On("GetZoneIDSymmetricKeys", zoneID).Return([][]byte{append([]byte{}, symKey...)}, nil)
+		keystore.On("GetZoneIDSymmetricKey", zoneID).Return(append([]byte{}, symKey...), nil)
 
 		t.Run("AcraStruct reEncryption Success ", func(t *testing.T) {
 			result, err := reEncryptor.EncryptWithZoneID(zoneID, rawAcraStruct, &config.BasicColumnEncryptionSetting{
@@ -113,7 +115,7 @@ func TestReEncryptHandler(t *testing.T) {
 				t.Fatal("failed to create acraBlock from internal container", err)
 			}
 
-			decrypted, err := acraBlock.Decrypt([][]byte{[]byte(`some key`)}, zoneID)
+			decrypted, err := acraBlock.Decrypt([][]byte{append([]byte{}, symKey...)}, zoneID)
 			if err != nil {
 				t.Fatal("failed to Decrypt internal container", err)
 			}

--- a/keystore/filesystem/server_keystore.go
+++ b/keystore/filesystem/server_keystore.go
@@ -1321,14 +1321,11 @@ func (store *KeyStore) GetDecryptionTokenSymmetricKeys(id []byte, ownerType keys
 // GetEncryptionTokenSymmetricKey return symmetric key which should be used to encrypt tokens
 func (store *KeyStore) GetEncryptionTokenSymmetricKey(id []byte, ownerType keystore2.KeyOwnerType) ([]byte, error) {
 	keyName := getTokenSymmetricKeyName(id, ownerType)
-	keys, err := store.getSymmetricKeys(id, keyName)
+	key, err := store.getLatestSymmetricKey(id, keyName)
 	if err != nil {
 		return nil, err
 	}
-	if len(keys) == 0 {
-		return nil, keystore2.ErrKeysNotFound
-	}
-	return keys[0], nil
+	return key, nil
 }
 
 // GenerateTokenSymmetricKey new symmetric key in keystore

--- a/poison/poison.go
+++ b/poison/poison.go
@@ -79,15 +79,11 @@ func CreateSymmetricPoisonRecord(keyStore keystore.PoisonKeyStore, dataLength in
 	if err != nil {
 		return nil, err
 	}
-	symmetricKeys, err := keyStore.GetPoisonSymmetricKeys()
+	symmetricKey, err := keyStore.GetPoisonSymmetricKey()
 	if err != nil {
 		return nil, err
 	}
-	if len(symmetricKeys) <= 0 {
-		return nil, keystore.ErrKeysNotFound
-	}
-
-	acraBlock, err := acrablock.CreateAcraBlock(data, symmetricKeys[0], nil)
+	acraBlock, err := acrablock.CreateAcraBlock(data, symmetricKey, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pseudonymization/storage/storageTokenEncryptor.go
+++ b/pseudonymization/storage/storageTokenEncryptor.go
@@ -41,25 +41,21 @@ func NewSCellEncryptor(tokenKeystore keystore.SymmetricEncryptionKeyStore) (Toke
 // Encrypt data with context
 func (s *scellEncryptor) Encrypt(data []byte, ctx common.TokenContext) ([]byte, error) {
 	var context []byte
-	var keys [][]byte
+	var key []byte
 	var err error
 	if len(ctx.ZoneID) != 0 {
 		context = ctx.ZoneID
-		keys, err = s.tokenKeystore.GetZoneIDSymmetricKeys(ctx.ZoneID)
+		key, err = s.tokenKeystore.GetZoneIDSymmetricKey(ctx.ZoneID)
 	} else {
 		context = ctx.ClientID
-		keys, err = s.tokenKeystore.GetClientIDSymmetricKeys(ctx.ClientID)
+		key, err = s.tokenKeystore.GetClientIDSymmetricKey(ctx.ClientID)
 	}
 	if err != nil {
 		return nil, err
 	}
-	if len(keys) == 0 {
-		return nil, keystore.ErrKeysNotFound
-	}
-	encrypted, err := acrablock.CreateAcraBlock(data, keys[0], context)
-	for _, key := range keys {
-		utils.ZeroizeSymmetricKey(key)
-	}
+	encrypted, err := acrablock.CreateAcraBlock(data, key, context)
+	utils.ZeroizeSymmetricKey(key)
+
 	return encrypted, err
 }
 


### PR DESCRIPTION
* Use the optimized new method for fetching symmetric encryption key instead of set of keys
* Update tests that verify that new method used
* adapt integration test script for python3.6 that used in Centos 7/8. Remove `default` keyword for namedtuple that introduced in python3.7 and `--directory` parameter for `http.server` and specify the working directory for fork.

<!-- Describe your changes here -->

## Checklist

- [+] Change is covered by automated tests
- [+] The [coding guidelines] are followed
- [+] Public API has proper documentation in the [Acra documentation] site or has PR on [documentation repository] 
  with new changes
- [+] CHANGELOG.md is updated (in case of notable or breaking changes)
- [+] CHANGELOG_DEV.md is updated
- [+] Benchmark results are attached (if applicable)
- [+] [Example projects and code samples] are up-to-date (in case of API changes) 

[coding guidelines]: https://golang.org/doc/effective_go
[Example projects and code samples]: https://github.com/cossacklabs/acra-engineering-demo
[Acra documentation]: https://docs.cossacklabs.com/
[documentation repository]: https://github.com/cossacklabs/product-docs