### PR TITLE
Fix echoing with escape sequences

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ endef
 
 ## Show this help
 help:
-	@echo -e "$(COLOR_MENU)Targets:$(COLOR_DEFAULT)"
+	@printf "$(COLOR_MENU)Targets:$(COLOR_DEFAULT)\n"
 	@awk 'BEGIN { FS = ":.*?" }\
 		/^## *--/ { print "" }\
 		/^## / { split($$0,a,/## /); comment = a[2] }\
@@ -170,7 +170,7 @@ help:
 			printf "  $(COLOR_TARGET)%-15s$(COLOR_DEFAULT) %s\n", $$1, comment;\
 			comment = "" }'\
 		$(MAKEFILE_LIST)
-	@echo -e "\n$(COLOR_MENU)Properties allowed for overriding:$(COLOR_DEFAULT)"
+	@printf "\n$(COLOR_MENU)Properties allowed for overriding:$(COLOR_DEFAULT)\n"
 	@awk 'BEGIN { FS = " *\\?= *" }\
 		/^## / { split($$0,a,/## /); comment = a[2] }\
 		/^[a-zA-Z][-_a-zA-Z]+ +\?=.*/ {\
@@ -179,8 +179,8 @@ help:
 			printf "%28s$(COLOR_COMMENT)'\''%s'\'' by default$(COLOR_DEFAULT)\n", "", $$2;\
 			comment = "" }'\
 		$(MAKEFILE_LIST)
-	@echo -e "$(COLOR_MENU)Usage example:$(COLOR_DEFAULT)\n\
-	  make DOCKER_EXTRA_BUILD_TAGS='staging' DOCKER_REGISTRY_HOST=registry.example.com docker-build"
+	@printf "$(COLOR_MENU)Usage example:$(COLOR_DEFAULT)\n\
+	  make DOCKER_EXTRA_BUILD_TAGS='staging' DOCKER_REGISTRY_HOST=registry.example.com docker-build\n"
 
 ##---- Application -------------------------------------------------------------
 

--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ endef
 
 ## Show this help
 help:
-	@echo "$(COLOR_MENU)Targets:$(COLOR_DEFAULT)"
+	@echo -e "$(COLOR_MENU)Targets:$(COLOR_DEFAULT)"
 	@awk 'BEGIN { FS = ":.*?" }\
 		/^## *--/ { print "" }\
 		/^## / { split($$0,a,/## /); comment = a[2] }\
@@ -170,7 +170,7 @@ help:
 			printf "  $(COLOR_TARGET)%-15s$(COLOR_DEFAULT) %s\n", $$1, comment;\
 			comment = "" }'\
 		$(MAKEFILE_LIST)
-	@echo "\n$(COLOR_MENU)Properties allowed for overriding:$(COLOR_DEFAULT)"
+	@echo -e "\n$(COLOR_MENU)Properties allowed for overriding:$(COLOR_DEFAULT)"
 	@awk 'BEGIN { FS = " *\\?= *" }\
 		/^## / { split($$0,a,/## /); comment = a[2] }\
 		/^[a-zA-Z][-_a-zA-Z]+ +\?=.*/ {\
@@ -179,7 +179,7 @@ help:
 			printf "%28s$(COLOR_COMMENT)'\''%s'\'' by default$(COLOR_DEFAULT)\n", "", $$2;\
 			comment = "" }'\
 		$(MAKEFILE_LIST)
-	@echo "$(COLOR_MENU)Usage example:$(COLOR_DEFAULT)\n\
+	@echo -e "$(COLOR_MENU)Usage example:$(COLOR_DEFAULT)\n\
 	  make DOCKER_EXTRA_BUILD_TAGS='staging' DOCKER_REGISTRY_HOST=registry.example.com docker-build"
 
 ##---- Application -------------------------------------------------------------


### PR DESCRIPTION
Escape sequences are not interpreted in `echo` if `-e` is not passed. Because of that, `make help` looked like:
<details>
<summary>Before</summary>

```
$ make help
\033[1mTargets:\033[0m
  help            Show this help

  build_protobuf  use this target only when it is really needed, not for usual builds
  build           Build the application in the subdirectory (default)
  install         Build the application and install to the system GOPATH
  test            Test the application
  test_python     Run extra python test
  clean           Remove build artifacts
  keys            Generate keys

  docker-build    Docker : build the image locally
  docker-build-ci Docker : build CI-related images
  docker-push     Docker : tag and push image to remote registry
  docker-push-ci  Docker : tag and push CI-related images to remote registry
  docker-clean    Docker : remove stopped containers and dangling images
  docker          Docker : alias for 'docker-build' target (DEPRECATED)

  pkg             Package : build deb/rpm depending on the current OS
  rpm             Package : alias for the 'pkg' target (DEPRECATED)
  deb             Package : alias for the 'pkg' target (DEPRECATED)
\n\033[1mProperties allowed for overriding:\033[0m
  BUILD_DIR               - Absolute or relative GOPATH for the 'build' target
                            'build' by default
  DOCKER_BUILD_CACHE      - Enable Docker build cache (true|false)
                            'false' by default
  PKG_COMPONENTS          - Application components to include
                            'addzone backup keymaker keys poisonrecordmaker rollback rotate server translator tokens' by default
  PKG_INSTALL_PREFIX      - Installation path prefix for packages
                            '/usr' by default
  DOCKER_REGISTRY_HOST    - Registry host
                            'localhost' by default
  DOCKER_REGISTRY_PATH    - Registry path, usually - company name
                            'cossacklabs' by default
  DOCKER_EXTRA_BUILD_TAGS - List of extra tags for building, delimiter - single space
                            '' by default
  DOCKER_EXTRA_PUSH_TAGS  - List of extra tags for pushing into remote registry, delimiter - single space
                            '' by default
\033[1mUsage example:\033[0m\n  make DOCKER_EXTRA_BUILD_TAGS='staging' DOCKER_REGISTRY_HOST=registry.example.com docker-build

```
</details>

And now they look like this:

<details>
<summary>After</summary>

```
$ make help
Targets:
  help            Show this help

  build_protobuf  use this target only when it is really needed, not for usual builds
  build           Build the application in the subdirectory (default)
  install         Build the application and install to the system GOPATH
  test            Test the application
  test_python     Run extra python test
  clean           Remove build artifacts
  keys            Generate keys

  docker-build    Docker : build the image locally
  docker-build-ci Docker : build CI-related images
  docker-push     Docker : tag and push image to remote registry
  docker-push-ci  Docker : tag and push CI-related images to remote registry
  docker-clean    Docker : remove stopped containers and dangling images
  docker          Docker : alias for 'docker-build' target (DEPRECATED)

  pkg             Package : build deb/rpm depending on the current OS
  rpm             Package : alias for the 'pkg' target (DEPRECATED)
  deb             Package : alias for the 'pkg' target (DEPRECATED)

Properties allowed for overriding:
  BUILD_DIR               - Absolute or relative GOPATH for the 'build' target
                            'build' by default
  DOCKER_BUILD_CACHE      - Enable Docker build cache (true|false)
                            'false' by default
  PKG_COMPONENTS          - Application components to include
                            'addzone backup keymaker keys poisonrecordmaker rollback rotate server translator tokens' by default
  PKG_INSTALL_PREFIX      - Installation path prefix for packages
                            '/usr' by default
  DOCKER_REGISTRY_HOST    - Registry host
                            'localhost' by default
  DOCKER_REGISTRY_PATH    - Registry path, usually - company name
                            'cossacklabs' by default
  DOCKER_EXTRA_BUILD_TAGS - List of extra tags for building, delimiter - single space
                            '' by default
  DOCKER_EXTRA_PUSH_TAGS  - List of extra tags for pushing into remote registry, delimiter - single space
                            '' by default
Usage example:
  make DOCKER_EXTRA_BUILD_TAGS='staging' DOCKER_REGISTRY_HOST=registry.example.com docker-build
```
</details>

## Checklist

- [x] ~Change is covered by automated tests~
- [x] ~The [coding guidelines] are followed~
- [x] ~Public API has proper documentation in the [Acra documentation] site or has PR on [documentation repository] 
  with new changes~
- [x] ~CHANGELOG.md is updated (in case of notable or breaking changes)~
- [x] ~CHANGELOG_DEV.md is updated~
- [x] ~Benchmark results are attached (if applicable)~
- [x] ~[Example projects and code samples] are up-to-date (in case of API changes)~

[coding guidelines]: https://golang.org/doc/effective_go
[Example projects and code samples]: https://github.com/cossacklabs/acra-engineering-demo
[Acra documentation]: https://docs.cossacklabs.com/
[documentation repository]: https://github.com/cossacklabs/product-docs