### PR TITLE
Don't generate poison keys during the query

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,3 +157,6 @@ examples/cpp/Testing
 examples/cpp/cmake-build-debug/*
 examples/cpp/cmake_install.cmake
 examples/cpp/cmake-build-debug
+
+# vscode project folder
+.vscode

--- a/CHANGELOG_DEV.md
+++ b/CHANGELOG_DEV.md
@@ -1,3 +1,7 @@
+## 0.93.0 - 2022-03-23
+- Remove autogeneration of poison keys on the first access (but keep in poisonrecordmaker).
+- Add warning on enabled poison detection if keys are not generated.
+
 ## 0.93.0 - 2022-03-15
 - Remove legacy flags dedicated to acra-connector from dockerfiles under the `./docker/` directory.
 

--- a/cmd/acra-keymaker/acra-keymaker.go
+++ b/cmd/acra-keymaker/acra-keymaker.go
@@ -184,7 +184,7 @@ func main() {
 
 	if *poisonRecord {
 		// Generate poison record symmetric key
-		if err = store.GeneratePoisonRecordSymmetricKey(); err != nil {
+		if err = store.GeneratePoisonSymmetricKey(); err != nil {
 			panic(err)
 		}
 		fmt.Println("Generated symmetric key for poison records")
@@ -249,7 +249,7 @@ func main() {
 		}
 		fmt.Println("Generated storage symmetric key for clientID")
 		// Generate poison record symmetric key
-		if err = store.GeneratePoisonRecordSymmetricKey(); err != nil {
+		if err = store.GeneratePoisonSymmetricKey(); err != nil {
 			panic(err)
 		}
 		fmt.Println("Generated symmetric key for poison records")

--- a/cmd/acra-keymaker/acra-keymaker.go
+++ b/cmd/acra-keymaker/acra-keymaker.go
@@ -189,8 +189,7 @@ func main() {
 		}
 		fmt.Println("Generated symmetric key for poison records")
 		// Generate poison record keypair
-		// TODO: Replace with GeneratePoisonKeyPair
-		if _, err = store.GetPoisonKeyPair(); err != nil {
+		if err = store.GeneratePoisonKeyPair(); err != nil {
 			panic(err)
 		}
 		fmt.Println("Generated keypair for poison records")
@@ -254,8 +253,7 @@ func main() {
 		}
 		fmt.Println("Generated symmetric key for poison records")
 		// Generate poison record keypair
-		// TODO: Replace with GeneratePoisonKeyPair
-		if _, err = store.GetPoisonKeyPair(); err != nil {
+		if err = store.GeneratePoisonKeyPair(); err != nil {
 			panic(err)
 		}
 		fmt.Println("Generated keypair for poison records")

--- a/cmd/acra-keymaker/acra-keymaker.go
+++ b/cmd/acra-keymaker/acra-keymaker.go
@@ -26,10 +26,11 @@ import (
 	"encoding/pem"
 	"flag"
 	"fmt"
-	"github.com/cossacklabs/acra/network"
 	"io/ioutil"
 	"os"
 	"strings"
+
+	"github.com/cossacklabs/acra/network"
 
 	"github.com/cossacklabs/acra/cmd"
 	"github.com/cossacklabs/acra/keystore"
@@ -188,6 +189,7 @@ func main() {
 		}
 		fmt.Println("Generated symmetric key for poison records")
 		// Generate poison record keypair
+		// TODO: Replace with GeneratePoisonKeyPair
 		if _, err = store.GetPoisonKeyPair(); err != nil {
 			panic(err)
 		}
@@ -252,6 +254,7 @@ func main() {
 		}
 		fmt.Println("Generated symmetric key for poison records")
 		// Generate poison record keypair
+		// TODO: Replace with GeneratePoisonKeyPair
 		if _, err = store.GetPoisonKeyPair(); err != nil {
 			panic(err)
 		}

--- a/cmd/acra-keys/keys/generate.go
+++ b/cmd/acra-keys/keys/generate.go
@@ -498,6 +498,7 @@ func GenerateAcraKeys(params GenerateKeyParams, keyStore keystore.KeyMaking, def
 		log.Info("Generated symmetric key for poison records")
 		didSomething = true
 
+		// TODO: Replace with GeneratePoisonKeyPair
 		_, err = keyStore.GetPoisonKeyPair()
 		if err != nil {
 			log.WithError(err).Error("Failed to generate keypair for poison records")

--- a/cmd/acra-keys/keys/generate.go
+++ b/cmd/acra-keys/keys/generate.go
@@ -498,8 +498,7 @@ func GenerateAcraKeys(params GenerateKeyParams, keyStore keystore.KeyMaking, def
 		log.Info("Generated symmetric key for poison records")
 		didSomething = true
 
-		// TODO: Replace with GeneratePoisonKeyPair
-		_, err = keyStore.GetPoisonKeyPair()
+		err = keyStore.GeneratePoisonKeyPair()
 		if err != nil {
 			log.WithError(err).Error("Failed to generate keypair for poison records")
 			return didSomething, err

--- a/cmd/acra-keys/keys/generate.go
+++ b/cmd/acra-keys/keys/generate.go
@@ -490,7 +490,7 @@ func GenerateAcraKeys(params GenerateKeyParams, keyStore keystore.KeyMaking, def
 	}
 
 	if generatePoisonKeys {
-		err := keyStore.GeneratePoisonRecordSymmetricKey()
+		err := keyStore.GeneratePoisonSymmetricKey()
 		if err != nil {
 			log.WithError(err).Error("Failed to generate symmetric key for poison records")
 			return didSomething, err

--- a/cmd/acra-poisonrecordmaker/acra-poisonrecordmaker.go
+++ b/cmd/acra-poisonrecordmaker/acra-poisonrecordmaker.go
@@ -81,7 +81,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	var store keystore.PoisonKeyStore
+	var store keystore.PoisonKeyStorageAndGenerator
 	if filesystemV2.IsKeyDirectory(*keysDir) {
 		store = openKeyStoreV2(*keysDir, keyLoader)
 	} else {
@@ -104,7 +104,7 @@ func main() {
 	fmt.Println(base64.StdEncoding.EncodeToString(poisonRecord))
 }
 
-func openKeyStoreV1(output string, loader keyloader.MasterKeyLoader) keystore.PoisonKeyStore {
+func openKeyStoreV1(output string, loader keyloader.MasterKeyLoader) keystore.PoisonKeyStorageAndGenerator {
 	masterKey, err := loader.LoadMasterKey()
 	if err != nil {
 		log.WithError(err).Errorln("Cannot load master key")
@@ -136,7 +136,7 @@ func openKeyStoreV1(output string, loader keyloader.MasterKeyLoader) keystore.Po
 	return keyStoreV1
 }
 
-func openKeyStoreV2(keyDirPath string, loader keyloader.MasterKeyLoader) keystore.PoisonKeyStore {
+func openKeyStoreV2(keyDirPath string, loader keyloader.MasterKeyLoader) keystore.PoisonKeyStorageAndGenerator {
 	encryption, signature, err := loader.LoadMasterKeys()
 	if err != nil {
 		log.WithError(err).Errorln("Cannot load master key")

--- a/cmd/acra-translator/grpc_api/api_test.go
+++ b/cmd/acra-translator/grpc_api/api_test.go
@@ -3,10 +3,11 @@ package grpc_api
 import (
 	"bytes"
 	"errors"
+	"testing"
+
 	acrastruct2 "github.com/cossacklabs/acra/acrastruct"
 	"github.com/cossacklabs/acra/crypto"
 	"github.com/cossacklabs/acra/keystore"
-	"testing"
 
 	"github.com/cossacklabs/acra/cmd/acra-translator/common"
 	"github.com/cossacklabs/acra/poison"
@@ -36,7 +37,7 @@ func (keystore *testKeystore) GenerateZoneIDSymmetricKey(id []byte) error {
 	panic("implement me")
 }
 
-func (keystore *testKeystore) GeneratePoisonRecordSymmetricKey() error {
+func (keystore *testKeystore) GeneratePoisonSymmetricKey() error {
 	panic("implement me")
 }
 

--- a/cmd/acra-translator/grpc_api/api_test.go
+++ b/cmd/acra-translator/grpc_api/api_test.go
@@ -40,6 +40,10 @@ func (keystore *testKeystore) GeneratePoisonRecordSymmetricKey() error {
 	panic("implement me")
 }
 
+func (keystore *testKeystore) GeneratePoisonKeyPair() error {
+	panic("implement me")
+}
+
 func (keystore *testKeystore) ListKeys() ([]keystore.KeyDescription, error) {
 	panic("implement me")
 }

--- a/keystore/filesystem/server_keystore.go
+++ b/keystore/filesystem/server_keystore.go
@@ -1244,19 +1244,13 @@ func (store *KeyStore) GenerateZoneIDSymmetricKey(id []byte) error {
 // GeneratePoisonSymmetricKey generate symmetric key for poison records
 func (store *KeyStore) GeneratePoisonSymmetricKey() error {
 	keyName := getSymmetricKeyName(PoisonKeyFilename)
-	exists, err := store.fs.Exists(keyName)
-	if err != nil {
-		return err
-	}
-	if exists {
-		return nil
-	}
-
-	return store.generateAndSaveSymmetricKey([]byte(keyName), store.GetPrivateKeyFilePath(keyName))
+	keyPath := store.GetPrivateKeyFilePath(keyName)
+	return store.generateAndSaveSymmetricKey([]byte(keyName), keyPath)
 }
 
 func (store *KeyStore) GeneratePoisonKeyPair() error {
-	panic("todo")
+	_, err := store.generateKeyPair(PoisonKeyFilename, []byte(PoisonKeyFilename))
+	return err
 }
 
 func (store *KeyStore) getSymmetricKeys(id []byte, keyname string) ([][]byte, error) {

--- a/keystore/filesystem/server_keystore.go
+++ b/keystore/filesystem/server_keystore.go
@@ -1255,6 +1255,10 @@ func (store *KeyStore) GeneratePoisonRecordSymmetricKey() error {
 	return store.generateAndSaveSymmetricKey([]byte(keyName), store.GetPrivateKeyFilePath(keyName))
 }
 
+func (store *KeyStore) GeneratePoisonKeyPair() error {
+	panic("todo")
+}
+
 func (store *KeyStore) getSymmetricKeys(id []byte, keyname string) ([][]byte, error) {
 	keys := make([][]byte, 0, 4)
 	historicalKeys, err := store.GetHistoricalPrivateKeyFilenames(keyname)

--- a/keystore/filesystem/server_keystore.go
+++ b/keystore/filesystem/server_keystore.go
@@ -916,9 +916,9 @@ func (store *KeyStore) Reset() {
 	store.cache.Clear()
 }
 
-// GetPoisonKeyPair generates EC keypair for encrypting/decrypting poison records, and writes it to fs
-// encrypting private key or reads existing keypair from fs.
-// Returns keypair or error if generation/decryption failed.
+// GetPoisonKeyPair reads and returns poison EC keypair from the fs.
+// Returns an error if fs or crypto operations fail. Also, returns ErrKeysNotFound
+// if the key pair doesn't exist.
 func (store *KeyStore) GetPoisonKeyPair() (*keys.Keypair, error) {
 	privateKey, privateOk := store.cache.Get(PoisonKeyFilename)
 	publicKey, publicOk := store.cache.Get(poisonKeyFilenamePublic)
@@ -933,8 +933,7 @@ func (store *KeyStore) GetPoisonKeyPair() (*keys.Keypair, error) {
 	private, err := store.loadPrivateKey(privatePath)
 	if err != nil {
 		if IsKeyReadError(err) {
-			log.Debug("Generate poison key pair")
-			return store.generateKeyPair(PoisonKeyFilename, []byte(PoisonKeyFilename))
+			return nil, keystore.ErrKeysNotFound
 		}
 		return nil, err
 	}
@@ -952,9 +951,10 @@ func (store *KeyStore) GetPoisonKeyPair() (*keys.Keypair, error) {
 	return &keys.Keypair{Public: public, Private: private}, nil
 }
 
-// GetPoisonPrivateKeys returns all private keys used to decrypt poison records, from newest to oldest.
-// If a poison record does not exist, it is created and its sole private key is returned.
-// Returns a list of private poison keys (possibly empty), or an error if decryption fails.
+// GetPoisonPrivateKeys reads and returns poison EC private keys from the fs,
+// returning them in order from newest to oldest.
+// Returns an error if fs or crypto operations fail. Also, returns
+// ErrKeysNotFound if the keys don't exist.
 func (store *KeyStore) GetPoisonPrivateKeys() ([]*keys.PrivateKey, error) {
 	// If some poison keypairs exist, pull their private keys.
 	filenames, err := store.GetHistoricalPrivateKeyFilenames(PoisonKeyFilename)
@@ -964,81 +964,51 @@ func (store *KeyStore) GetPoisonPrivateKeys() ([]*keys.PrivateKey, error) {
 	poisonKeys, err := store.getPrivateKeysByFilenames([]byte(PoisonKeyFilename), filenames)
 	if err != nil {
 		if IsKeyReadError(err) {
-			// If there is no poison record keypair, generated one and returns its private key.
-			log.Debug("Generate poison key pair")
-			keypair, err := store.generateKeyPair(PoisonKeyFilename, []byte(PoisonKeyFilename))
-			if err != nil {
-				return nil, err
-			}
-			return []*keys.PrivateKey{keypair.Private}, nil
-
+			return nil, keystore.ErrKeysNotFound
 		}
 		return nil, err
+	}
+	if len(poisonKeys) == 0 {
+		return nil, keystore.ErrKeysNotFound
 	}
 	return poisonKeys, nil
 }
 
-// GetPoisonSymmetricKeys returns all symmetric keys used to decrypt poison records with AcraBlock, from newest to oldest.
-// If a poison record does not exist, it is created and its sole symmetric key is returned.
-// Returns a list of symmetric poison keys (possibly empty), or an error if decryption fails.
+// GetPoisonSymmetricKeys reads and returns all poison symmetric keys from the
+// fs, returning them in order from newest to oldest.
+// Returns an error if fs or crypto operations fail. Also, returns
+// ErrKeysNotFound if the keys don't exist.
 func (store *KeyStore) GetPoisonSymmetricKeys() ([][]byte, error) {
 	keyFileName := getSymmetricKeyName(PoisonKeyFilename)
-	poisonKeyExists, err := store.fs.Exists(store.GetPrivateKeyFilePath(keyFileName))
+	keys, err := store.getSymmetricKeys([]byte(keyFileName), keyFileName)
+
 	if err != nil {
-		log.Debug("Can't check poison key existence")
+		if IsKeyReadError(err) {
+			return nil, keystore.ErrKeysNotFound
+		}
 		return nil, err
 	}
-	log.WithError(err).WithField("exists", poisonKeyExists).Debug("Get poison sym keys")
-	// If there is no poison record keypair, generated one and returns its private key.
-	if !poisonKeyExists {
-		log.Debugln("Generate poison symmetric key")
-
-		err := store.generateAndSaveSymmetricKey([]byte(keyFileName), store.GetPrivateKeyFilePath(keyFileName))
-		if err != nil {
-			log.Debug("Can't generate new poison sym key")
-			return nil, err
-		}
+	if len(keys) == 0 {
+		return nil, keystore.ErrKeysNotFound
 	}
-	return store.getSymmetricKeys([]byte(keyFileName), keyFileName)
+	return keys, nil
 }
 
-// GetPoisonSymmetricKey returns latest symmetric key for encryption of poison records with AcraBlock.
-// If a poison record does not exist, it is created and its sole symmetric key is returned.
+// GetPoisonSymmetricKey reads and returns poison symmetric key from the fs.
+// Returns an error if fs or crypto operations fail. Also, returns
+// ErrKeysNotFound if the keys don't exist.
 func (store *KeyStore) GetPoisonSymmetricKey() ([]byte, error) {
 	keyFileName := getSymmetricKeyName(PoisonKeyFilename)
-
-	// Try getting it from cache first
-	key, ok := store.cache.Get(keyFileName)
-	if ok {
-		decryptedKey, err := store.encryptor.Decrypt(key, []byte(keyFileName))
-		if err != nil {
-			return nil, err
-		}
-
-		return decryptedKey, nil
-	}
-
-	// Not cached? Try reading it
 	key, err := store.getLatestSymmetricKey([]byte(keyFileName), keyFileName)
 	if err == nil {
 		return key, nil
 	}
 
-	// Does not exist? Generate it!
-	log.Debugln("Generating poison symmetric key")
-	err = store.generateAndSaveSymmetricKey([]byte(keyFileName), store.GetPrivateKeyFilePath(keyFileName))
-	if err != nil {
-		log.Debug("Can't generate new poison sym key")
-		return nil, err
+	if IsKeyReadError(err) {
+		return nil, keystore.ErrKeysNotFound
 	}
 
-	// And read again, this time should be successful
-	key, err = store.getLatestSymmetricKey([]byte(keyFileName), keyFileName)
-	if err != nil {
-		return nil, err
-	}
-
-	return key, nil
+	return nil, err
 }
 
 // RotateZoneKey generate new key pair for ZoneId, overwrite private key with new and return new public key

--- a/keystore/filesystem/server_keystore.go
+++ b/keystore/filesystem/server_keystore.go
@@ -1241,8 +1241,8 @@ func (store *KeyStore) GenerateZoneIDSymmetricKey(id []byte) error {
 	return store.generateAndSaveSymmetricKey(id, store.GetPrivateKeyFilePath(keyName))
 }
 
-// GeneratePoisonRecordSymmetricKey generate symmetric key for poison records
-func (store *KeyStore) GeneratePoisonRecordSymmetricKey() error {
+// GeneratePoisonSymmetricKey generate symmetric key for poison records
+func (store *KeyStore) GeneratePoisonSymmetricKey() error {
 	keyName := getSymmetricKeyName(PoisonKeyFilename)
 	exists, err := store.fs.Exists(keyName)
 	if err != nil {

--- a/keystore/filesystem/server_keystore.go
+++ b/keystore/filesystem/server_keystore.go
@@ -1218,6 +1218,8 @@ func (store *KeyStore) GeneratePoisonSymmetricKey() error {
 	return store.generateAndSaveSymmetricKey([]byte(keyName), keyPath)
 }
 
+// GeneratePoisonKeyPair generates new poison keypair, saving it in the storage.
+// Old keypair is rotated.
 func (store *KeyStore) GeneratePoisonKeyPair() error {
 	_, err := store.generateKeyPair(PoisonKeyFilename, []byte(PoisonKeyFilename))
 	return err

--- a/keystore/filesystem/server_keystore_test.go
+++ b/keystore/filesystem/server_keystore_test.go
@@ -1315,3 +1315,191 @@ func TestKeyStore_GetPoisonKeyPair(t *testing.T) {
 		}
 	})
 }
+
+func getKeystore() (*KeyStore, string, error) {
+	keyDir, err := ioutil.TempDir(os.TempDir(), "testKeystore")
+
+	encryptor, err := keystore.NewSCellKeyEncryptor([]byte("some key"))
+	if err != nil {
+		return nil, "", err
+	}
+	keyStore, err := NewCustomFilesystemKeyStore().
+		KeyDirectory(keyDir).
+		Encryptor(encryptor).
+		Storage(&fileStorage{}).
+		Build()
+	return keyStore, keyDir, nil
+}
+
+func TestPoisonKeyGeneration(t *testing.T) {
+	keyStore, path, err := getKeystore()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer os.RemoveAll(path)
+
+	t.Run("Poison keys don't generate on Get", func(t *testing.T) {
+		_, err := keyStore.GetPoisonKeyPair()
+		if err != keystore.ErrKeysNotFound {
+			t.Fatalf("Expected ErrKeysNotFound, but got %v", err)
+		}
+
+		_, err = keyStore.GetPoisonSymmetricKey()
+		if err != keystore.ErrKeysNotFound {
+			t.Fatalf("Expected ErrKeysNotFound, but got %v", err)
+		}
+
+		_, err = keyStore.GetPoisonPrivateKeys()
+		if err != keystore.ErrKeysNotFound {
+			t.Fatalf("Expected ErrKeysNotFound, but got %v", err)
+		}
+		_, err = keyStore.GetPoisonSymmetricKeys()
+		if err != keystore.ErrKeysNotFound {
+			t.Fatalf("Expected ErrKeysNotFound, but got %v", err)
+		}
+	})
+
+	t.Run("Poison keys can be generated", func(t *testing.T) {
+		err := keyStore.GeneratePoisonKeyPair()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = keyStore.GeneratePoisonSymmetricKey()
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("Poison key are generated successfully", func(t *testing.T) {
+		keyPair, err := keyStore.GetPoisonKeyPair()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		symKey, err := keyStore.GetPoisonSymmetricKey()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(symKey) != keystore.SymmetricKeyLength {
+			t.Fatalf("Wrong length: expected %d, but got %d", keystore.SymmetricKeyLength, len(symKey))
+		}
+
+		privateKeys, err := keyStore.GetPoisonPrivateKeys()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(privateKeys) != 1 {
+			t.Fatalf("Wrong number of private keys: expected 1, but got %d", len(privateKeys))
+		}
+		if !bytes.Equal(privateKeys[0].Value, keyPair.Private.Value) {
+			t.Fatal("Private keys are not equal")
+		}
+
+		symKeys, err := keyStore.GetPoisonSymmetricKeys()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(symKeys) != 1 {
+			t.Fatalf("Wrong number of symmetric keys: expected 1, but got %d", len(symKeys))
+		}
+		if !bytes.Equal(symKeys[0], symKey) {
+			t.Fatal("Symmetric keys are not equal")
+		}
+	})
+
+	t.Run("Poison keys can be rotated", func(t *testing.T) {
+		// Save old keys
+		oldKeyPair, err := keyStore.GetPoisonKeyPair()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		oldSymKey, err := keyStore.GetPoisonSymmetricKey()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Generate new ones
+		err = keyStore.GeneratePoisonKeyPair()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = keyStore.GeneratePoisonSymmetricKey()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// TODO: for some reasons, new keys are not added to the cache. This
+		// resuts in a retrieval of wrong key.
+		// In theory, that's not a problem for Acra, because keys are generated
+		// and used by different entities (keymaker and Acra-server), but still
+		// could be an issue, if someone wants to rotate keys on the fly.
+		// .CacheSize(0) don't help
+		keyStore.cache.Clear()
+
+		// Retrieve new ones
+		newKeyPair, err := keyStore.GetPoisonKeyPair()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		newSymKey, err := keyStore.GetPoisonSymmetricKey()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		privateKeys, err := keyStore.GetPoisonPrivateKeys()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		symKeys, err := keyStore.GetPoisonSymmetricKeys()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Compare
+
+		if bytes.Equal(oldKeyPair.Private.Value, newKeyPair.Private.Value) {
+			t.Fatal("Private keys are equal after rotation")
+		}
+
+		if bytes.Equal(oldKeyPair.Public.Value, newKeyPair.Public.Value) {
+			t.Fatal("Public keys are equal after rotation")
+		}
+
+		if bytes.Equal(oldSymKey, newSymKey) {
+			t.Fatal("Symmetric keys are equal after rotation")
+		}
+
+		if len(privateKeys) != 2 {
+			t.Fatalf("Wrong number of private keys: expected 2, but got %d", len(privateKeys))
+		}
+		if len(symKeys) != 2 {
+			t.Fatalf("Wrong number of symmetric keys: expected 2, but got %d", len(symKeys))
+		}
+
+		if !bytes.Equal(privateKeys[0].Value, newKeyPair.Private.Value) {
+			t.Fatal("First private key should be the newest one")
+		}
+
+		if !bytes.Equal(privateKeys[1].Value, oldKeyPair.Private.Value) {
+			t.Fatal("First private key should be the oldest one")
+		}
+
+		if !bytes.Equal(privateKeys[0].Value, newKeyPair.Private.Value) {
+			t.Fatal("First private key should be the newest one")
+		}
+
+		if !bytes.Equal(symKeys[0], newSymKey) {
+			t.Fatal("First symmetric key should be the newest one")
+		}
+
+		if !bytes.Equal(symKeys[1], oldSymKey) {
+			t.Fatal("Second symmetric key should be the oldest one")
+		}
+	})
+}

--- a/keystore/filesystem/server_keystore_test.go
+++ b/keystore/filesystem/server_keystore_test.go
@@ -1254,6 +1254,27 @@ func TestKeyStore_GetPoisonKeyPair(t *testing.T) {
 		}
 	})
 
+	t.Run("Check keys don't generate on Get", func(t *testing.T) {
+		_, err := keyStore.GetPoisonKeyPair()
+		if err != keystore.ErrKeysNotFound {
+			t.Fatalf("Expected ErrKeysNotFound, but got %v", err)
+		}
+
+		_, err = keyStore.GetPoisonSymmetricKey()
+		if err != keystore.ErrKeysNotFound {
+			t.Fatalf("Expected ErrKeysNotFound, but got %v", err)
+		}
+
+		_, err = keyStore.GetPoisonPrivateKeys()
+		if err != keystore.ErrKeysNotFound {
+			t.Fatalf("Expected ErrKeysNotFound, but got %v", err)
+		}
+		_, err = keyStore.GetPoisonSymmetricKeys()
+		if err != keystore.ErrKeysNotFound {
+			t.Fatalf("Expected ErrKeysNotFound, but got %v", err)
+		}
+	})
+
 	if err = keyStore.GeneratePoisonKeyPair(); err != nil {
 		t.Fatal(err)
 	}

--- a/keystore/filesystem/server_keystore_test.go
+++ b/keystore/filesystem/server_keystore_test.go
@@ -693,10 +693,10 @@ func testFilesystemKeyStoreWithOnlyCachedData(storage Storage, t *testing.T) {
 	if err := store.GenerateClientIDSymmetricKey(testID); err != nil {
 		t.Fatal(err)
 	}
-	if err := store.GeneratePoisonRecordSymmetricKey(); err != nil {
+	if err := store.GeneratePoisonSymmetricKey(); err != nil {
 		t.Fatal(err)
 	}
-	if err := store.GeneratePoisonRecordSymmetricKey(); err != nil {
+	if err := store.GeneratePoisonSymmetricKey(); err != nil {
 		t.Fatal(err)
 	}
 	// we don't have public function to generate poison record keypair because it's generated on first fetch operation

--- a/keystore/keystore.go
+++ b/keystore/keystore.go
@@ -290,7 +290,8 @@ type KeyMaking interface {
 
 // PoisonKeyStore provides access to poison record key pairs.
 type PoisonKeyStore interface {
-	// Reads current poison record key pair, creating it if it does not exist yet.
+	// Reads current poison record key pair, returning ErrKeysNotFound if it
+	// does not exist yet.
 	GetPoisonKeyPair() (*keys.Keypair, error)
 	GetPoisonPrivateKeys() ([]*keys.PrivateKey, error)
 	GetPoisonSymmetricKeys() ([][]byte, error)

--- a/keystore/keystore.go
+++ b/keystore/keystore.go
@@ -106,6 +106,9 @@ type SymmetricEncryptionKeyStore interface {
 type SymmetricEncryptionKeyStoreGenerator interface {
 	GenerateClientIDSymmetricKey(id []byte) error
 	GenerateZoneIDSymmetricKey(id []byte) error
+}
+
+type PoisonKeyGenerator interface {
 	GeneratePoisonRecordSymmetricKey() error
 }
 
@@ -278,7 +281,8 @@ type StorageKeyGenerator interface {
 // KeyMaking enables keystore initialization. It is used by acra-keymaker tool.
 type KeyMaking interface {
 	StorageKeyCreation
-	PoisonKeyStore
+	PoisonKeyStore // TEMPORARY
+	PoisonKeyGenerator
 	AuditLogKeyGenerator
 	HmacKeyGenerator
 	SymmetricEncryptionKeyStoreGenerator

--- a/keystore/keystore.go
+++ b/keystore/keystore.go
@@ -109,7 +109,7 @@ type SymmetricEncryptionKeyStoreGenerator interface {
 }
 
 type PoisonKeyGenerator interface {
-	GeneratePoisonRecordSymmetricKey() error
+	GeneratePoisonSymmetricKey() error
 	GeneratePoisonKeyPair() error
 }
 

--- a/keystore/keystore.go
+++ b/keystore/keystore.go
@@ -110,6 +110,7 @@ type SymmetricEncryptionKeyStoreGenerator interface {
 
 type PoisonKeyGenerator interface {
 	GeneratePoisonRecordSymmetricKey() error
+	GeneratePoisonKeyPair() error
 }
 
 // AuditLogKeyStore keeps symmetric keys for audit log signtures.

--- a/keystore/keystore.go
+++ b/keystore/keystore.go
@@ -282,7 +282,6 @@ type StorageKeyGenerator interface {
 // KeyMaking enables keystore initialization. It is used by acra-keymaker tool.
 type KeyMaking interface {
 	StorageKeyCreation
-	PoisonKeyStore // TEMPORARY
 	PoisonKeyGenerator
 	AuditLogKeyGenerator
 	HmacKeyGenerator

--- a/keystore/keystore.go
+++ b/keystore/keystore.go
@@ -298,6 +298,13 @@ type PoisonKeyStore interface {
 	GetPoisonSymmetricKey() ([]byte, error)
 }
 
+// PoisonKeyStorageAndGenerator has all methods to create and retrieve various
+// keys dedicated to poison records.
+type PoisonKeyStorageAndGenerator interface {
+	PoisonKeyStore
+	PoisonKeyGenerator
+}
+
 // ServerKeyStore enables AcraStruct encryption, decryption,
 // and secure communication of acra-server with other services.
 type ServerKeyStore interface {

--- a/keystore/keystore.go
+++ b/keystore/keystore.go
@@ -108,6 +108,7 @@ type SymmetricEncryptionKeyStoreGenerator interface {
 	GenerateZoneIDSymmetricKey(id []byte) error
 }
 
+// PoisonKeyGenerator is responsible for generation of poison keys.
 type PoisonKeyGenerator interface {
 	GeneratePoisonSymmetricKey() error
 	GeneratePoisonKeyPair() error

--- a/keystore/mocks/KeyStore.go
+++ b/keystore/mocks/KeyStore.go
@@ -70,8 +70,8 @@ func (_m *KeyStore) GenerateLogKey() error {
 	return r0
 }
 
-// GeneratePoisonRecordSymmetricKey provides a mock function with given fields:
-func (_m *KeyStore) GeneratePoisonRecordSymmetricKey() error {
+// GeneratePoisonSymmetricKey provides a mock function with given fields:
+func (_m *KeyStore) GeneratePoisonSymmetricKey() error {
 	ret := _m.Called()
 
 	var r0 error

--- a/keystore/mocks/ServerKeyStore.go
+++ b/keystore/mocks/ServerKeyStore.go
@@ -56,20 +56,6 @@ func (_m *ServerKeyStore) GenerateDataEncryptionKeys(clientID []byte) error {
 	return r0
 }
 
-// GeneratePoisonRecordSymmetricKey provides a mock function with given fields:
-func (_m *ServerKeyStore) GeneratePoisonRecordSymmetricKey() error {
-	ret := _m.Called()
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func() error); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
 // GenerateZoneIDSymmetricKey provides a mock function with given fields: id
 func (_m *ServerKeyStore) GenerateZoneIDSymmetricKey(id []byte) error {
 	ret := _m.Called(id)

--- a/keystore/v2/keystore/importV1_test.go
+++ b/keystore/v2/keystore/importV1_test.go
@@ -101,8 +101,11 @@ func TestImportKeyStoreV1(t *testing.T) {
 	if err != nil {
 		t.Errorf("GetZonePrivateKey() failed: %v", err)
 	}
-	// Since we cannot access all generated key pairs via AcraServer keystore,
-	// we generate them here and use Save... API
+
+	if err = keyStoreV1.GeneratePoisonKeyPair(); err != nil {
+		t.Errorf("GeneratePoisonKeyPair() failed: %v", err)
+	}
+
 	poisonKeyPairV1, err := keyStoreV1.GetPoisonKeyPair()
 	if err != nil {
 		t.Errorf("GetPoisonKeyPair() failed: %v", err)

--- a/keystore/v2/keystore/poison.go
+++ b/keystore/v2/keystore/poison.go
@@ -149,6 +149,10 @@ func (s *ServerKeyStore) GeneratePoisonRecordSymmetricKey() error {
 	return nil
 }
 
+func (store *ServerKeyStore) GeneratePoisonKeyPair() error {
+	panic("todo")
+}
+
 func (s *ServerKeyStore) importPoisonRecordSymmetricKey(poisonKey []byte) error {
 	log := s.log
 	ring, err := s.OpenKeyRingRW(poisonSymmetricKeyPath)

--- a/keystore/v2/keystore/poison.go
+++ b/keystore/v2/keystore/poison.go
@@ -89,7 +89,7 @@ func (s *ServerKeyStore) GetPoisonSymmetricKeys() ([][]byte, error) {
 	symmetricKeys, err := s.allSymmetricKeys(ring)
 	if err != nil {
 		s.log.WithError(err).Debug("Failed to get poison record symmetric keys")
-		if err := s.GeneratePoisonRecordSymmetricKey(); err != nil {
+		if err := s.GeneratePoisonSymmetricKey(); err != nil {
 			return nil, err
 		}
 		return s.allSymmetricKeys(ring)
@@ -110,7 +110,7 @@ func (s *ServerKeyStore) GetPoisonSymmetricKey() ([]byte, error) {
 	symmetricKey, err := s.currentSymmetricKey(ring)
 	if err != nil {
 		s.log.WithError(err).Debug("Failed to get current poison record symmetric key")
-		if err := s.GeneratePoisonRecordSymmetricKey(); err != nil {
+		if err := s.GeneratePoisonSymmetricKey(); err != nil {
 			return nil, err
 		}
 		return s.currentSymmetricKey(ring)
@@ -133,8 +133,8 @@ func (s *ServerKeyStore) savePoisonKeyPair(keypair *keys.Keypair) error {
 	return nil
 }
 
-// GeneratePoisonRecordSymmetricKey generates new poison record symmetric key.
-func (s *ServerKeyStore) GeneratePoisonRecordSymmetricKey() error {
+// GeneratePoisonSymmetricKey generates new poison record symmetric key.
+func (s *ServerKeyStore) GeneratePoisonSymmetricKey() error {
 	log := s.log
 	ring, err := s.OpenKeyRingRW(poisonSymmetricKeyPath)
 	if err != nil {

--- a/keystore/v2/keystore/poison.go
+++ b/keystore/v2/keystore/poison.go
@@ -17,6 +17,7 @@
 package keystore
 
 import (
+	"github.com/cossacklabs/acra/keystore"
 	"github.com/cossacklabs/acra/keystore/v2/keystore/api"
 	"github.com/cossacklabs/themis/gothemis/keys"
 )
@@ -29,8 +30,8 @@ const (
 	poisonKeyPath          = "poison-record"
 )
 
-// GetPoisonKeyPair retrieves current poison record key pair.
-// The keypair is created if it does not exist yet.
+// GetPoisonKeyPair retrieves current poison EC keypair.
+// Returns ErrKeysNotFound if the keypair doesn't exist.
 func (s *ServerKeyStore) GetPoisonKeyPair() (*keys.Keypair, error) {
 	ring, err := s.OpenKeyRingRW(poisonKeyPath)
 	if err != nil {
@@ -40,8 +41,7 @@ func (s *ServerKeyStore) GetPoisonKeyPair() (*keys.Keypair, error) {
 	}
 	keypair, err := s.currentKeyPair(ring)
 	if err == api.ErrNoCurrentKey {
-		s.log.Debug("Generate poison record key pair")
-		return s.newCurrentKeyPair(ring)
+		return nil, keystore.ErrKeysNotFound
 	}
 	if err != nil {
 		s.log.WithError(err).Debug("failed to get current poison record key pair")
@@ -50,9 +50,9 @@ func (s *ServerKeyStore) GetPoisonKeyPair() (*keys.Keypair, error) {
 	return keypair, nil
 }
 
-// GetPoisonPrivateKeys returns all private keys used to decrypt poison records, from newest to oldest.
-// If a poison record does not exist, it is created and its sole private key is returned.
-// Returns a list of private poison keys (possibly empty), or an error if decryption fails.
+// GetPoisonPrivateKeys returns all private keys used to decrypt poison records,
+// from newest to oldest.
+// Returns ErrKeysNotFound if the keys don't exist.
 func (s *ServerKeyStore) GetPoisonPrivateKeys() ([]*keys.PrivateKey, error) {
 	ring, err := s.OpenKeyRingRW(poisonKeyPath)
 	if err != nil {
@@ -66,18 +66,14 @@ func (s *ServerKeyStore) GetPoisonPrivateKeys() ([]*keys.PrivateKey, error) {
 		return nil, err
 	}
 	if len(privateKeys) == 0 {
-		keypair, err := s.newCurrentKeyPair(ring)
-		if err != nil {
-			s.log.WithError(err).Debug("Failed to generated poison record key")
-		}
-		privateKeys = []*keys.PrivateKey{keypair.Private}
+		return nil, keystore.ErrKeysNotFound
 	}
 	return privateKeys, nil
 }
 
-// GetPoisonSymmetricKeys returns all symmetric keys used to decrypt poison records with AcraBlock, from newest to oldest.
-// If a poison record does not exist, it is created and its sole symmetric key is returned.
-// Returns a list of symmetric poison keys (possibly empty), or an error if decryption fails.
+// GetPoisonSymmetricKeys returns all symmetric keys used to decrypt poison
+// records with AcraBlock, from newest to oldest.
+// Returns ErrKeysNotFound if the keys don't exist.
 func (s *ServerKeyStore) GetPoisonSymmetricKeys() ([][]byte, error) {
 	ring, err := s.OpenKeyRingRW(poisonSymmetricKeyPath)
 	if err != nil {
@@ -88,17 +84,17 @@ func (s *ServerKeyStore) GetPoisonSymmetricKeys() ([][]byte, error) {
 
 	symmetricKeys, err := s.allSymmetricKeys(ring)
 	if err != nil {
-		s.log.WithError(err).Debug("Failed to get poison record symmetric keys")
-		if err := s.GeneratePoisonSymmetricKey(); err != nil {
-			return nil, err
-		}
-		return s.allSymmetricKeys(ring)
+		return nil, err
+	}
+	if len(symmetricKeys) == 0 {
+		return nil, keystore.ErrKeysNotFound
 	}
 	return symmetricKeys, nil
 }
 
-// GetPoisonSymmetricKey returns latest symmetric key for encryption of poison records with AcraBlock.
-// If a poison record does not exist, it is created and its sole symmetric key is returned.
+// GetPoisonSymmetricKey returns latest symmetric key for encryption of poison
+// records with AcraBlock.
+// Returns ErrKeysNotFound if the keys don't exist.
 func (s *ServerKeyStore) GetPoisonSymmetricKey() ([]byte, error) {
 	ring, err := s.OpenKeyRingRW(poisonSymmetricKeyPath)
 	if err != nil {
@@ -108,12 +104,11 @@ func (s *ServerKeyStore) GetPoisonSymmetricKey() ([]byte, error) {
 	}
 
 	symmetricKey, err := s.currentSymmetricKey(ring)
+	if err == api.ErrNoCurrentKey {
+		return nil, keystore.ErrKeysNotFound
+	}
 	if err != nil {
-		s.log.WithError(err).Debug("Failed to get current poison record symmetric key")
-		if err := s.GeneratePoisonSymmetricKey(); err != nil {
-			return nil, err
-		}
-		return s.currentSymmetricKey(ring)
+		return nil, err
 	}
 	return symmetricKey, nil
 }

--- a/keystore/v2/keystore/poison.go
+++ b/keystore/v2/keystore/poison.go
@@ -144,13 +144,15 @@ func (s *ServerKeyStore) GeneratePoisonSymmetricKey() error {
 	return nil
 }
 
-func (store *ServerKeyStore) GeneratePoisonKeyPair() error {
-	ring, err := store.OpenKeyRingRW(poisonKeyPath)
+// GeneratePoisonKeyPair generates new poison keypair, saving it in the storage.
+// Old keypair is rotated.
+func (s *ServerKeyStore) GeneratePoisonKeyPair() error {
+	ring, err := s.OpenKeyRingRW(poisonKeyPath)
 	if err != nil {
-		store.log.WithError(err).Debug("Failed to open poison record key ring")
+		s.log.WithError(err).Debug("Failed to open poison record key ring")
 		return err
 	}
-	_, err = store.newCurrentKeyPair(ring)
+	_, err = s.newCurrentKeyPair(ring)
 	return err
 }
 

--- a/keystore/v2/keystore/poison.go
+++ b/keystore/v2/keystore/poison.go
@@ -150,7 +150,13 @@ func (s *ServerKeyStore) GeneratePoisonSymmetricKey() error {
 }
 
 func (store *ServerKeyStore) GeneratePoisonKeyPair() error {
-	panic("todo")
+	ring, err := store.OpenKeyRingRW(poisonKeyPath)
+	if err != nil {
+		store.log.WithError(err).Debug("Failed to open poison record key ring")
+		return err
+	}
+	_, err = store.newCurrentKeyPair(ring)
+	return err
 }
 
 func (s *ServerKeyStore) importPoisonRecordSymmetricKey(poisonKey []byte) error {

--- a/keystore/v2/keystore/poison_test.go
+++ b/keystore/v2/keystore/poison_test.go
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2022, Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package keystore
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/cossacklabs/acra/keystore"
+	"github.com/cossacklabs/acra/keystore/v2/keystore/crypto"
+	"github.com/cossacklabs/acra/keystore/v2/keystore/filesystem"
+)
+
+func getKeystore() (*ServerKeyStore, string, error) {
+	testEncryptionKey := []byte("test encryptionn key")
+	testSignatureKey := []byte("test signature key")
+
+	keyDir, err := ioutil.TempDir(os.TempDir(), "testKeystore")
+
+	suite, err := crypto.NewSCellSuite(testEncryptionKey, testSignatureKey)
+	if err != nil {
+		return nil, "", err
+	}
+	keyDirectoryV2, err := filesystem.OpenDirectoryRW(keyDir, suite)
+	if err != nil {
+		return nil, "", err
+	}
+	return NewServerKeyStore(keyDirectoryV2), keyDir, nil
+}
+
+func TestPoisonKeyGeneration(t *testing.T) {
+	keyStore, path, err := getKeystore()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer os.RemoveAll(path)
+
+	t.Run("Poison keys don't generate on Get", func(t *testing.T) {
+		_, err := keyStore.GetPoisonKeyPair()
+		if err != keystore.ErrKeysNotFound {
+			t.Fatalf("Expected ErrKeysNotFound, but got %v", err)
+		}
+
+		_, err = keyStore.GetPoisonSymmetricKey()
+		if err != keystore.ErrKeysNotFound {
+			t.Fatalf("Expected ErrKeysNotFound, but got %v", err)
+		}
+
+		_, err = keyStore.GetPoisonPrivateKeys()
+		if err != keystore.ErrKeysNotFound {
+			t.Fatalf("Expected ErrKeysNotFound, but got %v", err)
+		}
+		_, err = keyStore.GetPoisonSymmetricKeys()
+		if err != keystore.ErrKeysNotFound {
+			t.Fatalf("Expected ErrKeysNotFound, but got %v", err)
+		}
+	})
+
+	t.Run("Poison keys can be generated", func(t *testing.T) {
+		err := keyStore.GeneratePoisonKeyPair()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = keyStore.GeneratePoisonSymmetricKey()
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("Poison key are generated successfully", func(t *testing.T) {
+		keyPair, err := keyStore.GetPoisonKeyPair()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		symKey, err := keyStore.GetPoisonSymmetricKey()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(symKey) != keystore.SymmetricKeyLength {
+			t.Fatalf("Wrong length: expected %d, but got %d", keystore.SymmetricKeyLength, len(symKey))
+		}
+
+		privateKeys, err := keyStore.GetPoisonPrivateKeys()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(privateKeys) != 1 {
+			t.Fatalf("Wrong number of private keys: expected 1, but got %d", len(privateKeys))
+		}
+		if !bytes.Equal(privateKeys[0].Value, keyPair.Private.Value) {
+			t.Fatal("Private keys are not equal")
+		}
+
+		symKeys, err := keyStore.GetPoisonSymmetricKeys()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(symKeys) != 1 {
+			t.Fatalf("Wrong number of symmetric keys: expected 1, but got %d", len(symKeys))
+		}
+		if !bytes.Equal(symKeys[0], symKey) {
+			t.Fatal("Symmetric keys are not equal")
+		}
+	})
+
+	t.Run("Poison keys can be rotated", func(t *testing.T) {
+		// Save old keys
+		oldKeyPair, err := keyStore.GetPoisonKeyPair()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		oldSymKey, err := keyStore.GetPoisonSymmetricKey()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Generate new ones
+		err = keyStore.GeneratePoisonKeyPair()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = keyStore.GeneratePoisonSymmetricKey()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Retrieve new ones
+		newKeyPair, err := keyStore.GetPoisonKeyPair()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		newSymKey, err := keyStore.GetPoisonSymmetricKey()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		privateKeys, err := keyStore.GetPoisonPrivateKeys()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		symKeys, err := keyStore.GetPoisonSymmetricKeys()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Compare
+
+		if bytes.Equal(oldKeyPair.Private.Value, newKeyPair.Private.Value) {
+			t.Fatal("Private keys are equal after rotation")
+		}
+
+		if bytes.Equal(oldKeyPair.Public.Value, newKeyPair.Public.Value) {
+			t.Fatal("Public keys are equal after rotation")
+		}
+
+		if bytes.Equal(oldSymKey, newSymKey) {
+			t.Fatal("Symmetric keys are equal after rotation")
+		}
+
+		if len(privateKeys) != 2 {
+			t.Fatalf("Wrong number of private keys: expected 2, but got %d", len(privateKeys))
+		}
+		if len(symKeys) != 2 {
+			t.Fatalf("Wrong number of symmetric keys: expected 2, but got %d", len(symKeys))
+		}
+
+		if !bytes.Equal(privateKeys[0].Value, newKeyPair.Private.Value) {
+			t.Fatal("First private key should be the newest one")
+		}
+
+		if !bytes.Equal(privateKeys[1].Value, oldKeyPair.Private.Value) {
+			t.Fatal("First private key should be the oldest one")
+		}
+
+		if !bytes.Equal(privateKeys[0].Value, newKeyPair.Private.Value) {
+			t.Fatal("First private key should be the newest one")
+		}
+
+		if !bytes.Equal(symKeys[0], newSymKey) {
+			t.Fatal("First symmetric key should be the newest one")
+		}
+
+		if !bytes.Equal(symKeys[1], oldSymKey) {
+			t.Fatal("Second symmetric key should be the oldest one")
+		}
+	})
+}

--- a/poison/poison.go
+++ b/poison/poison.go
@@ -54,12 +54,19 @@ func createPoisonRecordData(dataLength int) ([]byte, error) {
 }
 
 // CreatePoisonRecord generates AcraStruct encrypted with Poison Record public key
-func CreatePoisonRecord(keystore keystore.PoisonKeyStore, dataLength int) ([]byte, error) {
+func CreatePoisonRecord(keyStore keystore.PoisonKeyStorageAndGenerator, dataLength int) ([]byte, error) {
 	data, err := createPoisonRecordData(dataLength)
 	if err != nil {
 		return nil, err
 	}
-	poisonKeypair, err := keystore.GetPoisonKeyPair()
+	poisonKeypair, err := keyStore.GetPoisonKeyPair()
+	if err == keystore.ErrKeysNotFound {
+		if err = keyStore.GeneratePoisonKeyPair(); err != nil {
+			return nil, err
+		}
+		poisonKeypair, err = keyStore.GetPoisonKeyPair()
+	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -73,12 +80,18 @@ func CreatePoisonRecord(keystore keystore.PoisonKeyStore, dataLength int) ([]byt
 }
 
 // CreateSymmetricPoisonRecord generates AcraBlock encrypted with Poison Record symmetric key
-func CreateSymmetricPoisonRecord(keyStore keystore.PoisonKeyStore, dataLength int) ([]byte, error) {
+func CreateSymmetricPoisonRecord(keyStore keystore.PoisonKeyStorageAndGenerator, dataLength int) ([]byte, error) {
 	data, err := createPoisonRecordData(dataLength)
 	if err != nil {
 		return nil, err
 	}
 	symmetricKey, err := keyStore.GetPoisonSymmetricKey()
+	if err == keystore.ErrKeysNotFound {
+		if err = keyStore.GeneratePoisonSymmetricKey(); err != nil {
+			return nil, err
+		}
+		symmetricKey, err = keyStore.GetPoisonSymmetricKey()
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/poison/poison.go
+++ b/poison/poison.go
@@ -30,7 +30,6 @@ import (
 	"github.com/cossacklabs/acra/acrastruct"
 	"github.com/cossacklabs/acra/crypto"
 	"github.com/cossacklabs/acra/keystore"
-	"github.com/cossacklabs/themis/gothemis/keys"
 )
 
 // Poison records length constants
@@ -89,10 +88,4 @@ func CreateSymmetricPoisonRecord(keyStore keystore.PoisonKeyStore, dataLength in
 	}
 
 	return crypto.SerializeEncryptedData(acraBlock, crypto.AcraBlockEnvelopeID)
-}
-
-// RecordProcessorKeyStore interface with required methods for RecordProcessor
-type RecordProcessorKeyStore interface {
-	GetPoisonPrivateKeys() ([]*keys.PrivateKey, error)
-	GetPoisonSymmetricKeys() ([][]byte, error)
 }

--- a/sqlparser/sql.go
+++ b/sqlparser/sql.go
@@ -653,7 +653,7 @@ const yyErrCode = 2
 const yyInitialStackSize = 16
 
 //line yacctab:1
-var yyExca = [...]int{
+var yyExca = [...]int16{
 	-1, 1,
 	1, -1,
 	-2, 0,
@@ -720,7 +720,7 @@ const yyPrivate = 57344
 
 const yyLast = 12194
 
-var yyAct = [...]int{
+var yyAct = [...]int16{
 	285, 53, 1345, 924, 679, 500, 255, 840, 1302, 858,
 	876, 549, 1176, 1148, 880, 1149, 229, 1250, 1073, 882,
 	1145, 284, 598, 918, 879, 59, 24, 548, 3, 220,
@@ -1943,7 +1943,7 @@ var yyAct = [...]int{
 	175, 139, 101, 166,
 }
 
-var yyPact = [...]int{
+var yyPact = [...]int16{
 	1451, -1000, -210, -1000, -1000, -1000, -1000, -1000, -1000, -1000,
 	-1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000,
 	-1000, -1000, -1000, -1000, 811, 831, -1000, -1000, -1000, -1000,
@@ -2084,7 +2084,7 @@ var yyPact = [...]int{
 	-201, 571, -204, 7408, -1000, 2135, 342, -1000, -1000,
 }
 
-var yyPgo = [...]int{
+var yyPgo = [...]int16{
 	0, 1056, 27, 26, 1055, 1053, 1052, 844, 842, 840,
 	1051, 1047, 1046, 1045, 1044, 1043, 1041, 1038, 1037, 1036,
 	1034, 1033, 1026, 1024, 1021, 1018, 1014, 139, 1011, 1008,
@@ -2107,7 +2107,7 @@ var yyPgo = [...]int{
 	854, 852, 851, 850, 0, 163, 848, 838, 100,
 }
 
-var yyR1 = [...]int{
+var yyR1 = [...]uint8{
 	0, 192, 193, 193, 1, 1, 1, 1, 1, 1,
 	1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
 	1, 1, 1, 1, 1, 2, 2, 2, 6, 3,
@@ -2196,7 +2196,7 @@ var yyR1 = [...]int{
 	133,
 }
 
-var yyR2 = [...]int{
+var yyR2 = [...]int8{
 	0, 2, 0, 1, 1, 1, 1, 1, 1, 1,
 	1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
 	1, 1, 1, 1, 1, 4, 6, 7, 5, 10,
@@ -2285,7 +2285,7 @@ var yyR2 = [...]int{
 	1,
 }
 
-var yyChk = [...]int{
+var yyChk = [...]int16{
 	-1000, -192, -1, -2, -6, -7, -8, -9, -10, -11,
 	-12, -13, -14, -15, -17, -18, -19, -21, -22, -23,
 	-20, -24, -25, -26, -3, -4, 6, 7, -30, 9,
@@ -2426,7 +2426,7 @@ var yyChk = [...]int{
 	272, 169, 273, -194, 274, -64, 165, -195, -195,
 }
 
-var yyDef = [...]int{
+var yyDef = [...]int16{
 	0, -2, 2, -2, 5, 6, 7, 8, 9, 10,
 	11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
 	21, 22, 23, 24, 544, 0, 301, 301, 301, 301,
@@ -2567,7 +2567,7 @@ var yyDef = [...]int{
 	0, 0, 0, 0, 493, 0, 0, 226, 227,
 }
 
-var yyTok1 = [...]int{
+var yyTok1 = [...]int16{
 	1, 3, 3, 3, 3, 3, 3, 3, 3, 3,
 	3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
 	3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
@@ -2583,7 +2583,7 @@ var yyTok1 = [...]int{
 	3, 3, 3, 3, 116, 3, 128,
 }
 
-var yyTok2 = [...]int{
+var yyTok2 = [...]int16{
 	2, 3, 4, 5, 6, 7, 8, 9, 10, 11,
 	12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
 	22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
@@ -2612,7 +2612,7 @@ var yyTok2 = [...]int{
 	269, 270, 271, 272, 273, 274,
 }
 
-var yyTok3 = [...]int{
+var yyTok3 = [...]uint16{
 	57600, 275, 57601, 276, 0,
 }
 
@@ -2694,9 +2694,9 @@ func yyErrorMessage(state, lookAhead int) string {
 	expected := make([]int, 0, 4)
 
 	// Look for shiftable tokens.
-	base := yyPact[state]
+	base := int(yyPact[state])
 	for tok := TOKSTART; tok-1 < len(yyToknames); tok++ {
-		if n := base + tok; n >= 0 && n < yyLast && yyChk[yyAct[n]] == tok {
+		if n := base + tok; n >= 0 && n < yyLast && int(yyChk[int(yyAct[n])]) == tok {
 			if len(expected) == cap(expected) {
 				return res
 			}
@@ -2706,13 +2706,13 @@ func yyErrorMessage(state, lookAhead int) string {
 
 	if yyDef[state] == -2 {
 		i := 0
-		for yyExca[i] != -1 || yyExca[i+1] != state {
+		for yyExca[i] != -1 || int(yyExca[i+1]) != state {
 			i += 2
 		}
 
 		// Look for tokens that we accept or reduce.
 		for i += 2; yyExca[i] >= 0; i += 2 {
-			tok := yyExca[i]
+			tok := int(yyExca[i])
 			if tok < TOKSTART || yyExca[i+1] == 0 {
 				continue
 			}
@@ -2743,30 +2743,30 @@ func yylex1(lex yyLexer, lval *yySymType) (char, token int) {
 	token = 0
 	char = lex.Lex(lval)
 	if char <= 0 {
-		token = yyTok1[0]
+		token = int(yyTok1[0])
 		goto out
 	}
 	if char < len(yyTok1) {
-		token = yyTok1[char]
+		token = int(yyTok1[char])
 		goto out
 	}
 	if char >= yyPrivate {
 		if char < yyPrivate+len(yyTok2) {
-			token = yyTok2[char-yyPrivate]
+			token = int(yyTok2[char-yyPrivate])
 			goto out
 		}
 	}
 	for i := 0; i < len(yyTok3); i += 2 {
-		token = yyTok3[i+0]
+		token = int(yyTok3[i+0])
 		if token == char {
-			token = yyTok3[i+1]
+			token = int(yyTok3[i+1])
 			goto out
 		}
 	}
 
 out:
 	if token == 0 {
-		token = yyTok2[1] /* unknown char */
+		token = int(yyTok2[1]) /* unknown char */
 	}
 	if yyDebug >= 3 {
 		__yyfmt__.Printf("lex %s(%d)\n", yyTokname(token), uint(char))
@@ -2821,7 +2821,7 @@ yystack:
 	yyS[yyp].yys = yystate
 
 yynewstate:
-	yyn = yyPact[yystate]
+	yyn = int(yyPact[yystate])
 	if yyn <= yyFlag {
 		goto yydefault /* simple state */
 	}
@@ -2832,8 +2832,8 @@ yynewstate:
 	if yyn < 0 || yyn >= yyLast {
 		goto yydefault
 	}
-	yyn = yyAct[yyn]
-	if yyChk[yyn] == yytoken { /* valid shift */
+	yyn = int(yyAct[yyn])
+	if int(yyChk[yyn]) == yytoken { /* valid shift */
 		yyrcvr.char = -1
 		yytoken = -1
 		yyVAL = yyrcvr.lval
@@ -2846,7 +2846,7 @@ yynewstate:
 
 yydefault:
 	/* default state action */
-	yyn = yyDef[yystate]
+	yyn = int(yyDef[yystate])
 	if yyn == -2 {
 		if yyrcvr.char < 0 {
 			yyrcvr.char, yytoken = yylex1(yylex, &yyrcvr.lval)
@@ -2855,18 +2855,18 @@ yydefault:
 		/* look through exception table */
 		xi := 0
 		for {
-			if yyExca[xi+0] == -1 && yyExca[xi+1] == yystate {
+			if yyExca[xi+0] == -1 && int(yyExca[xi+1]) == yystate {
 				break
 			}
 			xi += 2
 		}
 		for xi += 2; ; xi += 2 {
-			yyn = yyExca[xi+0]
+			yyn = int(yyExca[xi+0])
 			if yyn < 0 || yyn == yytoken {
 				break
 			}
 		}
-		yyn = yyExca[xi+1]
+		yyn = int(yyExca[xi+1])
 		if yyn < 0 {
 			goto ret0
 		}
@@ -2888,10 +2888,10 @@ yydefault:
 
 			/* find a state where "error" is a legal shift action */
 			for yyp >= 0 {
-				yyn = yyPact[yyS[yyp].yys] + yyErrCode
+				yyn = int(yyPact[yyS[yyp].yys]) + yyErrCode
 				if yyn >= 0 && yyn < yyLast {
-					yystate = yyAct[yyn] /* simulate a shift of "error" */
-					if yyChk[yystate] == yyErrCode {
+					yystate = int(yyAct[yyn]) /* simulate a shift of "error" */
+					if int(yyChk[yystate]) == yyErrCode {
 						goto yystack
 					}
 				}
@@ -2927,7 +2927,7 @@ yydefault:
 	yypt := yyp
 	_ = yypt // guard against "declared and not used"
 
-	yyp -= yyR2[yyn]
+	yyp -= int(yyR2[yyn])
 	// yyp is now the index of $0. Perform the default action. Iff the
 	// reduced production is ε, $1 is possibly out of range.
 	if yyp+1 >= len(yyS) {
@@ -2938,16 +2938,16 @@ yydefault:
 	yyVAL = yyS[yyp+1]
 
 	/* consult goto table to find next state */
-	yyn = yyR1[yyn]
-	yyg := yyPgo[yyn]
+	yyn = int(yyR1[yyn])
+	yyg := int(yyPgo[yyn])
 	yyj := yyg + yyS[yyp].yys + 1
 
 	if yyj >= yyLast {
-		yystate = yyAct[yyg]
+		yystate = int(yyAct[yyg])
 	} else {
-		yystate = yyAct[yyj]
-		if yyChk[yystate] != -yyn {
-			yystate = yyAct[yyg]
+		yystate = int(yyAct[yyj])
+		if int(yyChk[yystate]) != -yyn {
+			yystate = int(yyAct[yyg])
 		}
 	}
 	// dummy call; replaced with literal code


### PR DESCRIPTION
Right now every call to the `GetPoison*` creates keys, if they don't exist. These results in a superfluous side effect, unexpected behaviour and delays in decryption (because we try to check records with fresh keys, which obviously do nothing useful).

Change this, by:
- Introducing new interface, which is responsible for poison key generation
- Removing creation of keys in `Get` methods

Also, keep this behaviour for poisonrecordmaker, but do this explicitly.

## Checklist

- [x] Change is covered by automated tests
- [x] The [coding guidelines] are followed
- [x] Public API has proper documentation in the [Acra documentation] site or has PR on [documentation repository] 
  with new changes: [here](https://github.com/cossacklabs/product-docs/pull/239).
- [x] ~CHANGELOG.md is updated (in case of notable or breaking changes)~
- [x] CHANGELOG_DEV.md is updated
- [x] ~Benchmark results are attached (if applicable)~
- [x] ~[Example projects and code samples] are up-to-date (in case of API changes)~

[coding guidelines]: https://golang.org/doc/effective_go
[Example projects and code samples]: https://github.com/cossacklabs/acra-engineering-demo
[Acra documentation]: https://docs.cossacklabs.com/
[documentation repository]: https://github.com/cossacklabs/product-docs