### PR TITLE
Remove logging encrypted data

### DIFF
--- a/decryptor/postgresql/data_encoder.go
+++ b/decryptor/postgresql/data_encoder.go
@@ -106,7 +106,7 @@ func (p *PgSQLDataEncoderProcessor) encodeText(ctx context.Context, data []byte,
 	case common2.EncryptedType_String:
 		if !base.IsDecryptedFromContext(ctx) {
 			if newVal := setting.GetDefaultDataValue(); newVal != nil {
-				logger.WithField("data", string(data)).WithField("default", *newVal).Debugln("Change with default")
+				logger.WithField("default", *newVal).Debugln("Change with default")
 				return ctx, []byte(*newVal), nil
 			}
 		}


### PR DESCRIPTION
In one of my previous PRs I didn't remove logging encrypted data*( And @iamnotacake found it when tested eng demo.

We don't need to log encrypted data even for debugging because it will significantly grow log's size.
Plus, we should avoid logging any data because in the future somebody may leave it in code in decrypted form or log before encryption. Just because code is complicated and it is hard to keep in mind all these problems like security, code conventions, design, etc.

<!-- Describe your changes here -->

## Checklist

- [  ] Change is covered by automated tests
- [+] The [coding guidelines] are followed
- [+] Public API has proper documentation in the [Acra documentation] site or has PR on [documentation repository] 
  with new changes
- [+] CHANGELOG.md is updated (in case of notable or breaking changes)
- [+] CHANGELOG_DEV.md is updated
- [+] Benchmark results are attached (if applicable)
- [+] [Example projects and code samples] are up-to-date (in case of API changes) 

[coding guidelines]: https://golang.org/doc/effective_go
[Example projects and code samples]: https://github.com/cossacklabs/acra-engineering-demo
[Acra documentation]: https://docs.cossacklabs.com/
[documentation repository]: https://github.com/cossacklabs/product-docs