### PR TITLE
Ignore legacy keys when caching keys on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ _Core_:
     - Added caching metadata about rotated keys [#498](https://github.com/cossacklabs/acra/pull/498)
     - Added new flag `--keystore_cache_on_start_enable` that turns on loading all keys into in-memory cache on startup. [#497](https://github.com/cossacklabs/acra/pull/497)
     - Changed default value for `--keystore_cache_size` parameter from `-1` (which means no limits for cache) to 1000 (cache items). [#497](https://github.com/cossacklabs/acra/pull/497)
+    - Legacy keys that were used with AcraConnector are now ignored during initial caching on startup. [#510](https://github.com/cossacklabs/acra/pull/510)
 - **AcraServer**:
   - The default CryptoEnvelope has changed from `acrastruct` to `acrablock` in the encryptor_config. Now AcraServer 
     will use faster encryption by default. You can select which CryptoEnvelope to use in encryptor_config. 

--- a/keystore/filesystem/key_export.go
+++ b/keystore/filesystem/key_export.go
@@ -80,6 +80,7 @@ const (
 	PurposeStorageZoneKeyPair        = "zone"
 	PurposeStorageZonePrivateKey     = "private_zone"
 	PurposeStorageZonePublicKey      = "public_zone"
+	PurposeLegacy                    = "legacy"
 )
 
 // ExportPublicKey loads a public key for export.

--- a/keystore/filesystem/server_keystore.go
+++ b/keystore/filesystem/server_keystore.go
@@ -810,7 +810,7 @@ func (store *KeyStore) describeDir(dirName string) ([]keystore.KeyDescription, e
 			return nil, err
 		}
 		if description.Purpose == PurposeLegacy {
-			log.WithField("ID", description.ID).Debug("Ignoring legacy key")
+			log.WithField("ID", description.ID).Warn("Ignoring legacy key")
 			continue
 		}
 		keys = append(keys, *description)
@@ -842,10 +842,7 @@ func (store *KeyStore) DescribeKeyFile(fileInfo os.FileInfo) (*keystore.KeyDescr
 	components := strings.Split(fileInfo.Name(), "_")
 
 	if len(components) == 1 {
-		id := fileInfo.Name()
-		if strings.HasSuffix(id, ".pub") {
-			id = id[:len(id)-4]
-		}
+		id := strings.TrimSuffix(fileInfo.Name(), ".pub")
 
 		return &keystore.KeyDescription{
 			ID:       id,

--- a/tests/test.py
+++ b/tests/test.py
@@ -6185,11 +6185,6 @@ class TestAcraIgnoresLegacyKeys(AcraCatchLogsMixin, BaseTestCase):
             self.skipTest("test only for keystore v1")
 
     def setUp(self):
-        super().setUp()
-
-        def create_key_file(name):
-            open(f"{KEYS_FOLDER.name}/{name}", "w").close()
-
         try:
             for key_file in self.legacy_key_files:
                 open(f"{KEYS_FOLDER.name}/{key_file}", "w").close()
@@ -6197,9 +6192,12 @@ class TestAcraIgnoresLegacyKeys(AcraCatchLogsMixin, BaseTestCase):
             self.tearDown()
             raise
 
+        super().setUp()
+
     def tearDown(self):
         for key_file in self.legacy_key_files:
-            os.remove(f"{KEYS_FOLDER.name}/{key_file}")
+            try: os.remove(f"{KEYS_FOLDER.name}/{key_file}")
+            except: pass
 
         super().tearDown()
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -6181,6 +6181,8 @@ class TestAcraIgnoresLegacyKeys(AcraCatchLogsMixin, BaseTestCase):
     ]
 
     def checkSkip(self):
+        super().checkSkip()
+
         if KEYSTORE_VERSION != 'v1':
             self.skipTest("test only for keystore v1")
 


### PR DESCRIPTION
When AcraServer/AcraTranslator starts and loads all the keys into cache (if the option is enabled), ignore old keys related to AcraConnector.
Add new key kind "legacy" and ignore this key if found inside keystore.

<!-- Describe your changes here -->

## Checklist

- [x] Change is covered by automated tests
- [x] The [coding guidelines] are followed
- [x] ~Public API has proper documentation in the [Acra documentation] site or has PR on [documentation repository] 
  with new changes~
- [x] CHANGELOG.md is updated (in case of notable or breaking changes)
- [x] ~CHANGELOG_DEV.md is updated~
- [x] ~Benchmark results are attached (if applicable)~
- [x] ~[Example projects and code samples] are up-to-date (in case of API changes)~

[coding guidelines]: https://golang.org/doc/effective_go
[Example projects and code samples]: https://github.com/cossacklabs/acra-engineering-demo
[Acra documentation]: https://docs.cossacklabs.com/
[documentation repository]: https://github.com/cossacklabs/product-docs