### PR TITLE
Convert 'bytes' data_type to BYTEA oid for postgresql

### DIFF
--- a/decryptor/postgresql/type_conversion.go
+++ b/decryptor/postgresql/type_conversion.go
@@ -13,6 +13,8 @@ func mapEncryptedTypeToOID(dataType common.EncryptedType) (uint32, bool) {
 		return pgtype.Int4OID, true
 	case common.EncryptedType_Int64:
 		return pgtype.Int8OID, true
+	case common.EncryptedType_Bytes:
+		return pgtype.ByteaOID, true
 	}
 	return 0, false
 }

--- a/decryptor/postgresql/type_conversion_test.go
+++ b/decryptor/postgresql/type_conversion_test.go
@@ -1,0 +1,37 @@
+package postgresql
+
+import (
+	"github.com/cossacklabs/acra/encryptor/config/common"
+	"github.com/jackc/pgx/pgtype"
+	"testing"
+)
+
+func Test_mapEncryptedTypeToOID(t *testing.T) {
+	type args struct {
+		dataType common.EncryptedType
+	}
+	tests := []struct {
+		name  string
+		args  args
+		want  uint32
+		want1 bool
+	}{
+		{"string", args{common.EncryptedType_String}, pgtype.TextOID, true},
+		{"bytes", args{common.EncryptedType_Bytes}, pgtype.ByteaOID, true},
+		{"int32", args{common.EncryptedType_Int32}, pgtype.Int4OID, true},
+		{"int64", args{common.EncryptedType_Int64}, pgtype.Int8OID, true},
+		{"unknown", args{common.EncryptedType_Unknown}, 0, false},
+		{"different value", args{common.EncryptedType(100500)}, 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1 := mapEncryptedTypeToOID(tt.args.dataType)
+			if got != tt.want {
+				t.Errorf("mapEncryptedTypeToOID() got = %v, want %v", got, tt.want)
+			}
+			if got1 != tt.want1 {
+				t.Errorf("mapEncryptedTypeToOID() got1 = %v, want %v", got1, tt.want1)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Found that `bytes` `data_type` not handled properly for postgresql

## Checklist

- [+] Change is covered by automated tests
- [+] The [coding guidelines] are followed
- [+] Public API has proper documentation in the [Acra documentation] site or has PR on [documentation repository] 
  with new changes
- [+] CHANGELOG.md is updated (in case of notable or breaking changes)
- [+] CHANGELOG_DEV.md is updated
- [+] Benchmark results are attached (if applicable)
- [+] [Example projects and code samples] are up-to-date (in case of API changes) 

[coding guidelines]: https://golang.org/doc/effective_go
[Example projects and code samples]: https://github.com/cossacklabs/acra-engineering-demo
[Acra documentation]: https://docs.cossacklabs.com/
[documentation repository]: https://github.com/cossacklabs/product-docs