### PR TITLE
Acra-censor: remove is forbidden

### DIFF
--- a/CHANGELOG_DEV.md
+++ b/CHANGELOG_DEV.md
@@ -1,4 +1,4 @@
-## 0.92.0 - 2022-03-10
+## 0.93.0 - 2022-03-10
 - Remove `IsForbidden` field from acra-censor’s logs
 
 ## 0.92.0 - 2022-02-21

--- a/CHANGELOG_DEV.md
+++ b/CHANGELOG_DEV.md
@@ -1,3 +1,6 @@
+## 0.92.0 - 2022-03-10
+- Remove `IsForbidden` field from acra-censor’s logs
+
 ## 0.92.0 - 2022-02-21
 - Adapt python integration tests for python3.6 for tests on centos 7/8
 

--- a/acra-censor/common/logging_logic.go
+++ b/acra-censor/common/logging_logic.go
@@ -3,8 +3,6 @@ package common
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/cossacklabs/acra/logging"
-	log "github.com/sirupsen/logrus"
 	"io"
 	"os"
 	"os/signal"
@@ -13,6 +11,9 @@ import (
 	"sync/atomic"
 	"syscall"
 	"time"
+
+	"github.com/cossacklabs/acra/logging"
+	log "github.com/sirupsen/logrus"
 )
 
 const defaultSerializationTimeout = time.Second
@@ -27,8 +28,7 @@ var DefaultWriteQueryChannelSize = defaultWriteQueryChannelSize
 
 // QueryInfo defines format of exporting query into file
 type QueryInfo struct {
-	RawQuery    string `json:"raw_query"`
-	IsForbidden bool   `json:"_blacklisted_by_web_config"`
+	RawQuery string `json:"raw_query"`
 }
 
 // LogStorage defines basic storage that should be used by QueryWriter
@@ -224,7 +224,6 @@ func (queryWriter *QueryWriter) serializeQueries(queries []*QueryInfo) []byte {
 	var tempQueryInfo = QueryInfo{}
 	for _, queryInfo := range queries {
 		tempQueryInfo.RawQuery = queryInfo.RawQuery
-		tempQueryInfo.IsForbidden = queryInfo.IsForbidden
 		jsonQueryInfo, err := json.Marshal(tempQueryInfo)
 		if err != nil {
 			queryWriter.logger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCensorQuerySerializeError).Errorln("Can't serialize stored queries")
@@ -249,6 +248,5 @@ func (queryWriter *QueryWriter) captureQuery(query string) {
 	}
 	queryInfo := &QueryInfo{}
 	queryInfo.RawQuery = query
-	queryInfo.IsForbidden = false
 	queryWriter.Queries = append(queryWriter.Queries, queryInfo)
 }

--- a/acra-censor/common/logging_logic_test.go
+++ b/acra-censor/common/logging_logic_test.go
@@ -3,13 +3,14 @@ package common
 import (
 	"bytes"
 	"fmt"
-	"github.com/cossacklabs/acra/sqlparser"
 	"io/ioutil"
 	"os"
 	"strings"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/cossacklabs/acra/sqlparser"
 )
 
 const testSerializationTime = 100 * time.Millisecond
@@ -264,9 +265,9 @@ func TestQueryCaptureOnDuplicates(t *testing.T) {
 	for _, query := range testQueries {
 		writer.WriteQuery(query)
 	}
-	expected := "{\"raw_query\":\"SELECT Student_ID FROM STUDENT;\",\"_blacklisted_by_web_config\":false}\n" +
-		"{\"raw_query\":\"SELECT * FROM STUDENT;\",\"_blacklisted_by_web_config\":false}\n" +
-		"{\"raw_query\":\"SELECT * FROM X;\",\"_blacklisted_by_web_config\":false}\n"
+	expected := "{\"raw_query\":\"SELECT Student_ID FROM STUDENT;\"}\n" +
+		"{\"raw_query\":\"SELECT * FROM STUDENT;\"}\n" +
+		"{\"raw_query\":\"SELECT * FROM X;\"}\n"
 	if writer.skippedQueryCount > 0 {
 		t.Fatal("Detected unexpected skipping queries")
 	}
@@ -283,10 +284,10 @@ func TestQueryCaptureOnDuplicates(t *testing.T) {
 	}
 	testQuery := "SELECT * FROM Z;"
 	writer.WriteQuery(testQuery)
-	expected = "{\"raw_query\":\"SELECT Student_ID FROM STUDENT;\",\"_blacklisted_by_web_config\":false}\n" +
-		"{\"raw_query\":\"SELECT * FROM STUDENT;\",\"_blacklisted_by_web_config\":false}\n" +
-		"{\"raw_query\":\"SELECT * FROM X;\",\"_blacklisted_by_web_config\":false}\n" +
-		"{\"raw_query\":\"SELECT * FROM Z;\",\"_blacklisted_by_web_config\":false}\n"
+	expected = "{\"raw_query\":\"SELECT Student_ID FROM STUDENT;\"}\n" +
+		"{\"raw_query\":\"SELECT * FROM STUDENT;\"}\n" +
+		"{\"raw_query\":\"SELECT * FROM X;\"}\n" +
+		"{\"raw_query\":\"SELECT * FROM Z;\"}\n"
 	if writer.skippedQueryCount > 0 {
 		t.Fatal("Detected unexpected skipping queries")
 	}
@@ -315,11 +316,11 @@ func TestQueryCaptureOnDuplicates(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expected = "{\"raw_query\":\"SELECT Student_ID FROM STUDENT;\",\"_blacklisted_by_web_config\":false}\n" +
-		"{\"raw_query\":\"SELECT * FROM STUDENT;\",\"_blacklisted_by_web_config\":false}\n" +
-		"{\"raw_query\":\"SELECT * FROM X;\",\"_blacklisted_by_web_config\":false}\n" +
-		"{\"raw_query\":\"SELECT * FROM Z;\",\"_blacklisted_by_web_config\":false}\n" +
-		"{\"raw_query\":\"select songName from t where personName in ('Ryan', 'Holly') group by songName having count(distinct personName) = 10\",\"_blacklisted_by_web_config\":false}\n"
+	expected = "{\"raw_query\":\"SELECT Student_ID FROM STUDENT;\"}\n" +
+		"{\"raw_query\":\"SELECT * FROM STUDENT;\"}\n" +
+		"{\"raw_query\":\"SELECT * FROM X;\"}\n" +
+		"{\"raw_query\":\"SELECT * FROM Z;\"}\n" +
+		"{\"raw_query\":\"select songName from t where personName in ('Ryan', 'Holly') group by songName having count(distinct personName) = 10\"}\n"
 
 	if !strings.EqualFold(expected, string(result)) {
 		t.Fatal("Expected: ", expected, " | Got: ", string(result))


### PR DESCRIPTION
This removes unnecessary field `IsForbidden` from `QueryInfo`, which was used only in a couple of tests. This could potentially break the user API, so it is documented [here](https://github.com/cossacklabs/product-docs/pull/238).

## Checklist

- [x] Change is covered by automated tests
- [x] The [coding guidelines] are followed
- [x] Public API has proper documentation in the [Acra documentation] site or has PR on [documentation repository] 
  with new changes.
- [x] ~CHANGELOG.md is updated (in case of notable or breaking changes)~
- [x] CHANGELOG_DEV.md is updated
- [x] ~Benchmark results are attached (if applicable)~
- [x] ~[Example projects and code samples] are up-to-date (in case of API changes)~

[coding guidelines]: https://golang.org/doc/effective_go
[Example projects and code samples]: https://github.com/cossacklabs/acra-engineering-demo
[Acra documentation]: https://docs.cossacklabs.com/
[documentation repository]: https://github.com/cossacklabs/product-docs