### PR TITLE
Remove legacy TokenKeystore

### DIFF
--- a/keystore/filesystem/key_names.go
+++ b/keystore/filesystem/key_names.go
@@ -16,25 +16,8 @@ limitations under the License.
 
 package filesystem
 
-import (
-	keystore2 "github.com/cossacklabs/acra/keystore"
-)
-
 func getSymmetricKeyName(id string) string {
 	return id + `_sym`
-}
-
-func getTokenSymmetricKeyName(id []byte, ownerType keystore2.KeyOwnerType) string {
-	var name string
-	switch ownerType {
-	case keystore2.KeyOwnerTypeClient:
-		name = getClientIDSymmetricKeyName(id)
-	case keystore2.KeyOwnerTypeZone:
-		name = getZoneIDSymmetricKeyName(id)
-	default:
-		name = string(id)
-	}
-	return name + ".token"
 }
 
 func getClientIDSymmetricKeyName(id []byte) string {

--- a/keystore/filesystem/server_keystore.go
+++ b/keystore/filesystem/server_keystore.go
@@ -36,7 +36,6 @@ import (
 
 	"github.com/cossacklabs/acra/cmd"
 	"github.com/cossacklabs/acra/keystore"
-	keystore2 "github.com/cossacklabs/acra/keystore"
 	fs "github.com/cossacklabs/acra/keystore/filesystem/internal"
 	"github.com/cossacklabs/acra/keystore/lru"
 	"github.com/cossacklabs/acra/logging"
@@ -1310,26 +1309,4 @@ func (store *KeyStore) GetZoneIDSymmetricKeys(id []byte) ([][]byte, error) {
 func (store *KeyStore) GetZoneIDSymmetricKey(id []byte) ([]byte, error) {
 	keyName := getZoneIDSymmetricKeyName(id)
 	return store.getLatestSymmetricKey(id, keyName)
-}
-
-// GetDecryptionTokenSymmetricKeys return symmetric keys which may be used to decrypt encrypted token
-func (store *KeyStore) GetDecryptionTokenSymmetricKeys(id []byte, ownerType keystore2.KeyOwnerType) ([][]byte, error) {
-	keyName := getTokenSymmetricKeyName(id, ownerType)
-	return store.getSymmetricKeys(id, keyName)
-}
-
-// GetEncryptionTokenSymmetricKey return symmetric key which should be used to encrypt tokens
-func (store *KeyStore) GetEncryptionTokenSymmetricKey(id []byte, ownerType keystore2.KeyOwnerType) ([]byte, error) {
-	keyName := getTokenSymmetricKeyName(id, ownerType)
-	key, err := store.getLatestSymmetricKey(id, keyName)
-	if err != nil {
-		return nil, err
-	}
-	return key, nil
-}
-
-// GenerateTokenSymmetricKey new symmetric key in keystore
-func (store *KeyStore) GenerateTokenSymmetricKey(id []byte, ownerType keystore2.KeyOwnerType) error {
-	keyName := getTokenSymmetricKeyName(id, ownerType)
-	return store.generateAndSaveSymmetricKey(id, store.GetPrivateKeyFilePath(keyName))
 }

--- a/keystore/filesystem/server_keystore_test.go
+++ b/keystore/filesystem/server_keystore_test.go
@@ -693,12 +693,6 @@ func testFilesystemKeyStoreWithOnlyCachedData(storage Storage, t *testing.T) {
 	if err := store.GenerateClientIDSymmetricKey(testID); err != nil {
 		t.Fatal(err)
 	}
-	if err := store.GenerateTokenSymmetricKey(testID, keystore.KeyOwnerTypeClient); err != nil {
-		t.Fatal(err)
-	}
-	if err := store.GenerateTokenSymmetricKey(testID, keystore.KeyOwnerTypeClient); err != nil {
-		t.Fatal(err)
-	}
 	if err := store.GeneratePoisonRecordSymmetricKey(); err != nil {
 		t.Fatal(err)
 	}
@@ -748,10 +742,6 @@ func testFilesystemKeyStoreWithOnlyCachedData(storage Storage, t *testing.T) {
 		t.Fatal(err)
 	}
 	_, err = store.GetClientIDSymmetricKeys(testID)
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = store.GetDecryptionTokenSymmetricKeys(testID, keystore.KeyOwnerTypeClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -806,14 +796,6 @@ func testFilesystemKeyStoreWithOnlyCachedData(storage Storage, t *testing.T) {
 	}
 	if len(symKeys) != 2 {
 		t.Fatal("ClientID sym keys not cached")
-	}
-
-	symKeys, err = store.GetDecryptionTokenSymmetricKeys(testID, keystore.KeyOwnerTypeClient)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(symKeys) != 2 {
-		t.Fatal("Token sym keys not cached")
 	}
 
 	symKeys, err = store.GetPoisonSymmetricKeys()

--- a/keystore/keystore.go
+++ b/keystore/keystore.go
@@ -84,12 +84,6 @@ const (
 // ErrKeysNotFound used if can't find key or keys
 var ErrKeysNotFound = errors.New("keys not found")
 
-// TokenKeystore method related with key management used by tokenization components
-type TokenKeystore interface {
-	GetEncryptionTokenSymmetricKey(id []byte, ownerType KeyOwnerType) ([]byte, error)
-	GetDecryptionTokenSymmetricKeys(id []byte, ownerType KeyOwnerType) ([][]byte, error)
-}
-
 // HmacKeyStore interface to fetch keys for hma calculation
 type HmacKeyStore interface {
 	GetHMACSecretKey(id []byte) ([]byte, error)


### PR DESCRIPTION
Removing `TokenKeystore` interface and all related methods.

## Checklist

- [x] Change is covered by automated tests
- [x] The [coding guidelines] are followed
- [x] Public API has proper documentation in the [Acra documentation] site or has PR on [documentation repository] 
  with new changes
- [x] CHANGELOG.md is updated (in case of notable or breaking changes)
- [x] CHANGELOG_DEV.md is updated
- [x] Benchmark results are attached (if applicable)
- [x] [Example projects and code samples] are up-to-date (in case of API changes) 

[coding guidelines]: https://golang.org/doc/effective_go
[Example projects and code samples]: https://github.com/cossacklabs/acra-engineering-demo
[Acra documentation]: https://docs.cossacklabs.com/
[documentation repository]: https://github.com/cossacklabs/product-docs