### PR TITLE
Add db-specific error

### DIFF
--- a/CHANGELOG_DEV.md
+++ b/CHANGELOG_DEV.md
@@ -1,3 +1,6 @@
+# 0.93.0 - 2022-04-07
+- Extend config with `on_fail` field, which indicates wheter to return error ("error") to a client, or default values ("default") in case of error.
+
 ## 0.93.0 - 2022-03-28
 - Transparent decryption with replacing type's metadata
 - Extend `encryptor_config` with new settings: `data_type=[int32|int64|str|bytes]` and `default_data_value: <SQL int literal | string | base64 string>`

--- a/decryptor/base/encoder.go
+++ b/decryptor/base/encoder.go
@@ -1,0 +1,30 @@
+package base
+
+import "fmt"
+
+// EncodingError is returned from encoding handlers when some failure occurs.
+// This error should be sent to the user directly, so it needs to be own type
+// to be distinguishable.
+type EncodingError struct {
+	column string
+}
+
+func (e *EncodingError) Error() string {
+	return fmt.Sprintf("encoding error in column %q", e.column)
+}
+
+// Is checks if err is the same as target error.
+// It checks the type and the `.column` field.
+// Used in tests to provide functionality of `errors.Is`
+func (e *EncodingError) Is(err error) bool {
+	encErr, ok := err.(*EncodingError)
+	if !ok {
+		return false
+	}
+	return encErr.column == e.column
+}
+
+// NewEncodingError returns new EncodingError with specified column
+func NewEncodingError(column string) error {
+	return &EncodingError{column}
+}

--- a/decryptor/base/proxy.go
+++ b/decryptor/base/proxy.go
@@ -19,8 +19,9 @@ package base
 import (
 	"context"
 	"fmt"
-	"github.com/cossacklabs/acra/network"
 	"net"
+
+	"github.com/cossacklabs/acra/network"
 
 	acracensor "github.com/cossacklabs/acra/acra-censor"
 	"github.com/cossacklabs/acra/encryptor/config"
@@ -220,3 +221,7 @@ func OnlyDefaultEncryptorSettings(store config.TableSchemaStore) bool {
 		config.SettingDefaultDataValueFlag|
 		config.SettingDataTypeFlag) == 0
 }
+
+// AcraCensorBlockedThisQuery is an error message, that is sent to the user in case of
+// query blockage
+const AcraCensorBlockedThisQuery = "AcraCensor blocked this query"

--- a/decryptor/postgresql/data_encoder.go
+++ b/decryptor/postgresql/data_encoder.go
@@ -275,7 +275,7 @@ func (v *intValue) asText() []byte {
 	return []byte(v.strValue)
 }
 
-// encodeDefault returns wrapped default value from settings ready for encdoing
+// encodeDefault returns wrapped default value from settings ready for encoding
 // returns nil if something went wrong, which in many cases indicates that the
 // original value should be returned as it is
 func encodeDefault(setting config.ColumnEncryptionSetting, logger *logrus.Entry) encodingValue {

--- a/decryptor/postgresql/data_encoder.go
+++ b/decryptor/postgresql/data_encoder.go
@@ -16,6 +16,15 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// EncodingError is returned from encoding handlers when some failure occurs.
+// This error should be sent to the user directly, so it needs to be own type
+// to be distinguishable.
+type EncodingError struct{}
+
+func (e *EncodingError) Error() string {
+	return "encoding error"
+}
+
 // PgSQLDataEncoderProcessor implements processor and encode binary/text values before sending to app
 type PgSQLDataEncoderProcessor struct{}
 
@@ -314,6 +323,8 @@ func onFail(setting config.ColumnEncryptionSetting, logger *logrus.Entry) (encod
 		return nil, nil
 	case action == "default":
 		return encodeDefault(setting, logger), nil
+	case action == "error":
+		return nil, &EncodingError{}
 	default:
 		return nil, fmt.Errorf("unknown action")
 	}

--- a/decryptor/postgresql/data_encoder.go
+++ b/decryptor/postgresql/data_encoder.go
@@ -134,7 +134,7 @@ func (p *PgSQLDataEncoderProcessor) OnColumn(ctx context.Context, data []byte) (
 		// for case when data encrypted with acrastructs on app's side and used without any encryption setting
 		columnSetting = &config.BasicColumnEncryptionSetting{}
 	}
-	logger := logging.GetLoggerFromContext(ctx)
+	logger := logging.GetLoggerFromContext(ctx).WithField("column", columnSetting.ColumnName())
 	columnInfo, ok := base.ColumnInfoFromContext(ctx)
 	if !ok {
 		logger.WithField("processor", "PgSQLDataEncoderProcessor").Warningln("No column info in ctx")
@@ -219,7 +219,7 @@ func (p *PgSQLDataDecoderProcessor) OnColumn(ctx context.Context, data []byte) (
 		// for case when data encrypted with acrastructs on app's side and used without any encryption setting
 		columnSetting = &config.BasicColumnEncryptionSetting{}
 	}
-	logger := logging.GetLoggerFromContext(ctx)
+	logger := logging.GetLoggerFromContext(ctx).WithField("column", columnSetting.ColumnName())
 	columnInfo, ok := base.ColumnInfoFromContext(ctx)
 	if !ok {
 		logger.WithField("processor", "PgSQLDataDecoderProcessor").Warningln("No column info in ctx")

--- a/decryptor/postgresql/data_encoder.go
+++ b/decryptor/postgresql/data_encoder.go
@@ -309,14 +309,16 @@ func encodeDefault(setting config.ColumnEncryptionSetting, logger *logrus.Entry)
 // which indicates that original value should be returned as is.
 func onFail(setting config.ColumnEncryptionSetting, logger *logrus.Entry) (encodingValue, error) {
 	action := setting.GetResponseOnFail()
-	switch {
-	case action == "":
+	switch action {
+	case common2.ResponseOnFailEmpty, common2.ResponseOnFailCiphertext:
 		return nil, nil
-	case action == "default":
+
+	case common2.ResponseOnFailDefault:
 		return encodeDefault(setting, logger), nil
-	case action == "error":
+
+	case common2.ResponseOnFailError:
 		return nil, base.NewEncodingError(setting.ColumnName())
-	default:
-		return nil, fmt.Errorf("unknown action: %q", action)
 	}
+
+	return nil, fmt.Errorf("unknown action: %q", action)
 }

--- a/decryptor/postgresql/data_encoder.go
+++ b/decryptor/postgresql/data_encoder.go
@@ -16,15 +16,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// EncodingError is returned from encoding handlers when some failure occurs.
-// This error should be sent to the user directly, so it needs to be own type
-// to be distinguishable.
-type EncodingError struct{}
-
-func (e *EncodingError) Error() string {
-	return "encoding error"
-}
-
 // PgSQLDataEncoderProcessor implements processor and encode binary/text values before sending to app
 type PgSQLDataEncoderProcessor struct{}
 
@@ -324,7 +315,7 @@ func onFail(setting config.ColumnEncryptionSetting, logger *logrus.Entry) (encod
 	case action == "default":
 		return encodeDefault(setting, logger), nil
 	case action == "error":
-		return nil, &EncodingError{}
+		return nil, base.NewEncodingError(setting.ColumnName())
 	default:
 		return nil, fmt.Errorf("unknown action: %q", action)
 	}

--- a/decryptor/postgresql/data_encoder.go
+++ b/decryptor/postgresql/data_encoder.go
@@ -308,7 +308,7 @@ func encodeDefault(setting config.ColumnEncryptionSetting, logger *logrus.Entry)
 // should be encoded, because there is some problem with original, or `nil`
 // which indicates that original value should be returned as is.
 func onFail(setting config.ColumnEncryptionSetting, logger *logrus.Entry) (encodingValue, error) {
-	action := setting.GetOnFail()
+	action := setting.GetResponseOnFail()
 	switch {
 	case action == "":
 		return nil, nil

--- a/decryptor/postgresql/data_encoder.go
+++ b/decryptor/postgresql/data_encoder.go
@@ -42,7 +42,7 @@ func (p *PgSQLDataEncoderProcessor) encodeBinary(ctx context.Context, data []byt
 	switch setting.GetEncryptedDataType() {
 	case common2.EncryptedType_String, common2.EncryptedType_Bytes:
 		if !base.IsDecryptedFromContext(ctx) {
-			if value, err := onFail(setting, logger); err != nil {
+			if value, err := encodeOnFail(setting, logger); err != nil {
 				return ctx, nil, err
 			} else if value != nil {
 				return ctx, value.asBinary(), nil
@@ -62,7 +62,7 @@ func (p *PgSQLDataEncoderProcessor) encodeBinary(ctx context.Context, data []byt
 			val := intValue{size, value, strValue}
 			return ctx, val.asBinary(), nil
 		}
-		if value, err := onFail(setting, logger); err != nil {
+		if value, err := encodeOnFail(setting, logger); err != nil {
 			return ctx, nil, err
 		} else if value != nil {
 			return ctx, value.asBinary(), nil
@@ -89,7 +89,7 @@ func (p *PgSQLDataEncoderProcessor) encodeText(ctx context.Context, data []byte,
 	switch setting.GetEncryptedDataType() {
 	case common2.EncryptedType_String, common2.EncryptedType_Bytes:
 		if !base.IsDecryptedFromContext(ctx) {
-			if value, err := onFail(setting, logger); err != nil {
+			if value, err := encodeOnFail(setting, logger); err != nil {
 				return ctx, nil, err
 			} else if value != nil {
 				return ctx, value.asText(), nil
@@ -103,7 +103,7 @@ func (p *PgSQLDataEncoderProcessor) encodeText(ctx context.Context, data []byte,
 		}
 		// if it's encrypted binary, then it is binary array that is invalid int literal
 		if !base.IsDecryptedFromContext(ctx) {
-			if value, err := onFail(setting, logger); err != nil {
+			if value, err := encodeOnFail(setting, logger); err != nil {
 				return ctx, nil, err
 			} else if value != nil {
 				return ctx, value.asText(), nil
@@ -304,10 +304,10 @@ func encodeDefault(setting config.ColumnEncryptionSetting, logger *logrus.Entry)
 	return nil
 }
 
-// onFail returns either an error, which should be returned, or value, which
+// encodeOnFail returns either an error, which should be returned, or value, which
 // should be encoded, because there is some problem with original, or `nil`
 // which indicates that original value should be returned as is.
-func onFail(setting config.ColumnEncryptionSetting, logger *logrus.Entry) (encodingValue, error) {
+func encodeOnFail(setting config.ColumnEncryptionSetting, logger *logrus.Entry) (encodingValue, error) {
 	action := setting.GetResponseOnFail()
 	switch action {
 	case common2.ResponseOnFailEmpty, common2.ResponseOnFailCiphertext:

--- a/decryptor/postgresql/data_encoder.go
+++ b/decryptor/postgresql/data_encoder.go
@@ -69,7 +69,7 @@ func (p *PgSQLDataEncoderProcessor) encodeBinary(ctx context.Context, data []byt
 				value, err = strconv.ParseInt(*newVal, 10, 64)
 				if err != nil {
 					logger.WithError(err).Errorln("Can't parse default integer value")
-					return ctx, data, err
+					return ctx, data, nil
 				}
 			} else {
 				logger.WithError(err).Errorln("Can't decode int value and no default value")
@@ -80,10 +80,8 @@ func (p *PgSQLDataEncoderProcessor) encodeBinary(ctx context.Context, data []byt
 		switch size {
 		case 4:
 			binary.BigEndian.PutUint32(newData, uint32(value))
-			break
 		case 8:
 			binary.BigEndian.PutUint64(newData, uint64(value))
-			break
 		}
 		return ctx, newData, nil
 	}

--- a/decryptor/postgresql/data_encoder.go
+++ b/decryptor/postgresql/data_encoder.go
@@ -326,6 +326,6 @@ func onFail(setting config.ColumnEncryptionSetting, logger *logrus.Entry) (encod
 	case action == "error":
 		return nil, &EncodingError{}
 	default:
-		return nil, fmt.Errorf("unknown action")
+		return nil, fmt.Errorf("unknown action: %q", action)
 	}
 }

--- a/decryptor/postgresql/data_encoder_test.go
+++ b/decryptor/postgresql/data_encoder_test.go
@@ -4,6 +4,9 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"strings"
+	"testing"
+
 	"github.com/cossacklabs/acra/decryptor/base"
 	"github.com/cossacklabs/acra/encryptor"
 	"github.com/cossacklabs/acra/encryptor/config"
@@ -11,9 +14,6 @@ import (
 	"github.com/cossacklabs/acra/pseudonymization/common"
 	"github.com/cossacklabs/acra/utils"
 	"github.com/sirupsen/logrus"
-	"strconv"
-	"strings"
-	"testing"
 )
 
 // TestEncodingDecodingProcessorBinaryIntData checks decoding binary INT values to string SQL literals and back
@@ -411,7 +411,10 @@ func TestFailedEncodingInvalidTextValue(t *testing.T) {
 	// without default value
 	_, data, err := encoder.OnColumn(ctx, testData)
 	if err != nil {
-		t.Fatal("Expects nil on encode error")
+		t.Fatal("Expected nil on encode error")
+	}
+	if !bytes.Equal(data, testData) {
+		t.Fatal("Result data should be the same")
 	}
 
 	// invalid int32 valid value
@@ -419,12 +422,8 @@ func TestFailedEncodingInvalidTextValue(t *testing.T) {
 	testSetting = config.BasicColumnEncryptionSetting{DataType: "int32", DefaultDataValue: &strValue}
 	ctx = encryptor.NewContextWithEncryptionSetting(ctx, &testSetting)
 	_, data, err = encoder.OnColumn(ctx, testData)
-	numErr, ok := err.(*strconv.NumError)
-	if !ok {
-		t.Fatal("Expect strconv.NumError")
-	}
-	if numErr.Err != strconv.ErrSyntax {
-		t.Fatalf("Expect ErrSyntax, took %s\n", numErr.Err)
+	if err != nil {
+		t.Fatal("Expected nil on encode error")
 	}
 	if !bytes.Equal(data, testData) {
 		t.Fatal("Result data should be the same")

--- a/decryptor/postgresql/data_encoder_test.go
+++ b/decryptor/postgresql/data_encoder_test.go
@@ -161,7 +161,7 @@ func TestTextMode(t *testing.T) {
 
 		// encryption/decryption integer data, not tokenization
 		{input: []byte("some data"), decodedData: []byte("some data"), encodedData: []byte(strDefaultValue), decodeErr: nil, encodeErr: nil,
-			setting: &config.BasicColumnEncryptionSetting{Tokenized: false, DataType: "int32", OnFail: "default", DefaultDataValue: &strDefaultValue}},
+			setting: &config.BasicColumnEncryptionSetting{Tokenized: false, DataType: "int32", ResponseOnFail: "default", DefaultDataValue: &strDefaultValue}},
 
 		// invalid binary hex value that should be returned as is. Also encoded into hex due to invalid hex value
 		{input: []byte("\\xTT"), decodedData: []byte("\\xTT"), encodedData: []byte("\\x5c785454"), decodeErr: nil, encodeErr: nil,
@@ -258,7 +258,7 @@ func TestBinaryMode(t *testing.T) {
 
 		// encryption/decryption integer data, not tokenization
 		{input: []byte("some data"), decodedData: []byte("some data"), encodedData: []byte{0, 0, 0, 1}, decodeErr: nil, encodeErr: nil,
-			setting: &config.BasicColumnEncryptionSetting{DataType: "int32", OnFail: "default", DefaultDataValue: &strDefaultValue}},
+			setting: &config.BasicColumnEncryptionSetting{DataType: "int32", ResponseOnFail: "default", DefaultDataValue: &strDefaultValue}},
 
 		// invalid binary hex value that should be returned as is. Also encoded into hex due to invalid hex value
 		{input: []byte("\\xTT"), decodedData: []byte("\\xTT"), encodedData: []byte("\\xTT"), decodeErr: nil, encodeErr: nil,
@@ -421,7 +421,7 @@ func TestFailedEncodingInvalidTextValue(t *testing.T) {
 
 	// invalid int32 valid value
 	strValue := utils.BytesToString(testData)
-	testSetting = config.BasicColumnEncryptionSetting{DataType: "int32", OnFail: "default", DefaultDataValue: &strValue}
+	testSetting = config.BasicColumnEncryptionSetting{DataType: "int32", ResponseOnFail: "default", DefaultDataValue: &strValue}
 	ctx = encryptor.NewContextWithEncryptionSetting(ctx, &testSetting)
 	_, data, err = encoder.OnColumn(ctx, testData)
 	if err != nil {
@@ -454,7 +454,7 @@ func TestFailedEncodingInvalidBinaryValue(t *testing.T) {
 	strValue := utils.BytesToString(testData)
 	testSetting = config.BasicColumnEncryptionSetting{
 		DataType:         "bytes",
-		OnFail:           "default",
+		ResponseOnFail:   "default",
 		DefaultDataValue: &strValue,
 	}
 	ctx = encryptor.NewContextWithEncryptionSetting(ctx, &testSetting)
@@ -485,7 +485,7 @@ func TestErrorOnFail(t *testing.T) {
 
 	column := "gopher"
 
-	// test all possible cases with happy and error paths with `on_fail = error`.
+	// test all possible cases with happy and error paths with `response_on_fail = error`.
 	// check only whether error is returned or not
 	testcases := []testcase{
 		// decryption successfull, we expect no error
@@ -519,9 +519,9 @@ func TestErrorOnFail(t *testing.T) {
 
 	for _, tcase := range testcases {
 		testSetting := config.BasicColumnEncryptionSetting{
-			Name:     column,
-			DataType: tcase.dataType,
-			OnFail:   "error",
+			Name:           column,
+			DataType:       tcase.dataType,
+			ResponseOnFail: "error",
 		}
 		ctx := encryptor.NewContextWithEncryptionSetting(context.Background(), &testSetting)
 		if tcase.decrypted {
@@ -575,8 +575,8 @@ func TestEmptyOnFail(t *testing.T) {
 
 	for _, tcase := range testcases {
 		testSetting := config.BasicColumnEncryptionSetting{
-			DataType: tcase.dataType,
-			OnFail:   "",
+			DataType:       tcase.dataType,
+			ResponseOnFail: "",
 		}
 		ctx := encryptor.NewContextWithEncryptionSetting(context.Background(), &testSetting)
 
@@ -765,7 +765,7 @@ func TestDefaultOnFail(t *testing.T) {
 	for _, tcase := range testcases {
 		testSetting := config.BasicColumnEncryptionSetting{
 			DataType:         tcase.dataType,
-			OnFail:           "default",
+			ResponseOnFail:   "default",
 			DefaultDataValue: &tcase.defaultValue,
 		}
 		ctx := encryptor.NewContextWithEncryptionSetting(context.Background(), &testSetting)

--- a/decryptor/postgresql/data_encoder_test.go
+++ b/decryptor/postgresql/data_encoder_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cossacklabs/acra/decryptor/base"
 	"github.com/cossacklabs/acra/encryptor"
 	"github.com/cossacklabs/acra/encryptor/config"
+	common2 "github.com/cossacklabs/acra/encryptor/config/common"
 	"github.com/cossacklabs/acra/logging"
 	"github.com/cossacklabs/acra/pseudonymization/common"
 	"github.com/cossacklabs/acra/utils"
@@ -169,7 +170,7 @@ func TestTextMode(t *testing.T) {
 			setting: &config.BasicColumnEncryptionSetting{
 				Tokenized:        false,
 				DataType:         "int32",
-				ResponseOnFail:   "default_value",
+				ResponseOnFail:   common2.ResponseOnFailDefault,
 				DefaultDataValue: &strDefaultValue,
 			},
 		},
@@ -276,7 +277,7 @@ func TestBinaryMode(t *testing.T) {
 			encodeErr:   nil,
 			setting: &config.BasicColumnEncryptionSetting{
 				DataType:         "int32",
-				ResponseOnFail:   "default_value",
+				ResponseOnFail:   common2.ResponseOnFailDefault,
 				DefaultDataValue: &strDefaultValue,
 			},
 		},
@@ -444,7 +445,7 @@ func TestFailedEncodingInvalidTextValue(t *testing.T) {
 	strValue := utils.BytesToString(testData)
 	testSetting = config.BasicColumnEncryptionSetting{
 		DataType:         "int32",
-		ResponseOnFail:   "default_value",
+		ResponseOnFail:   common2.ResponseOnFailDefault,
 		DefaultDataValue: &strValue,
 	}
 	ctx = encryptor.NewContextWithEncryptionSetting(ctx, &testSetting)
@@ -479,7 +480,7 @@ func TestFailedEncodingInvalidBinaryValue(t *testing.T) {
 	strValue := utils.BytesToString(testData)
 	testSetting = config.BasicColumnEncryptionSetting{
 		DataType:         "bytes",
-		ResponseOnFail:   "default_value",
+		ResponseOnFail:   common2.ResponseOnFailDefault,
 		DefaultDataValue: &strValue,
 	}
 	ctx = encryptor.NewContextWithEncryptionSetting(ctx, &testSetting)
@@ -546,7 +547,7 @@ func TestErrorOnFail(t *testing.T) {
 		testSetting := config.BasicColumnEncryptionSetting{
 			Name:           column,
 			DataType:       tcase.dataType,
-			ResponseOnFail: "error",
+			ResponseOnFail: common2.ResponseOnFailError,
 		}
 		ctx := encryptor.NewContextWithEncryptionSetting(context.Background(), &testSetting)
 		if tcase.decrypted {
@@ -601,7 +602,7 @@ func TestEmptyOnFail(t *testing.T) {
 	for _, tcase := range testcases {
 		testSetting := config.BasicColumnEncryptionSetting{
 			DataType:       tcase.dataType,
-			ResponseOnFail: "",
+			ResponseOnFail: common2.ResponseOnFailEmpty,
 		}
 		ctx := encryptor.NewContextWithEncryptionSetting(context.Background(), &testSetting)
 
@@ -661,7 +662,7 @@ func TestCiphertextOnFail(t *testing.T) {
 	for _, tcase := range testcases {
 		testSetting := config.BasicColumnEncryptionSetting{
 			DataType:       tcase.dataType,
-			ResponseOnFail: "ciphertext",
+			ResponseOnFail: common2.ResponseOnFailCiphertext,
 		}
 		ctx := encryptor.NewContextWithEncryptionSetting(context.Background(), &testSetting)
 
@@ -850,7 +851,7 @@ func TestDefaultOnFail(t *testing.T) {
 	for _, tcase := range testcases {
 		testSetting := config.BasicColumnEncryptionSetting{
 			DataType:         tcase.dataType,
-			ResponseOnFail:   "default_value",
+			ResponseOnFail:   common2.ResponseOnFailDefault,
 			DefaultDataValue: &tcase.defaultValue,
 		}
 		ctx := encryptor.NewContextWithEncryptionSetting(context.Background(), &testSetting)

--- a/decryptor/postgresql/data_encoder_test.go
+++ b/decryptor/postgresql/data_encoder_test.go
@@ -526,7 +526,7 @@ func TestErrorOnFail(t *testing.T) {
 		}
 
 		// Text format
-		columnInfo := base.NewColumnInfo(0, "", false, 4)
+		columnInfo := base.NewColumnInfo(0, "", false, 4, 0, 0)
 		accessContext := &base.AccessContext{}
 		accessContext.SetColumnInfo(columnInfo)
 		textCtx := base.SetAccessContextToContext(ctx, accessContext)
@@ -537,7 +537,7 @@ func TestErrorOnFail(t *testing.T) {
 		}
 
 		// Binary format
-		columnInfo = base.NewColumnInfo(0, "", true, 4)
+		columnInfo = base.NewColumnInfo(0, "", true, 4, 0, 0)
 		accessContext = &base.AccessContext{}
 		accessContext.SetColumnInfo(columnInfo)
 		binaryCtx := base.SetAccessContextToContext(ctx, accessContext)
@@ -578,7 +578,7 @@ func TestEmptyOnFail(t *testing.T) {
 		ctx := encryptor.NewContextWithEncryptionSetting(context.Background(), &testSetting)
 
 		// Text format
-		columnInfo := base.NewColumnInfo(0, "", false, 4)
+		columnInfo := base.NewColumnInfo(0, "", false, 4, 0, 0)
 		accessContext := &base.AccessContext{}
 		accessContext.SetColumnInfo(columnInfo)
 		textCtx := base.SetAccessContextToContext(ctx, accessContext)
@@ -592,7 +592,7 @@ func TestEmptyOnFail(t *testing.T) {
 		}
 
 		// Binary format
-		columnInfo = base.NewColumnInfo(0, "", true, 4)
+		columnInfo = base.NewColumnInfo(0, "", true, 4, 0, 0)
 		accessContext = &base.AccessContext{}
 		accessContext.SetColumnInfo(columnInfo)
 		binaryCtx := base.SetAccessContextToContext(ctx, accessContext)
@@ -771,7 +771,7 @@ func TestDefaultOnFail(t *testing.T) {
 		}
 
 		// Text format
-		columnInfo := base.NewColumnInfo(0, "", false, 4)
+		columnInfo := base.NewColumnInfo(0, "", false, 4, 0, 0)
 		accessContext := &base.AccessContext{}
 		accessContext.SetColumnInfo(columnInfo)
 		textCtx := base.SetAccessContextToContext(ctx, accessContext)
@@ -785,7 +785,7 @@ func TestDefaultOnFail(t *testing.T) {
 		}
 
 		// Binary format
-		columnInfo = base.NewColumnInfo(0, "", true, 4)
+		columnInfo = base.NewColumnInfo(0, "", true, 4, 0, 0)
 		accessContext = &base.AccessContext{}
 		accessContext.SetColumnInfo(columnInfo)
 		binaryCtx := base.SetAccessContextToContext(ctx, accessContext)

--- a/decryptor/postgresql/data_encoder_test.go
+++ b/decryptor/postgresql/data_encoder_test.go
@@ -160,8 +160,19 @@ func TestTextMode(t *testing.T) {
 			logMessage: `Can't decode int value and no default value`},
 
 		// encryption/decryption integer data, not tokenization
-		{input: []byte("some data"), decodedData: []byte("some data"), encodedData: []byte(strDefaultValue), decodeErr: nil, encodeErr: nil,
-			setting: &config.BasicColumnEncryptionSetting{Tokenized: false, DataType: "int32", ResponseOnFail: "default", DefaultDataValue: &strDefaultValue}},
+		{
+			input:       []byte("some data"),
+			decodedData: []byte("some data"),
+			encodedData: []byte(strDefaultValue),
+			decodeErr:   nil,
+			encodeErr:   nil,
+			setting: &config.BasicColumnEncryptionSetting{
+				Tokenized:        false,
+				DataType:         "int32",
+				ResponseOnFail:   "default_value",
+				DefaultDataValue: &strDefaultValue,
+			},
+		},
 
 		// invalid binary hex value that should be returned as is. Also encoded into hex due to invalid hex value
 		{input: []byte("\\xTT"), decodedData: []byte("\\xTT"), encodedData: []byte("\\x5c785454"), decodeErr: nil, encodeErr: nil,
@@ -257,8 +268,18 @@ func TestBinaryMode(t *testing.T) {
 			logMessage: `Can't decode int value and no default value`},
 
 		// encryption/decryption integer data, not tokenization
-		{input: []byte("some data"), decodedData: []byte("some data"), encodedData: []byte{0, 0, 0, 1}, decodeErr: nil, encodeErr: nil,
-			setting: &config.BasicColumnEncryptionSetting{DataType: "int32", ResponseOnFail: "default", DefaultDataValue: &strDefaultValue}},
+		{
+			input:       []byte("some data"),
+			decodedData: []byte("some data"),
+			encodedData: []byte{0, 0, 0, 1},
+			decodeErr:   nil,
+			encodeErr:   nil,
+			setting: &config.BasicColumnEncryptionSetting{
+				DataType:         "int32",
+				ResponseOnFail:   "default_value",
+				DefaultDataValue: &strDefaultValue,
+			},
+		},
 
 		// invalid binary hex value that should be returned as is. Also encoded into hex due to invalid hex value
 		{input: []byte("\\xTT"), decodedData: []byte("\\xTT"), encodedData: []byte("\\xTT"), decodeErr: nil, encodeErr: nil,
@@ -421,7 +442,11 @@ func TestFailedEncodingInvalidTextValue(t *testing.T) {
 
 	// invalid int32 valid value
 	strValue := utils.BytesToString(testData)
-	testSetting = config.BasicColumnEncryptionSetting{DataType: "int32", ResponseOnFail: "default", DefaultDataValue: &strValue}
+	testSetting = config.BasicColumnEncryptionSetting{
+		DataType:         "int32",
+		ResponseOnFail:   "default_value",
+		DefaultDataValue: &strValue,
+	}
 	ctx = encryptor.NewContextWithEncryptionSetting(ctx, &testSetting)
 	_, data, err = encoder.OnColumn(ctx, testData)
 	if err != nil {
@@ -454,7 +479,7 @@ func TestFailedEncodingInvalidBinaryValue(t *testing.T) {
 	strValue := utils.BytesToString(testData)
 	testSetting = config.BasicColumnEncryptionSetting{
 		DataType:         "bytes",
-		ResponseOnFail:   "default",
+		ResponseOnFail:   "default_value",
 		DefaultDataValue: &strValue,
 	}
 	ctx = encryptor.NewContextWithEncryptionSetting(ctx, &testSetting)
@@ -825,7 +850,7 @@ func TestDefaultOnFail(t *testing.T) {
 	for _, tcase := range testcases {
 		testSetting := config.BasicColumnEncryptionSetting{
 			DataType:         tcase.dataType,
-			ResponseOnFail:   "default",
+			ResponseOnFail:   "default_value",
 			DefaultDataValue: &tcase.defaultValue,
 		}
 		ctx := encryptor.NewContextWithEncryptionSetting(context.Background(), &testSetting)

--- a/decryptor/postgresql/pg_decryptor.go
+++ b/decryptor/postgresql/pg_decryptor.go
@@ -536,7 +536,7 @@ func (proxy *PgProxy) ProxyDatabaseConnection(ctx context.Context, errCh chan<- 
 
 			// Massage the packet. This should not normally fail. If it does, the client will not receive the packet.
 			err := proxy.handleDatabasePacket(packetCtx, packetHandler, logger)
-			if decryptionError, ok := err.(*EncodingError); ok {
+			if decryptionError, ok := err.(*base.EncodingError); ok {
 				if err = proxy.sendClientError(decryptionError.Error(), logger); err != nil {
 					logger.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorNetworkWrite).
 						WithError(err).Errorln("Can't send packet")

--- a/decryptor/postgresql/pg_decryptor.go
+++ b/decryptor/postgresql/pg_decryptor.go
@@ -537,7 +537,6 @@ func (proxy *PgProxy) ProxyDatabaseConnection(ctx context.Context, errCh chan<- 
 			// Massage the packet. This should not normally fail. If it does, the client will not receive the packet.
 			err := proxy.handleDatabasePacket(packetCtx, packetHandler, logger)
 			if decryptionError, ok := err.(*EncodingError); ok {
-				logger.Debugln("G1gg1l3s: sending error to the client")
 				if err = proxy.sendClientError(decryptionError.Error(), logger); err != nil {
 					logger.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorNetworkWrite).
 						WithError(err).Errorln("Can't send packet")

--- a/decryptor/postgresql/pg_decryptor.go
+++ b/decryptor/postgresql/pg_decryptor.go
@@ -252,7 +252,7 @@ func (proxy *PgProxy) ProxyClientConnection(ctx context.Context, errCh chan<- ba
 		// If the packet has been rejected by AcraCensor, stop here and don't send it to the database.
 		// Also, craft and send the client an error so that they know their query has been rejected.
 		if censored {
-			err := proxy.sendClientError("AcraCensor blocked this query", logger)
+			err := proxy.sendClientError(base.AcraCensorBlockedThisQuery, logger)
 			if err != nil {
 				errCh <- base.NewClientProxyError(err)
 				return

--- a/encryptor/config/common/encryptedTypes.go
+++ b/encryptor/config/common/encryptedTypes.go
@@ -9,6 +9,29 @@ import (
 	"github.com/cossacklabs/acra/pseudonymization/common"
 )
 
+// ResponseOnFail represents possible values for `response_on_fail` field
+type ResponseOnFail string
+
+const (
+	// ResponseOnFailEmpty occurs as a default value of fresh settings
+	// Should be treated in the same way as ResponseOnFail_Ciphertext
+	// TODO: maybe then hide this conversion under the call of
+	//       `GetResponseOnFail`
+	ResponseOnFailEmpty ResponseOnFail = ""
+
+	// ResponseOnFailCiphertext indicates that raw cip value should be returned
+	// as is.
+	ResponseOnFailCiphertext ResponseOnFail = "ciphertext"
+
+	// ResponseOnFailDefault indicates that default value should be returned
+	// instead of failed one.
+	ResponseOnFailDefault ResponseOnFail = "default"
+
+	// ResponseOnFailError indicates that db-specific error should be returned
+	// to a client
+	ResponseOnFailError ResponseOnFail = "error"
+)
+
 // ParseStringEncryptedType parse string value to EncryptedType value
 func ParseStringEncryptedType(value string) (EncryptedType, error) {
 	parsed, ok := encryptedTypeNames[value]
@@ -110,10 +133,13 @@ func TokenTypeToEncryptedDataType(tokenType common.TokenType) EncryptedType {
 	return EncryptedType_Unknown
 }
 
-// ValidateOnFail returns error if `OnFail` value is not supported
-func ValidateOnFail(value string) (err error) {
-	switch {
-	case value == "", value == "error", value == "default":
+// ValidateOnFail returns error if `response_on_fail` value is not supported
+func ValidateOnFail(value ResponseOnFail) (err error) {
+	switch value {
+	case ResponseOnFailEmpty,
+		ResponseOnFailCiphertext,
+		ResponseOnFailDefault,
+		ResponseOnFailError:
 		return nil
 	}
 	return fmt.Errorf("unknown response_on_fail value: '%s'", value)

--- a/encryptor/config/common/encryptedTypes.go
+++ b/encryptor/config/common/encryptedTypes.go
@@ -25,7 +25,7 @@ const (
 
 	// ResponseOnFailDefault indicates that default value should be returned
 	// instead of failed one.
-	ResponseOnFailDefault ResponseOnFail = "default"
+	ResponseOnFailDefault ResponseOnFail = "default_value"
 
 	// ResponseOnFailError indicates that db-specific error should be returned
 	// to a client

--- a/encryptor/config/common/encryptedTypes.go
+++ b/encryptor/config/common/encryptedTypes.go
@@ -116,5 +116,5 @@ func ValidateOnFail(value string) (err error) {
 	case value == "", value == "error", value == "default":
 		return nil
 	}
-	return fmt.Errorf("unknown on_fail value: '%s'", value)
+	return fmt.Errorf("unknown response_on_fail value: '%s'", value)
 }

--- a/encryptor/config/common/encryptedTypes.go
+++ b/encryptor/config/common/encryptedTypes.go
@@ -19,7 +19,7 @@ const (
 	//       `GetResponseOnFail`
 	ResponseOnFailEmpty ResponseOnFail = ""
 
-	// ResponseOnFailCiphertext indicates that raw cip value should be returned
+	// ResponseOnFailCiphertext indicates that raw ciphertext value should be returned
 	// as is.
 	ResponseOnFailCiphertext ResponseOnFail = "ciphertext"
 

--- a/encryptor/config/common/encryptedTypes.go
+++ b/encryptor/config/common/encryptedTypes.go
@@ -2,9 +2,11 @@ package common
 
 import (
 	"errors"
-	"github.com/cossacklabs/acra/pseudonymization/common"
+	"fmt"
 	"strconv"
 	"unicode/utf8"
+
+	"github.com/cossacklabs/acra/pseudonymization/common"
 )
 
 // ParseStringEncryptedType parse string value to EncryptedType value
@@ -104,4 +106,13 @@ func TokenTypeToEncryptedDataType(tokenType common.TokenType) EncryptedType {
 		return EncryptedType_Bytes
 	}
 	return EncryptedType_Unknown
+}
+
+// ValidateOnFail returns error if `OnFail` value is not supported
+func ValidateOnFail(value string) (err error) {
+	switch {
+	case value == "", value == "error", value == "default":
+		return nil
+	}
+	return fmt.Errorf("unknown on_fail value: '%s'", value)
 }

--- a/encryptor/config/common/encryptedTypes_test.go
+++ b/encryptor/config/common/encryptedTypes_test.go
@@ -47,3 +47,28 @@ func TestValidateDefaultValue(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateOnFail(t *testing.T) {
+	type testcase struct {
+		input       string
+		expectError bool
+	}
+
+	testcases := []testcase{
+		{"", false},
+		{"error", false},
+		{"default_value", false},
+		{"ciphertext", false},
+		{"gibberish", true},
+	}
+
+	for _, testcase := range testcases {
+		err := ValidateOnFail(ResponseOnFail(testcase.input))
+
+		if testcase.expectError && err == nil {
+			t.Fatalf("[%s] expected error but found nothing", testcase.input)
+		} else if !testcase.expectError && err != nil {
+			t.Fatalf("[%s] expected not errors, but found %s", testcase.input, err)
+		}
+	}
+}

--- a/encryptor/config/encryptionSettings.go
+++ b/encryptor/config/encryptionSettings.go
@@ -184,7 +184,7 @@ type BasicColumnEncryptionSetting struct {
 	// the the error should be returned to a user
 	// to return a default value, use  "default" together with
 	// `default_data_value` field
-	OnFail string `yaml:"on_fail"`
+	ResponseOnFail string `yaml:"response_on_fail"`
 
 	// Data pseudonymization (tokenization)
 	Tokenized              bool   `yaml:"tokenized"`
@@ -254,7 +254,7 @@ func (s *BasicColumnEncryptionSetting) Init() (err error) {
 		}
 	}
 
-	if s.OnFail != "" {
+	if s.ResponseOnFail != "" {
 		s.settingMask |= SettingOnFailFlag
 	}
 
@@ -272,8 +272,8 @@ func (s *BasicColumnEncryptionSetting) Init() (err error) {
 		s.settingMask |= SettingDataTypeFlag
 		// If transparent encryption is enabled, by default we return an error
 		// to a client in case of failure
-		if s.OnFail == "" {
-			s.OnFail = "error"
+		if s.ResponseOnFail == "" {
+			s.ResponseOnFail = "error"
 		}
 	}
 	if s.DataType != "" {
@@ -284,11 +284,11 @@ func (s *BasicColumnEncryptionSetting) Init() (err error) {
 		if err = common2.ValidateEncryptedType(dataType); err != nil {
 			return err
 		}
-	} else if s.OnFail != "" {
-		return errors.New("on_fail is defined without data type")
+	} else if s.ResponseOnFail != "" {
+		return errors.New("response_on_fail is defined without data type")
 	}
 
-	if err := common2.ValidateOnFail(s.OnFail); err != nil {
+	if err := common2.ValidateOnFail(s.ResponseOnFail); err != nil {
 		return err
 	}
 
@@ -297,8 +297,8 @@ func (s *BasicColumnEncryptionSetting) Init() (err error) {
 			return errors.New("default_data_value used without data_type")
 		}
 		s.settingMask |= SettingDefaultDataValueFlag
-		if s.OnFail != "default" {
-			return fmt.Errorf("default data value is defined, but `on_fail` operation is not \"default\" (%s)", s.OnFail)
+		if s.ResponseOnFail != "default" {
+			return fmt.Errorf("default data value is defined, but `response_on_fail` operation is not \"default\" (%s)", s.ResponseOnFail)
 		}
 	}
 	if err = common2.ValidateDefaultValue(s.DefaultDataValue, dataType); err != nil {
@@ -450,10 +450,10 @@ func (s *BasicColumnEncryptionSetting) applyDefaults(defaults defaultValues) {
 	}
 }
 
-// GetOnFail returns the action that should be performed on failure
+// GetResponseOnFail returns the action that should be performed on failure
 // Valid values are "", "error" and "default"
-func (s *BasicColumnEncryptionSetting) GetOnFail() string {
-	return s.OnFail
+func (s *BasicColumnEncryptionSetting) GetResponseOnFail() string {
+	return s.ResponseOnFail
 }
 
 // HasTypeAwareSupport return true if setting configured for decryption with type awareness

--- a/encryptor/config/encryptionSettings.go
+++ b/encryptor/config/encryptionSettings.go
@@ -19,6 +19,7 @@ package config
 import (
 	"errors"
 	"fmt"
+
 	common2 "github.com/cossacklabs/acra/encryptor/config/common"
 	maskingCommon "github.com/cossacklabs/acra/masking/common"
 	"github.com/cossacklabs/acra/pseudonymization/common"
@@ -173,6 +174,12 @@ type BasicColumnEncryptionSetting struct {
 	DataType string `yaml:"data_type"`
 	// string for str/email/int32/int64 ans base64 string for binary data
 	DefaultDataValue *string `yaml:"default_data_value"`
+	// an action that should be performed on failure
+	// for type awareness decryption the default is "error", which indicates
+	// the the error should be returned to a user
+	// to return a default value, use  "default" together with
+	// `default_data_value` field
+	OnFail string `yaml:"on_fail"`
 
 	// Data pseudonymization (tokenization)
 	Tokenized              bool   `yaml:"tokenized"`
@@ -268,6 +275,8 @@ func (s *BasicColumnEncryptionSetting) Init() (err error) {
 			return errors.New("default_data_value used without data_type")
 		}
 		s.settingMask |= SettingDefaultDataValueFlag
+		// TODO: temporary
+		s.OnFail = "default"
 	}
 	if err = common2.ValidateDefaultValue(s.DefaultDataValue, dataType); err != nil {
 		return fmt.Errorf("invalid default value: %w", err)
@@ -416,6 +425,12 @@ func (s *BasicColumnEncryptionSetting) applyDefaults(defaults defaultValues) {
 			s.ReEncryptToAcraBlock = &v
 		}
 	}
+}
+
+// GetOnFail returns the action that should be performed on failure
+// Valid values are "", "error" and "default"
+func (s *BasicColumnEncryptionSetting) GetOnFail() string {
+	return s.OnFail
 }
 
 // HasTypeAwareSupport return true if setting configured for decryption with type awareness

--- a/encryptor/config/encryptionSettings.go
+++ b/encryptor/config/encryptionSettings.go
@@ -44,6 +44,7 @@ const (
 	SettingAcraStructEncryptionFlag
 	SettingDataTypeFlag
 	SettingDefaultDataValueFlag
+	SettingOnFailFlag
 )
 
 // validSettings store all valid combinations of encryption settings
@@ -71,25 +72,29 @@ var validSettings = map[SettingMask]struct{}{
 	// AcraBlock
 
 	// ClientID
-	SettingDataTypeFlag | SettingReEncryptionFlag | SettingClientIDFlag | SettingAcraBlockEncryptionFlag:                               {},
-	SettingDataTypeFlag | SettingDefaultDataValueFlag | SettingReEncryptionFlag | SettingClientIDFlag | SettingAcraBlockEncryptionFlag: {},
+	SettingDataTypeFlag | SettingReEncryptionFlag | SettingClientIDFlag | SettingAcraBlockEncryptionFlag:                                                   {},
+	SettingDataTypeFlag | SettingOnFailFlag | SettingReEncryptionFlag | SettingClientIDFlag | SettingAcraBlockEncryptionFlag:                               {},
+	SettingDataTypeFlag | SettingOnFailFlag | SettingDefaultDataValueFlag | SettingReEncryptionFlag | SettingClientIDFlag | SettingAcraBlockEncryptionFlag: {},
 
 	SettingDataTypeFlag | SettingReEncryptionFlag | SettingClientIDFlag | SettingAcraBlockEncryptionFlag | SettingMaskingFlag | SettingMaskingPlaintextLengthFlag | SettingMaskingPlaintextSideFlag: {},
 
 	// ZoneID
 
-	SettingDataTypeFlag | SettingReEncryptionFlag | SettingAcraBlockEncryptionFlag | SettingZoneIDFlag:                               {},
-	SettingDataTypeFlag | SettingDefaultDataValueFlag | SettingReEncryptionFlag | SettingAcraBlockEncryptionFlag | SettingZoneIDFlag: {},
+	SettingDataTypeFlag | SettingReEncryptionFlag | SettingAcraBlockEncryptionFlag | SettingZoneIDFlag:                                                   {},
+	SettingDataTypeFlag | SettingOnFailFlag | SettingReEncryptionFlag | SettingAcraBlockEncryptionFlag | SettingZoneIDFlag:                               {},
+	SettingDataTypeFlag | SettingOnFailFlag | SettingDefaultDataValueFlag | SettingReEncryptionFlag | SettingAcraBlockEncryptionFlag | SettingZoneIDFlag: {},
 
 	// AcraStruct
 	// ClientID
-	SettingDataTypeFlag | SettingReEncryptionFlag | SettingClientIDFlag | SettingAcraStructEncryptionFlag:                               {},
-	SettingDataTypeFlag | SettingDefaultDataValueFlag | SettingReEncryptionFlag | SettingClientIDFlag | SettingAcraStructEncryptionFlag: {},
+	SettingDataTypeFlag | SettingReEncryptionFlag | SettingClientIDFlag | SettingAcraStructEncryptionFlag:                                                   {},
+	SettingDataTypeFlag | SettingOnFailFlag | SettingReEncryptionFlag | SettingClientIDFlag | SettingAcraStructEncryptionFlag:                               {},
+	SettingDataTypeFlag | SettingOnFailFlag | SettingDefaultDataValueFlag | SettingReEncryptionFlag | SettingClientIDFlag | SettingAcraStructEncryptionFlag: {},
 
 	// ZoneID
 
-	SettingDataTypeFlag | SettingReEncryptionFlag | SettingAcraStructEncryptionFlag | SettingZoneIDFlag:                               {},
-	SettingDataTypeFlag | SettingDefaultDataValueFlag | SettingReEncryptionFlag | SettingAcraStructEncryptionFlag | SettingZoneIDFlag: {},
+	SettingDataTypeFlag | SettingReEncryptionFlag | SettingAcraStructEncryptionFlag | SettingZoneIDFlag:                                                   {},
+	SettingDataTypeFlag | SettingOnFailFlag | SettingReEncryptionFlag | SettingAcraStructEncryptionFlag | SettingZoneIDFlag:                               {},
+	SettingDataTypeFlag | SettingOnFailFlag | SettingDefaultDataValueFlag | SettingReEncryptionFlag | SettingAcraStructEncryptionFlag | SettingZoneIDFlag: {},
 
 	/////////////
 	// SEARCHABLE
@@ -248,6 +253,11 @@ func (s *BasicColumnEncryptionSetting) Init() (err error) {
 			return err
 		}
 	}
+
+	if s.OnFail != "" {
+		s.settingMask |= SettingOnFailFlag
+	}
+
 	dataType := common2.EncryptedType_Unknown
 	if s.DataType == "" {
 		// if DataType empty but configured for tokenization then map TokenType to appropriate DataType
@@ -274,6 +284,8 @@ func (s *BasicColumnEncryptionSetting) Init() (err error) {
 		if err = common2.ValidateEncryptedType(dataType); err != nil {
 			return err
 		}
+	} else if s.OnFail != "" {
+		return errors.New("on_fail is defined without data type")
 	}
 
 	if err := common2.ValidateOnFail(s.OnFail); err != nil {

--- a/encryptor/config/encryptionSettings.go
+++ b/encryptor/config/encryptionSettings.go
@@ -180,11 +180,8 @@ type BasicColumnEncryptionSetting struct {
 	// string for str/email/int32/int64 ans base64 string for binary data
 	DefaultDataValue *string `yaml:"default_data_value"`
 	// an action that should be performed on failure
-	// for type awareness decryption the default is "error", which indicates
-	// the the error should be returned to a user
-	// to return a default value, use  "default" together with
-	// `default_data_value` field
-	ResponseOnFail string `yaml:"response_on_fail"`
+	// possible actions are "ciphertext", "error" or "default"
+	ResponseOnFail common2.ResponseOnFail `yaml:"response_on_fail"`
 
 	// Data pseudonymization (tokenization)
 	Tokenized              bool   `yaml:"tokenized"`
@@ -254,7 +251,7 @@ func (s *BasicColumnEncryptionSetting) Init() (err error) {
 		}
 	}
 
-	if s.ResponseOnFail != "" {
+	if s.ResponseOnFail != common2.ResponseOnFailEmpty {
 		s.settingMask |= SettingOnFailFlag
 	}
 
@@ -272,8 +269,8 @@ func (s *BasicColumnEncryptionSetting) Init() (err error) {
 		s.settingMask |= SettingDataTypeFlag
 		// If transparent encryption is enabled, by default we return an error
 		// to a client in case of failure
-		if s.ResponseOnFail == "" {
-			s.ResponseOnFail = "error"
+		if s.ResponseOnFail == common2.ResponseOnFailEmpty {
+			s.ResponseOnFail = common2.ResponseOnFailError
 		}
 	}
 	if s.DataType != "" {
@@ -297,7 +294,7 @@ func (s *BasicColumnEncryptionSetting) Init() (err error) {
 			return errors.New("default_data_value used without data_type")
 		}
 		s.settingMask |= SettingDefaultDataValueFlag
-		if s.ResponseOnFail != "default" {
+		if s.ResponseOnFail != common2.ResponseOnFailDefault {
 			return fmt.Errorf("default data value is defined, but `response_on_fail` operation is not \"default\" (%s)", s.ResponseOnFail)
 		}
 	}
@@ -451,8 +448,8 @@ func (s *BasicColumnEncryptionSetting) applyDefaults(defaults defaultValues) {
 }
 
 // GetResponseOnFail returns the action that should be performed on failure
-// Valid values are "", "error" and "default"
-func (s *BasicColumnEncryptionSetting) GetResponseOnFail() string {
+// Valid values are "", "ciphertext", "error" and "default"
+func (s *BasicColumnEncryptionSetting) GetResponseOnFail() common2.ResponseOnFail {
 	return s.ResponseOnFail
 }
 

--- a/encryptor/config/schemaStore_test.go
+++ b/encryptor/config/schemaStore_test.go
@@ -427,22 +427,22 @@ schemas:
     encrypted:
       - column: data1
         data_type: str
-        on_fail: default
+        response_on_fail: default
         default_data_value: "str"
 
       - column: data2
         data_type: bytes
-        on_fail: default
+        response_on_fail: default
         default_data_value: "bytes"
 
       - column: data3
         data_type: int32
-        on_fail: default
+        response_on_fail: default
         default_data_value: "123"
 
       - column: data4
         data_type: int64
-        on_fail: default
+        response_on_fail: default
         default_data_value: "123"
 `,
 			nil},
@@ -459,25 +459,25 @@ schemas:
     encrypted:
       - column: data1
         data_type: str
-        on_fail: default
+        response_on_fail: default
         default_data_value: "str"
         client_id: client
 
       - column: data2
         data_type: bytes
-        on_fail: default
+        response_on_fail: default
         default_data_value: "bytes"
         client_id: client
 
       - column: data3
         data_type: int32
-        on_fail: default
+        response_on_fail: default
         default_data_value: "123"
         client_id: client
 
       - column: data4
         data_type: int64
-        on_fail: default
+        response_on_fail: default
         default_data_value: "123"
         client_id: client
 `,
@@ -495,25 +495,25 @@ schemas:
     encrypted:
       - column: data1
         data_type: str
-        on_fail: default
+        response_on_fail: default
         default_data_value: "str"
         zone_id: zone
 
       - column: data2
         data_type: bytes
-        on_fail: default
+        response_on_fail: default
         default_data_value: "bytes"
         zone_id: zone
 
       - column: data3
         data_type: int32
-        on_fail: default
+        response_on_fail: default
         default_data_value: "123"
         zone_id: zone
 
       - column: data4
         data_type: int64
-        on_fail: default
+        response_on_fail: default
         default_data_value: "123"
         zone_id: zone
 `,
@@ -610,22 +610,22 @@ schemas:
     encrypted:
       - column: data1
         data_type: str
-        on_fail: default
+        response_on_fail: default
         default_data_value: "str"
 
       - column: data2
         data_type: bytes
-        on_fail: default
+        response_on_fail: default
         default_data_value: "bytes"
 
       - column: data3
         data_type: int32
-        on_fail: default
+        response_on_fail: default
         default_data_value: "123"
 
       - column: data4
         data_type: int64
-        on_fail: default
+        response_on_fail: default
         default_data_value: "123"
 `,
 			nil},
@@ -644,25 +644,25 @@ schemas:
     encrypted:
       - column: data1
         data_type: str
-        on_fail: default
+        response_on_fail: default
         default_data_value: "str"
         client_id: client
 
       - column: data2
         data_type: bytes
-        on_fail: default
+        response_on_fail: default
         default_data_value: "bytes"
         client_id: client
 
       - column: data3
         data_type: int32
-        on_fail: default
+        response_on_fail: default
         default_data_value: "123"
         client_id: client
 
       - column: data4
         data_type: int64
-        on_fail: default
+        response_on_fail: default
         default_data_value: "123"
         client_id: client
 `,
@@ -682,25 +682,25 @@ schemas:
     encrypted:
       - column: data1
         data_type: str
-        on_fail: default
+        response_on_fail: default
         default_data_value: "str"
         zone_id: zone
 
       - column: data2
         data_type: bytes
-        on_fail: default
+        response_on_fail: default
         default_data_value: "bytes"
         zone_id: zone
 
       - column: data3
         data_type: int32
-        on_fail: default
+        response_on_fail: default
         default_data_value: "123"
         zone_id: zone
 
       - column: data4
         data_type: int64
-        on_fail: default
+        response_on_fail: default
         default_data_value: "123"
         zone_id: zone
 `,
@@ -902,22 +902,22 @@ schemas:
       encrypted:
         - column: data_str
           data_type: str
-          on_fail: default
+          response_on_fail: default
           default_data_value: string
 
         - column: data_bytes
           data_type: bytes
-          on_fail: default
+          response_on_fail: default
           default_data_value: Ynl0ZXM=
 
         - column: data_int32
           data_type: int32
-          on_fail: default
+          response_on_fail: default
           default_data_value: 2147483647
 
         - column: data_int64
           data_type: int64
-          on_fail: default
+          response_on_fail: default
           default_data_value: 9223372036854775807`},
 	}
 
@@ -929,8 +929,8 @@ schemas:
 		}
 
 		for _, column := range config.schemas["test_table"].EncryptionColumnSettings {
-			if column.GetOnFail() != tcase.onFail {
-				t.Fatalf("[%s] OnFail expected %q but found %q\n", tcase.name, tcase.onFail, column.GetOnFail())
+			if column.GetResponseOnFail() != tcase.onFail {
+				t.Fatalf("[%s] GetResponseOnFail expected %q but found %q\n", tcase.name, tcase.onFail, column.GetResponseOnFail())
 			}
 		}
 	}
@@ -951,10 +951,10 @@ schemas:
     encrypted:
       - column: data
         data_type: str
-        on_fail: error
+        response_on_fail: error
         default_data_value: hidden by cossacklabs`},
 
-		{"Only `default` without `on_fail`",
+		{"Only `default` without `response_on_fail`",
 			`
 schemas:
   - table: test_table
@@ -974,7 +974,7 @@ schemas:
       encrypted:
         - column: data
           data_type: str
-          on_fail: unknown`},
+          response_on_fail: unknown`},
 
 		{"OnFail without data_type",
 			`
@@ -984,7 +984,7 @@ schemas:
             - data
           encrypted:
             - column: data
-              on_fail: error`},
+              response_on_fail: error`},
 
 		{"OnFail and default without data_type",
 			`
@@ -994,7 +994,7 @@ schemas:
                     - data
                   encrypted:
                     - column: data
-                      on_fail: default
+                      response_on_fail: default
                       default_data_value: ukraine`},
 	}
 

--- a/encryptor/config/schemaStore_test.go
+++ b/encryptor/config/schemaStore_test.go
@@ -860,8 +860,8 @@ func TestTypeAwarenessOnFailDefaults(t *testing.T) {
 		config string
 	}
 	testcases := []testcase{
-		{"By default, onFail is ''",
-			common2.ResponseOnFailEmpty,
+		{"By default, onFail is 'ciphertext'",
+			common2.ResponseOnFailCiphertext,
 			`
 schemas:
   - table: test_table
@@ -870,8 +870,8 @@ schemas:
     encrypted:
       - column: data`},
 
-		{"onFail is 'error' if data type is defined",
-			common2.ResponseOnFailError,
+		{"onFail is 'ciphertext' if data type is defined",
+			common2.ResponseOnFailCiphertext,
 			`
 schemas:
   - table: test_table
@@ -890,36 +890,90 @@ schemas:
       - column: data_int64
         data_type: int64`},
 
-		{"onFail is 'default' if explicitly defined",
+		{"onFail is 'default_vaue' if explicitly defined",
 			common2.ResponseOnFailDefault,
 			`
-  schemas:
-    - table: test_table
-      columns:
-        - data_str
-        - data_bytes
-        - data_int32
-        - data_int64
-      encrypted:
-        - column: data_str
-          data_type: str
-          response_on_fail: default_value
-          default_data_value: string
+schemas:
+  - table: test_table
+    columns:
+      - data_str
+      - data_bytes
+      - data_int32
+      - data_int64
+    encrypted:
+      - column: data_str
+        data_type: str
+        response_on_fail: default_value
+        default_data_value: string
 
-        - column: data_bytes
-          data_type: bytes
-          response_on_fail: default_value
-          default_data_value: Ynl0ZXM=
+      - column: data_bytes
+        data_type: bytes
+        response_on_fail: default_value
+        default_data_value: Ynl0ZXM=
 
-        - column: data_int32
-          data_type: int32
-          response_on_fail: default_value
-          default_data_value: 2147483647
+      - column: data_int32
+        data_type: int32
+        response_on_fail: default_value
+        default_data_value: 2147483647
 
-        - column: data_int64
-          data_type: int64
-          response_on_fail: default_value
-          default_data_value: 9223372036854775807`},
+      - column: data_int64
+        data_type: int64
+        response_on_fail: default_value
+        default_data_value: 9223372036854775807`},
+
+		{"onFail is 'error' if explicitly defined",
+			common2.ResponseOnFailError,
+			`
+schemas:
+  - table: test_table
+    columns:
+      - data_str
+      - data_bytes
+      - data_int32
+      - data_int64
+    encrypted:
+      - column: data_str
+        data_type: str
+        response_on_fail: error
+
+      - column: data_bytes
+        data_type: bytes
+        response_on_fail: error
+
+      - column: data_int32
+        data_type: int32
+        response_on_fail: error
+
+      - column: data_int64
+        data_type: int64
+        response_on_fail: error`},
+
+		{"onFail is implicitly 'default_value' if 'default_data_value' is defined",
+			common2.ResponseOnFailDefault,
+			`
+schemas:
+  - table: test_table
+    columns:
+      - data_str
+      - data_bytes
+      - data_int32
+      - data_int64
+    encrypted:
+    - column: data_str
+      data_type: str
+      default_data_value: string
+
+    - column: data_bytes
+      data_type: bytes
+      default_data_value: Ynl0ZXM=
+
+    - column: data_int32
+      data_type: int32
+      default_data_value: 2147483647
+
+    - column: data_int64
+      data_type: int64
+      default_data_value: 9223372036854775807`},
 	}
 
 	for _, tcase := range testcases {
@@ -955,7 +1009,7 @@ schemas:
         response_on_fail: error
         default_data_value: hidden by cossacklabs`},
 
-		{"Only `default` without `response_on_fail`",
+		{"OnFail=unknown",
 			`
 schemas:
   - table: test_table
@@ -964,39 +1018,39 @@ schemas:
     encrypted:
       - column: data
         data_type: str
-        default_data_value: hidden by cossacklabs`},
-
-		{"OnFail=unknown",
-			`
-  schemas:
-    - table: test_table
-      columns:
-        - data
-      encrypted:
-        - column: data
-          data_type: str
-          response_on_fail: unknown`},
+        response_on_fail: unknown`},
 
 		{"OnFail without data_type",
 			`
-      schemas:
-        - table: test_table
-          columns:
-            - data
-          encrypted:
-            - column: data
-              response_on_fail: error`},
+schemas:
+  - table: test_table
+    columns:
+      - data
+    encrypted:
+      - column: data
+        response_on_fail: error`},
 
 		{"OnFail and default without data_type",
 			`
-              schemas:
-                - table: test_table
-                  columns:
-                    - data
-                  encrypted:
-                    - column: data
-                      response_on_fail: default_value
-                      default_data_value: ukraine`},
+schemas:
+  - table: test_table
+    columns:
+      - data
+    encrypted:
+      - column: data
+        response_on_fail: default_value
+        default_data_value: ukraine`},
+		{"OnFai=ciphertext and default",
+			`
+schemas:
+  - table: test_table
+    columns:
+      - data
+    encrypted:
+      - column: data
+        data_type: str
+        response_on_fail: ciphertext
+        default_data_value: oops`},
 	}
 
 	for _, tcase := range testcases {

--- a/encryptor/config/schemaStore_test.go
+++ b/encryptor/config/schemaStore_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	common2 "github.com/cossacklabs/acra/encryptor/config/common"
 	"github.com/cossacklabs/acra/masking/common"
 )
 
@@ -855,7 +856,7 @@ schemas:
 func TestTypeAwarenessOnFailDefaults(t *testing.T) {
 	type testcase struct {
 		name   string
-		onFail string
+		onFail common2.ResponseOnFail
 		config string
 	}
 	testcases := []testcase{

--- a/encryptor/config/schemaStore_test.go
+++ b/encryptor/config/schemaStore_test.go
@@ -2,8 +2,9 @@ package config
 
 import (
 	"errors"
-	"github.com/cossacklabs/acra/masking/common"
 	"testing"
+
+	"github.com/cossacklabs/acra/masking/common"
 )
 
 func TestCryptoEnvelopeDefaultValuesWithDefinedValue(t *testing.T) {
@@ -168,12 +169,13 @@ schemas:
 
 func TestInvalidMasking(t *testing.T) {
 	type testcase struct {
+		name   string
 		config string
 		err    error
 	}
 	testcases := []testcase{
-		// masking can't be searchable
-		{`
+		{"masking can't be searchable",
+			`
 schemas:
   - table: test_table
     columns:
@@ -186,8 +188,9 @@ schemas:
         searchable: true
 `,
 			ErrInvalidEncryptorConfig},
-		// plaintext_length should be > 0
-		{`
+
+		{"plaintext_length should be > 0",
+			`
 schemas:
   - table: test_table
     columns:
@@ -199,8 +202,9 @@ schemas:
         plaintext_side: "right"
 `,
 			common.ErrInvalidPlaintextLength},
-		// invalid crypto_envelope
-		{`
+
+		{"invalid crypto_envelope",
+			`
 schemas:
   - table: test_table
     columns:
@@ -213,8 +217,9 @@ schemas:
         crypto_envelope: "invalid"
 `,
 			ErrInvalidCryptoEnvelopeType},
-		// should be specified plaintext_side
-		{`
+
+		{"should be specified plaintext_side",
+			`
 schemas:
   - table: test_table
     columns:
@@ -225,8 +230,9 @@ schemas:
         plaintext_length: 9
 `,
 			common.ErrInvalidPlaintextSide},
-		// should be specified masking pattern
-		{`
+
+		{"should be specified masking pattern",
+			`
 schemas:
   - table: test_table
     columns:
@@ -237,8 +243,9 @@ schemas:
         plaintext_side: "right"
 `,
 			common.ErrInvalidMaskingPattern},
-		// searchable encryption doesn't support zones
-		{`
+
+		{"searchable encryption doesn't support zones",
+			`
 schemas:
   - table: test_table
     columns:
@@ -249,8 +256,9 @@ schemas:
         zone_id: DDDDDDDDMatNOMYjqVOuhACC
 `,
 			ErrInvalidEncryptorConfig},
-		// tokenization can't be searchable
-		{`
+
+		{"tokenization can't be searchable",
+			`
 schemas:
   - table: test_table
     columns:
@@ -263,7 +271,9 @@ schemas:
 			//pseudonymization.ErrUnknownTokenType
 			// use new declared to avoid cycle import
 			errors.New("unknown token type")},
-		{`
+
+		{"invalid token type",
+			`
 schemas:
   - table: test_table
     columns:
@@ -276,9 +286,8 @@ schemas:
 			// use new declared to avoid cycle import
 			errors.New("unknown token type")},
 
-		// AcraBlock
-		// type aware decryption, all supported types
-		{`
+		{"AcraBlock - type aware decryption, all supported types",
+			`
 schemas:
   - table: test_table
     columns:
@@ -297,8 +306,9 @@ schemas:
         data_type: int64
 `,
 			nil},
-		// type aware decryption, all supported types + masking
-		{`
+
+		{"type aware decryption, all supported types + masking",
+			`
 schemas:
   - table: test_table
     columns:
@@ -323,8 +333,9 @@ schemas:
         data_type: int64
 `,
 			nil},
-		// type aware decryption, all supported types, specified client id
-		{`
+
+		{"type aware decryption, all supported types, specified client id",
+			`
 schemas:
   - table: test_table
     columns:
@@ -347,8 +358,9 @@ schemas:
         client_id: client
 `,
 			nil},
-		// type aware decryption, all supported types, specified client id + masking
-		{`
+
+		{"type aware decryption, all supported types, specified client id + masking",
+			`
 schemas:
   - table: test_table
     columns:
@@ -377,8 +389,9 @@ schemas:
         client_id: client
 `,
 			nil},
-		// type aware decryption, all supported types, specified zone id
-		{`
+
+		{"type aware decryption, all supported types, specified zone id",
+			`
 schemas:
   - table: test_table
     columns:
@@ -401,8 +414,9 @@ schemas:
         zone_id: client
 `,
 			nil},
-		// type aware decryption, all supported types, default value
-		{`
+
+		{"type aware decryption, all supported types, default value",
+			`
 schemas:
   - table: test_table
     columns:
@@ -413,20 +427,28 @@ schemas:
     encrypted:
       - column: data1
         data_type: str
+        on_fail: default
         default_data_value: "str"
+
       - column: data2
         data_type: bytes
+        on_fail: default
         default_data_value: "bytes"
+
       - column: data3
         data_type: int32
+        on_fail: default
         default_data_value: "123"
+
       - column: data4
         data_type: int64
+        on_fail: default
         default_data_value: "123"
 `,
 			nil},
-		// type aware decryption, all supported types, default value, specified client id
-		{`
+
+		{"type aware decryption, all supported types, default value, specified client id",
+			`
 schemas:
   - table: test_table
     columns:
@@ -437,24 +459,32 @@ schemas:
     encrypted:
       - column: data1
         data_type: str
+        on_fail: default
         default_data_value: "str"
         client_id: client
+
       - column: data2
         data_type: bytes
+        on_fail: default
         default_data_value: "bytes"
         client_id: client
+
       - column: data3
         data_type: int32
+        on_fail: default
         default_data_value: "123"
         client_id: client
+
       - column: data4
         data_type: int64
+        on_fail: default
         default_data_value: "123"
         client_id: client
 `,
 			nil},
-		// type aware decryption, all supported types, default value, specified zone id
-		{`
+
+		{"type aware decryption, all supported types, default value, specified zone id",
+			`
 schemas:
   - table: test_table
     columns:
@@ -465,25 +495,32 @@ schemas:
     encrypted:
       - column: data1
         data_type: str
+        on_fail: default
         default_data_value: "str"
         zone_id: zone
+
       - column: data2
         data_type: bytes
+        on_fail: default
         default_data_value: "bytes"
         zone_id: zone
+
       - column: data3
         data_type: int32
+        on_fail: default
         default_data_value: "123"
         zone_id: zone
+
       - column: data4
         data_type: int64
+        on_fail: default
         default_data_value: "123"
         zone_id: zone
 `,
 			nil},
-		// AcraBlock
-		// type aware decryption, all supported types
-		{`
+
+		{"AcraBlock - type aware decryption, all supported types",
+			`
 defaults:
   crypto_envelope: acrastruct
 schemas:
@@ -504,8 +541,9 @@ schemas:
         data_type: int64
 `,
 			nil},
-		// type aware decryption, all supported types, specified client id
-		{`
+
+		{"type aware decryption, all supported types, specified client id",
+			`
 defaults:
   crypto_envelope: acrastruct
 schemas:
@@ -530,8 +568,9 @@ schemas:
         client_id: client
 `,
 			nil},
-		// type aware decryption, all supported types, specified zone id
-		{`
+
+		{"type aware decryption, all supported types, specified zone id",
+			`
 defaults:
   crypto_envelope: acrastruct
 schemas:
@@ -556,8 +595,9 @@ schemas:
         zone_id: client
 `,
 			nil},
-		// type aware decryption, all supported types, default value
-		{`
+
+		{"type aware decryption, all supported types, default value",
+			`
 defaults:
   crypto_envelope: acrastruct
 schemas:
@@ -570,20 +610,28 @@ schemas:
     encrypted:
       - column: data1
         data_type: str
+        on_fail: default
         default_data_value: "str"
+
       - column: data2
         data_type: bytes
+        on_fail: default
         default_data_value: "bytes"
+
       - column: data3
         data_type: int32
+        on_fail: default
         default_data_value: "123"
+
       - column: data4
         data_type: int64
+        on_fail: default
         default_data_value: "123"
 `,
 			nil},
-		// type aware decryption, all supported types, default value, specified client id
-		{`
+
+		{"Acrastruct - type aware decryption, all supported types, default value, specified client id",
+			`
 defaults:
   crypto_envelope: acrastruct
 schemas:
@@ -596,24 +644,32 @@ schemas:
     encrypted:
       - column: data1
         data_type: str
+        on_fail: default
         default_data_value: "str"
         client_id: client
+
       - column: data2
         data_type: bytes
+        on_fail: default
         default_data_value: "bytes"
         client_id: client
+
       - column: data3
         data_type: int32
+        on_fail: default
         default_data_value: "123"
         client_id: client
+
       - column: data4
         data_type: int64
+        on_fail: default
         default_data_value: "123"
         client_id: client
 `,
 			nil},
-		// type aware decryption, all supported types, default value, specified zone id
-		{`
+
+		{"type aware decryption, all supported types, default value, specified zone id",
+			`
 defaults:
   crypto_envelope: acrastruct
 schemas:
@@ -626,24 +682,32 @@ schemas:
     encrypted:
       - column: data1
         data_type: str
+        on_fail: default
         default_data_value: "str"
         zone_id: zone
+
       - column: data2
         data_type: bytes
+        on_fail: default
         default_data_value: "bytes"
         zone_id: zone
+
       - column: data3
         data_type: int32
+        on_fail: default
         default_data_value: "123"
         zone_id: zone
+
       - column: data4
         data_type: int64
+        on_fail: default
         default_data_value: "123"
         zone_id: zone
 `,
 			nil},
 	}
-	for i, tcase := range testcases {
+
+	for _, tcase := range testcases {
 		_, err := MapTableSchemaStoreFromConfig([]byte(tcase.config))
 		u, ok := err.(interface {
 			Unwrap() error
@@ -654,8 +718,16 @@ schemas:
 		if tcase.err == err {
 			continue
 		}
+		if tcase.err == nil {
+			t.Fatalf("[%s] Expected nil, took %s\n", tcase.name, err)
+		}
+
+		if err == nil {
+			t.Fatalf("[%s] Expected %s, took nil\n", tcase.name, tcase.err)
+		}
+
 		if err.Error() != tcase.err.Error() {
-			t.Fatalf("[%d] Expect %s, took %s\n", i, tcase.err.Error(), err)
+			t.Fatalf("[%s] Expect %s, took %s\n", tcase.name, tcase.err.Error(), err)
 		}
 	}
 }

--- a/encryptor/config/schemaStore_test.go
+++ b/encryptor/config/schemaStore_test.go
@@ -428,22 +428,22 @@ schemas:
     encrypted:
       - column: data1
         data_type: str
-        response_on_fail: default
+        response_on_fail: default_value
         default_data_value: "str"
 
       - column: data2
         data_type: bytes
-        response_on_fail: default
+        response_on_fail: default_value
         default_data_value: "bytes"
 
       - column: data3
         data_type: int32
-        response_on_fail: default
+        response_on_fail: default_value
         default_data_value: "123"
 
       - column: data4
         data_type: int64
-        response_on_fail: default
+        response_on_fail: default_value
         default_data_value: "123"
 `,
 			nil},
@@ -460,25 +460,25 @@ schemas:
     encrypted:
       - column: data1
         data_type: str
-        response_on_fail: default
+        response_on_fail: default_value
         default_data_value: "str"
         client_id: client
 
       - column: data2
         data_type: bytes
-        response_on_fail: default
+        response_on_fail: default_value
         default_data_value: "bytes"
         client_id: client
 
       - column: data3
         data_type: int32
-        response_on_fail: default
+        response_on_fail: default_value
         default_data_value: "123"
         client_id: client
 
       - column: data4
         data_type: int64
-        response_on_fail: default
+        response_on_fail: default_value
         default_data_value: "123"
         client_id: client
 `,
@@ -496,25 +496,25 @@ schemas:
     encrypted:
       - column: data1
         data_type: str
-        response_on_fail: default
+        response_on_fail: default_value
         default_data_value: "str"
         zone_id: zone
 
       - column: data2
         data_type: bytes
-        response_on_fail: default
+        response_on_fail: default_value
         default_data_value: "bytes"
         zone_id: zone
 
       - column: data3
         data_type: int32
-        response_on_fail: default
+        response_on_fail: default_value
         default_data_value: "123"
         zone_id: zone
 
       - column: data4
         data_type: int64
-        response_on_fail: default
+        response_on_fail: default_value
         default_data_value: "123"
         zone_id: zone
 `,
@@ -611,22 +611,22 @@ schemas:
     encrypted:
       - column: data1
         data_type: str
-        response_on_fail: default
+        response_on_fail: default_value
         default_data_value: "str"
 
       - column: data2
         data_type: bytes
-        response_on_fail: default
+        response_on_fail: default_value
         default_data_value: "bytes"
 
       - column: data3
         data_type: int32
-        response_on_fail: default
+        response_on_fail: default_value
         default_data_value: "123"
 
       - column: data4
         data_type: int64
-        response_on_fail: default
+        response_on_fail: default_value
         default_data_value: "123"
 `,
 			nil},
@@ -645,25 +645,25 @@ schemas:
     encrypted:
       - column: data1
         data_type: str
-        response_on_fail: default
+        response_on_fail: default_value
         default_data_value: "str"
         client_id: client
 
       - column: data2
         data_type: bytes
-        response_on_fail: default
+        response_on_fail: default_value
         default_data_value: "bytes"
         client_id: client
 
       - column: data3
         data_type: int32
-        response_on_fail: default
+        response_on_fail: default_value
         default_data_value: "123"
         client_id: client
 
       - column: data4
         data_type: int64
-        response_on_fail: default
+        response_on_fail: default_value
         default_data_value: "123"
         client_id: client
 `,
@@ -683,25 +683,25 @@ schemas:
     encrypted:
       - column: data1
         data_type: str
-        response_on_fail: default
+        response_on_fail: default_value
         default_data_value: "str"
         zone_id: zone
 
       - column: data2
         data_type: bytes
-        response_on_fail: default
+        response_on_fail: default_value
         default_data_value: "bytes"
         zone_id: zone
 
       - column: data3
         data_type: int32
-        response_on_fail: default
+        response_on_fail: default_value
         default_data_value: "123"
         zone_id: zone
 
       - column: data4
         data_type: int64
-        response_on_fail: default
+        response_on_fail: default_value
         default_data_value: "123"
         zone_id: zone
 `,
@@ -861,7 +861,7 @@ func TestTypeAwarenessOnFailDefaults(t *testing.T) {
 	}
 	testcases := []testcase{
 		{"By default, onFail is ''",
-			"",
+			common2.ResponseOnFailEmpty,
 			`
 schemas:
   - table: test_table
@@ -871,7 +871,7 @@ schemas:
       - column: data`},
 
 		{"onFail is 'error' if data type is defined",
-			"error",
+			common2.ResponseOnFailError,
 			`
 schemas:
   - table: test_table
@@ -891,7 +891,7 @@ schemas:
         data_type: int64`},
 
 		{"onFail is 'default' if explicitly defined",
-			"default",
+			common2.ResponseOnFailDefault,
 			`
   schemas:
     - table: test_table
@@ -903,22 +903,22 @@ schemas:
       encrypted:
         - column: data_str
           data_type: str
-          response_on_fail: default
+          response_on_fail: default_value
           default_data_value: string
 
         - column: data_bytes
           data_type: bytes
-          response_on_fail: default
+          response_on_fail: default_value
           default_data_value: Ynl0ZXM=
 
         - column: data_int32
           data_type: int32
-          response_on_fail: default
+          response_on_fail: default_value
           default_data_value: 2147483647
 
         - column: data_int64
           data_type: int64
-          response_on_fail: default
+          response_on_fail: default_value
           default_data_value: 9223372036854775807`},
 	}
 
@@ -995,7 +995,7 @@ schemas:
                     - data
                   encrypted:
                     - column: data
-                      response_on_fail: default
+                      response_on_fail: default_value
                       default_data_value: ukraine`},
 	}
 

--- a/encryptor/config/tableSchema.go
+++ b/encryptor/config/tableSchema.go
@@ -47,7 +47,7 @@ type ColumnEncryptionSetting interface {
 
 	GetEncryptedDataType() common2.EncryptedType
 	GetDefaultDataValue() *string
-	GetResponseOnFail() string
+	GetResponseOnFail() common2.ResponseOnFail
 
 	// Searchable encryption
 	IsSearchable() bool

--- a/encryptor/config/tableSchema.go
+++ b/encryptor/config/tableSchema.go
@@ -47,6 +47,7 @@ type ColumnEncryptionSetting interface {
 
 	GetEncryptedDataType() common2.EncryptedType
 	GetDefaultDataValue() *string
+	GetOnFail() string
 
 	// Searchable encryption
 	IsSearchable() bool

--- a/encryptor/config/tableSchema.go
+++ b/encryptor/config/tableSchema.go
@@ -47,7 +47,7 @@ type ColumnEncryptionSetting interface {
 
 	GetEncryptedDataType() common2.EncryptedType
 	GetDefaultDataValue() *string
-	GetOnFail() string
+	GetResponseOnFail() string
 
 	// Searchable encryption
 	IsSearchable() bool

--- a/encryptor/dataEncryptor_test.go
+++ b/encryptor/dataEncryptor_test.go
@@ -89,7 +89,7 @@ func (s *emptyEncryptionSetting) GetDefaultDataValue() *string {
 	panic("implement me")
 }
 
-func (s *emptyEncryptionSetting) GetResponseOnFail() string {
+func (s *emptyEncryptionSetting) GetResponseOnFail() common2.ResponseOnFail {
 	panic("implement me")
 }
 

--- a/encryptor/dataEncryptor_test.go
+++ b/encryptor/dataEncryptor_test.go
@@ -19,10 +19,11 @@ package encryptor
 import (
 	"bytes"
 	"errors"
+	"testing"
+
 	"github.com/cossacklabs/acra/acrastruct"
 	"github.com/cossacklabs/acra/encryptor/config"
 	common2 "github.com/cossacklabs/acra/encryptor/config/common"
-	"testing"
 
 	"github.com/cossacklabs/acra/pseudonymization/common"
 	"github.com/cossacklabs/themis/gothemis/keys"
@@ -85,6 +86,10 @@ func (s *emptyEncryptionSetting) GetEncryptedDataType() common2.EncryptedType {
 }
 
 func (s *emptyEncryptionSetting) GetDefaultDataValue() *string {
+	panic("implement me")
+}
+
+func (s *emptyEncryptionSetting) GetOnFail() string {
 	panic("implement me")
 }
 

--- a/encryptor/dataEncryptor_test.go
+++ b/encryptor/dataEncryptor_test.go
@@ -89,7 +89,7 @@ func (s *emptyEncryptionSetting) GetDefaultDataValue() *string {
 	panic("implement me")
 }
 
-func (s *emptyEncryptionSetting) GetOnFail() string {
+func (s *emptyEncryptionSetting) GetResponseOnFail() string {
 	panic("implement me")
 }
 

--- a/tests/encryptor_configs/transparent_type_aware_decryption.yaml
+++ b/tests/encryptor_configs/transparent_type_aware_decryption.yaml
@@ -73,3 +73,43 @@ schemas:
 
       - column: value_empty_str
         data_type: "str"
+
+  - table: test_type_aware_decryption_with_error
+    columns:
+      - id
+      - value_str
+      - value_bytes
+      - value_int32
+      - value_int64
+      - value_null_str
+      - value_null_int32
+      - value_empty_str
+
+    encrypted:
+      - column: value_str
+        data_type: "str"
+        response_on_fail: error
+
+      - column: value_bytes
+        data_type: "bytes"
+        response_on_fail: error
+
+      - column: value_int32
+        data_type: "int32"
+        response_on_fail: error
+
+      - column: value_int64
+        data_type: "int64"
+        response_on_fail: error
+
+      - column: value_null_str
+        data_type: "str"
+        response_on_fail: error
+
+      - column: value_null_int32
+        data_type: "str"
+        response_on_fail: error
+
+      - column: value_empty_str
+        data_type: "str"
+        response_on_fail: error

--- a/tests/encryptor_configs/transparent_type_aware_decryption.yaml
+++ b/tests/encryptor_configs/transparent_type_aware_decryption.yaml
@@ -14,18 +14,22 @@ schemas:
   encrypted:
   - column: value_str
     data_type: "str"
+    on_fail: default
     default_data_value: "value_str"
 
   - column: value_bytes
     data_type: "bytes"
+    on_fail: default
     default_data_value: "dmFsdWVfYnl0ZXM="
 
   - column: value_int32
     data_type: "int32"
+    on_fail: default
     default_data_value: "32"
 
   - column: value_int64
     data_type: "int64"
+    on_fail: default
     default_data_value: "64"
 
   - column: value_null_str

--- a/tests/encryptor_configs/transparent_type_aware_decryption.yaml
+++ b/tests/encryptor_configs/transparent_type_aware_decryption.yaml
@@ -14,22 +14,22 @@ schemas:
     encrypted:
       - column: value_str
         data_type: "str"
-        response_on_fail: default
+        response_on_fail: default_value
         default_data_value: "value_str"
 
       - column: value_bytes
         data_type: "bytes"
-        response_on_fail: default
+        response_on_fail: default_value
         default_data_value: "dmFsdWVfYnl0ZXM="
 
       - column: value_int32
         data_type: "int32"
-        response_on_fail: default
+        response_on_fail: default_value
         default_data_value: "32"
 
       - column: value_int64
         data_type: "int64"
-        response_on_fail: default
+        response_on_fail: default_value
         default_data_value: "64"
 
       - column: value_null_str

--- a/tests/encryptor_configs/transparent_type_aware_decryption.yaml
+++ b/tests/encryptor_configs/transparent_type_aware_decryption.yaml
@@ -113,3 +113,43 @@ schemas:
       - column: value_empty_str
         data_type: "str"
         response_on_fail: error
+
+  - table: test_type_aware_decryption_with_ciphertext
+    columns:
+      - id
+      - value_str
+      - value_bytes
+      - value_int32
+      - value_int64
+      - value_null_str
+      - value_null_int32
+      - value_empty_str
+
+    encrypted:
+      - column: value_str
+        data_type: "str"
+        response_on_fail: ciphertext
+
+      - column: value_bytes
+        data_type: "bytes"
+        response_on_fail: ciphertext
+
+      - column: value_int32
+        data_type: "int32"
+        response_on_fail: ciphertext
+
+      - column: value_int64
+        data_type: "int64"
+        response_on_fail: ciphertext
+
+      - column: value_null_str
+        data_type: "str"
+        response_on_fail: ciphertext
+
+      - column: value_null_int32
+        data_type: "str"
+        response_on_fail: ciphertext
+
+      - column: value_empty_str
+        data_type: "str"
+        response_on_fail: ciphertext

--- a/tests/encryptor_configs/transparent_type_aware_decryption.yaml
+++ b/tests/encryptor_configs/transparent_type_aware_decryption.yaml
@@ -1,75 +1,75 @@
 schemas:
   # used in test.py
-- table: test_type_aware_decryption_with_defaults
-  columns:
-  - id
-  - value_str
-  - value_bytes
-  - value_int32
-  - value_int64
-  - value_null_str
-  - value_null_int32
-  - value_empty_str
+  - table: test_type_aware_decryption_with_defaults
+    columns:
+      - id
+      - value_str
+      - value_bytes
+      - value_int32
+      - value_int64
+      - value_null_str
+      - value_null_int32
+      - value_empty_str
 
-  encrypted:
-  - column: value_str
-    data_type: "str"
-    on_fail: default
-    default_data_value: "value_str"
+    encrypted:
+      - column: value_str
+        data_type: "str"
+        response_on_fail: default
+        default_data_value: "value_str"
 
-  - column: value_bytes
-    data_type: "bytes"
-    on_fail: default
-    default_data_value: "dmFsdWVfYnl0ZXM="
+      - column: value_bytes
+        data_type: "bytes"
+        response_on_fail: default
+        default_data_value: "dmFsdWVfYnl0ZXM="
 
-  - column: value_int32
-    data_type: "int32"
-    on_fail: default
-    default_data_value: "32"
+      - column: value_int32
+        data_type: "int32"
+        response_on_fail: default
+        default_data_value: "32"
 
-  - column: value_int64
-    data_type: "int64"
-    on_fail: default
-    default_data_value: "64"
+      - column: value_int64
+        data_type: "int64"
+        response_on_fail: default
+        default_data_value: "64"
 
-  - column: value_null_str
-    data_type: "str"
+      - column: value_null_str
+        data_type: "str"
 
-  - column: value_null_int32
-    data_type: "str"
+      - column: value_null_int32
+        data_type: "str"
 
-  - column: value_empty_str
-    data_type: "str"
+      - column: value_empty_str
+        data_type: "str"
 
-- table: test_type_aware_decryption_without_defaults
-  columns:
-  - id
-  - value_str
-  - value_bytes
-  - value_int32
-  - value_int64
-  - value_null_str
-  - value_null_int32
-  - value_empty_str
+  - table: test_type_aware_decryption_without_defaults
+    columns:
+      - id
+      - value_str
+      - value_bytes
+      - value_int32
+      - value_int64
+      - value_null_str
+      - value_null_int32
+      - value_empty_str
 
-  encrypted:
-  - column: value_str
-    data_type: "str"
+    encrypted:
+      - column: value_str
+        data_type: "str"
 
-  - column: value_bytes
-    data_type: "bytes"
+      - column: value_bytes
+        data_type: "bytes"
 
-  - column: value_int32
-    data_type: "int32"
+      - column: value_int32
+        data_type: "int32"
 
-  - column: value_int64
-    data_type: "int64"
+      - column: value_int64
+        data_type: "int64"
 
-  - column: value_null_str
-    data_type: "str"
+      - column: value_null_str
+        data_type: "str"
 
-  - column: value_null_int32
-    data_type: "str"
+      - column: value_null_int32
+        data_type: "str"
 
-  - column: value_empty_str
-    data_type: "str"
+      - column: value_empty_str
+        data_type: "str"

--- a/tests/test.py
+++ b/tests/test.py
@@ -9108,7 +9108,8 @@ class TestPostgresqlBinaryTypeAwareDecryptionWithError(TestPostgresqlBinaryForma
         # We expect db-driver error
         with self.assertRaises(asyncpg.exceptions.SyntaxOrAccessError) as ex:
             row = self.executor2.execute_prepared_statement(query, args)[0]
-            self.assertIn("encoding error", str(ex))
+
+        self.assertEqual('encoding error in column "value_str"', str(ex.exception))
 
         row = self.raw_executor.execute_prepared_statement(query, args)[0]
         for column in columns:
@@ -9180,7 +9181,8 @@ class TestPostgresqlTextTypeAwareDecryptionWithError(BaseTransparentEncryption):
             self.engine2.execute(
                 sa.select([self.test_table])
                     .where(self.test_table.c.id == data['id']))
-            self.assertIn("encoding error", str(ex))
+
+        self.assertEqual('encoding error in column "value_str"\n', str(ex.exception.orig))
 
         # direct connection should receive binary data according to real scheme
         result = self.engine_raw.execute(

--- a/tests/test.py
+++ b/tests/test.py
@@ -9197,6 +9197,160 @@ class TestPostgresqlTextTypeAwareDecryptionWithError(BaseTransparentEncryption):
             self.assertNotEqual(data[column], value, column)
 
 
+# `response_on_fail` is `ciphertext` if not defined. That's why the code is
+# exactly the same as inTestPostgresqlBinaryTypeAwareDecryptionWithoutDefaults
+class TestPostgresqlBinaryTypeAwareDecryptionWithCiphertext(TestPostgresqlBinaryFormatTypeAwareDecryptionWithDefaults):
+    # test table used for queries and data mapping into python types
+    test_table = sa.Table(
+        # use new object of metadata to avoid name conflict
+        'test_type_aware_decryption_without_defaults', sa.MetaData(),
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('value_str', sa.Text),
+        sa.Column('value_bytes', sa.LargeBinary),
+        sa.Column('value_int32', sa.Integer),
+        sa.Column('value_int64', sa.BigInteger),
+        sa.Column('value_null_str', sa.Text, nullable=True, default=None),
+        sa.Column('value_null_int32', sa.Integer, nullable=True, default=None),
+        sa.Column('value_empty_str', sa.Text, nullable=False, default=''),
+        extend_existing=True
+    )
+    # schema table used to generate table in the database with binary column types
+    schema_table = sa.Table(
+        'test_type_aware_decryption_without_defaults', metadata,
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('value_str', sa.LargeBinary),
+        sa.Column('value_bytes', sa.LargeBinary),
+        sa.Column('value_int32', sa.LargeBinary),
+        sa.Column('value_int64', sa.LargeBinary),
+        sa.Column('value_null_str', sa.LargeBinary, nullable=True, default=None),
+        sa.Column('value_null_int32', sa.LargeBinary, nullable=True, default=None),
+        sa.Column('value_empty_str', sa.LargeBinary, nullable=False, default=b''),
+        extend_existing=True
+    )
+    ENCRYPTOR_CONFIG = get_encryptor_config('tests/encryptor_configs/transparent_type_aware_decryption.yaml')
+
+    def checkSkip(self):
+        if not (TEST_POSTGRESQL and TEST_WITH_TLS):
+            self.skipTest("Test only for PostgreSQL with TLS")
+
+    def testClientIDRead(self):
+        """test decrypting with correct clientID and not decrypting with
+        incorrect clientID or using direct connection to db
+        All result data should be valid for application. Not decrypted data should be returned as is and DB driver
+        should cause error
+        """
+        data = {
+            'id': get_random_id(),
+            'value_str': random_str(),
+            'value_bytes': random_bytes(),
+            'value_int32': random_int32(),
+            'value_int64': random_int64(),
+            'value_null_str': None,
+            'value_null_int32': None,
+            'value_empty_str': ''
+        }
+        self.schema_table.create(bind=self.engine_raw, checkfirst=True)
+        ######
+        columns = ('value_str', 'value_bytes', 'value_int32', 'value_int64', 'value_null_str', 'value_null_int32',
+                   'value_empty_str')
+        query, args = self.compileQuery(self.test_table.insert(), data)
+        self.executor1.execute_prepared_statement(query, args)
+
+        query, args = self.compileQuery(
+            sa.select([self.test_table])
+                .where(self.test_table.c.id == sa.bindparam('id')), {'id': data['id']})
+
+        # Check that raw bytes were returned, which would not be valid utf
+        with self.assertRaises(UnicodeDecodeError):
+            row = self.executor2.execute_prepared_statement(query, args)[0]
+
+        row = self.raw_executor.execute_prepared_statement(query, args)[0]
+        for column in columns:
+            if 'null' in column or 'empty' in column:
+                # asyncpg decodes None values as empty str/bytes value
+                self.assertFalse(row[column])
+                continue
+            value = utils.memoryview_to_bytes(row[column])
+            self.assertIsInstance(value, bytes, column)
+            self.assertNotEqual(data[column], value, column)
+
+# `response_on_fail` is `ciphertext` if not defined. That's why the code is
+# exactly the same as inTestPostgresqlTextTypeAwareDecryptionWithoutDefaults
+class TestPostgresqlTextTypeAwareDecryptionWithCiphertext(BaseTransparentEncryption):
+    # test table used for queries and data mapping into python types
+    test_table = sa.Table(
+        # use new object of metadata to avoid name conflict
+        'test_type_aware_decryption_with_ciphertext', sa.MetaData(),
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('value_str', sa.Text),
+        sa.Column('value_bytes', sa.LargeBinary),
+        sa.Column('value_int32', sa.Integer),
+        sa.Column('value_int64', sa.BigInteger),
+        sa.Column('value_null_str', sa.Text, nullable=True, default=None),
+        sa.Column('value_null_int32', sa.Integer, nullable=True, default=None),
+        sa.Column('value_empty_str', sa.Text, nullable=False, default=''),
+    )
+    # schema table used to generate table in the database with binary column types
+    schema_table = sa.Table(
+        'test_type_aware_decryption_with_ciphertext', sa.MetaData(),
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('value_str', sa.LargeBinary),
+        sa.Column('value_bytes', sa.LargeBinary),
+        sa.Column('value_int32', sa.LargeBinary),
+        sa.Column('value_int64', sa.LargeBinary),
+        sa.Column('value_null_str', sa.LargeBinary, nullable=True, default=None),
+        sa.Column('value_null_int32', sa.LargeBinary, nullable=True, default=None),
+        sa.Column('value_empty_str', sa.LargeBinary, nullable=False, default=b''),
+    )
+    ENCRYPTOR_CONFIG = get_encryptor_config('tests/encryptor_configs/transparent_type_aware_decryption.yaml')
+
+    def checkSkip(self):
+        if not (TEST_POSTGRESQL and TEST_WITH_TLS):
+            self.skipTest("Test only for PostgreSQL with TLS")
+
+    def testClientIDRead(self):
+        """test decrypting with correct clientID and not decrypting with
+        incorrect clientID or using direct connection to db
+        All result data should be valid for application. Not decrypted data should be returned as is and DB driver
+        should cause error
+        """
+        data = {
+            'id': get_random_id(),
+            'value_str': random_str(),
+            'value_bytes': random_bytes(),
+            'value_int32': random_int32(),
+            'value_int64': random_int64(),
+            'value_null_str': None,
+            'value_null_int32': None,
+            'value_empty_str': ''
+        }
+        self.schema_table.create(bind=self.engine_raw, checkfirst=True)
+        self.engine1.execute(self.test_table.insert(), data)
+        columns = ('value_str', 'value_bytes', 'value_int32', 'value_int64', 'value_null_str', 'value_null_int32',
+                   'value_empty_str')
+
+        result = self.engine2.execute(
+            sa.select([self.test_table])
+                .where(self.test_table.c.id == data['id']))
+        # acra change types for binary data columns and python driver can't decode to correct types
+        with self.assertRaises(UnicodeDecodeError):
+            row = result.fetchone()
+
+        # direct connection should receive binary data according to real scheme
+        result = self.engine_raw.execute(
+            sa.select([self.test_table])
+                .where(self.test_table.c.id == data['id']))
+        row = result.fetchone()
+        for column in columns:
+            if 'null' in column or 'empty' in column:
+                # asyncpg decodes None values as empty str/bytes value
+                self.assertFalse(row[column])
+                continue
+            value = utils.memoryview_to_bytes(row[column])
+            self.assertIsInstance(value, bytes, column)
+            self.assertNotEqual(data[column], value, column)
+
+
 class TestMySQLBinaryTypeAwareDecryptionWithoutDefaults(TestMySQLTextTypeAwareDecryptionWithoutDefaults):
     def checkSkip(self):
         if not (TEST_MYSQL and TEST_WITH_TLS):

--- a/tests/test.py
+++ b/tests/test.py
@@ -58,7 +58,7 @@ from prometheus_client.parser import text_string_to_metric_families
 from sqlalchemy.dialects import mysql as mysql_dialect
 from sqlalchemy.dialects import postgresql as postgresql_dialect
 from sqlalchemy.dialects.postgresql import BYTEA
-from sqlalchemy.exc import DatabaseError
+from sqlalchemy.exc import DatabaseError, ProgrammingError
 
 import api_pb2
 import api_pb2_grpc
@@ -9034,6 +9034,159 @@ class TestPostgresqlBinaryTypeAwareDecryptionWithoutDefaults(TestPostgresqlBinar
             row = self.executor2.execute_prepared_statement(query, args)[0]
 
         row = self.raw_executor.execute_prepared_statement(query, args)[0]
+        for column in columns:
+            if 'null' in column or 'empty' in column:
+                # asyncpg decodes None values as empty str/bytes value
+                self.assertFalse(row[column])
+                continue
+            value = utils.memoryview_to_bytes(row[column])
+            self.assertIsInstance(value, bytes, column)
+            self.assertNotEqual(data[column], value, column)
+
+class TestPostgresqlBinaryTypeAwareDecryptionWithError(TestPostgresqlBinaryFormatTypeAwareDecryptionWithDefaults):
+    # test table used for queries and data mapping into python types
+    test_table = sa.Table(
+        # use new object of metadata to avoid name conflict
+        'test_type_aware_decryption_with_error', sa.MetaData(),
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('value_str', sa.Text),
+        sa.Column('value_bytes', sa.LargeBinary),
+        sa.Column('value_int32', sa.Integer),
+        sa.Column('value_int64', sa.BigInteger),
+        sa.Column('value_null_str', sa.Text, nullable=True, default=None),
+        sa.Column('value_null_int32', sa.Integer, nullable=True, default=None),
+        sa.Column('value_empty_str', sa.Text, nullable=False, default=''),
+        extend_existing=True
+    )
+    # schema table used to generate table in the database with binary column types
+    schema_table = sa.Table(
+        'test_type_aware_decryption_with_error', sa.MetaData(),
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('value_str', sa.LargeBinary),
+        sa.Column('value_bytes', sa.LargeBinary),
+        sa.Column('value_int32', sa.LargeBinary),
+        sa.Column('value_int64', sa.LargeBinary),
+        sa.Column('value_null_str', sa.LargeBinary, nullable=True, default=None),
+        sa.Column('value_null_int32', sa.LargeBinary, nullable=True, default=None),
+        sa.Column('value_empty_str', sa.LargeBinary, nullable=False, default=b''),
+        extend_existing=True
+    )
+    ENCRYPTOR_CONFIG = get_encryptor_config('tests/encryptor_configs/transparent_type_aware_decryption.yaml')
+
+    def checkSkip(self):
+        if not (TEST_POSTGRESQL and TEST_WITH_TLS):
+            self.skipTest("Test only for PostgreSQL with TLS")
+
+    def testClientIDRead(self):
+        """
+        test decrypting with correct clientID and not decrypting with
+        incorrect clientID or using direct connection to db
+        All result data should be valid for application. Not decrypted data
+        should cause driver specific error
+        """
+        data = {
+            'id': get_random_id(),
+            'value_str': random_str(),
+            'value_bytes': random_bytes(),
+            'value_int32': random_int32(),
+            'value_int64': random_int64(),
+            'value_null_str': None,
+            'value_null_int32': None,
+            'value_empty_str': ''
+        }
+        self.schema_table.create(bind=self.engine_raw, checkfirst=True)
+        ######
+        columns = ('value_str', 'value_bytes', 'value_int32', 'value_int64',
+                   'value_null_str', 'value_null_int32', 'value_empty_str')
+        query, args = self.compileQuery(self.test_table.insert(), data)
+        self.executor1.execute_prepared_statement(query, args)
+
+        query, args = self.compileQuery(
+            sa.select([self.test_table])
+                .where(self.test_table.c.id == sa.bindparam('id')), {'id': data['id']})
+
+        # We expect db-driver error
+        with self.assertRaises(asyncpg.exceptions.SyntaxOrAccessError) as ex:
+            row = self.executor2.execute_prepared_statement(query, args)[0]
+            self.assertIn("encoding error", str(ex))
+
+        row = self.raw_executor.execute_prepared_statement(query, args)[0]
+        for column in columns:
+            if 'null' in column or 'empty' in column:
+                # asyncpg decodes None values as empty str/bytes value
+                self.assertFalse(row[column])
+                continue
+            value = utils.memoryview_to_bytes(row[column])
+            self.assertIsInstance(value, bytes, column)
+            self.assertNotEqual(data[column], value, column)
+
+
+class TestPostgresqlTextTypeAwareDecryptionWithError(BaseTransparentEncryption):
+    # test table used for queries and data mapping into python types
+    test_table = sa.Table(
+        # use new object of metadata to avoid name conflict
+        'test_type_aware_decryption_with_error', sa.MetaData(),
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('value_str', sa.Text),
+        sa.Column('value_bytes', sa.LargeBinary),
+        sa.Column('value_int32', sa.Integer),
+        sa.Column('value_int64', sa.BigInteger),
+        sa.Column('value_null_str', sa.Text, nullable=True, default=None),
+        sa.Column('value_null_int32', sa.Integer, nullable=True, default=None),
+        sa.Column('value_empty_str', sa.Text, nullable=False, default=''),
+    )
+    # schema table used to generate table in the database with binary column types
+    schema_table = sa.Table(
+        'test_type_aware_decryption_with_error', sa.MetaData(),
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('value_str', sa.LargeBinary),
+        sa.Column('value_bytes', sa.LargeBinary),
+        sa.Column('value_int32', sa.LargeBinary),
+        sa.Column('value_int64', sa.LargeBinary),
+        sa.Column('value_null_str', sa.LargeBinary, nullable=True, default=None),
+        sa.Column('value_null_int32', sa.LargeBinary, nullable=True, default=None),
+        sa.Column('value_empty_str', sa.LargeBinary, nullable=False, default=b''),
+    )
+    ENCRYPTOR_CONFIG = get_encryptor_config('tests/encryptor_configs/transparent_type_aware_decryption.yaml')
+
+    def checkSkip(self):
+        if not (TEST_POSTGRESQL and TEST_WITH_TLS):
+            self.skipTest("Test only for PostgreSQL with TLS")
+
+    def testClientIDRead(self):
+        """
+        test decrypting with correct clientID and not decrypting with
+        incorrect clientID or using direct connection to db
+        All result data should be valid for application. Not decrypted data
+        should cause a db-driver error.
+        """
+        data = {
+            'id': get_random_id(),
+            'value_str': random_str(),
+            'value_bytes': random_bytes(),
+            'value_int32': random_int32(),
+            'value_int64': random_int64(),
+            'value_null_str': None,
+            'value_null_int32': None,
+            'value_empty_str': ''
+        }
+        self.schema_table.create(bind=self.engine_raw, checkfirst=True)
+        self.engine1.execute(self.test_table.insert(), data)
+        columns = ('value_str', 'value_bytes', 'value_int32', 'value_int64',
+                   'value_null_str', 'value_null_int32', 'value_empty_str')
+
+        # our custom error is wrapped around sqlalchemy's ProgrammingError
+        with self.assertRaises(ProgrammingError) as ex:
+            self.engine2.execute(
+                sa.select([self.test_table])
+                    .where(self.test_table.c.id == data['id']))
+            self.assertIn("encoding error", str(ex))
+
+        # direct connection should receive binary data according to real scheme
+        result = self.engine_raw.execute(
+            sa.select([self.test_table])
+                .where(self.test_table.c.id == data['id']))
+        row = result.fetchone()
         for column in columns:
             if 'null' in column or 'empty' in column:
                 # asyncpg decodes None values as empty str/bytes value

--- a/tests/test.py
+++ b/tests/test.py
@@ -58,7 +58,7 @@ from prometheus_client.parser import text_string_to_metric_families
 from sqlalchemy.dialects import mysql as mysql_dialect
 from sqlalchemy.dialects import postgresql as postgresql_dialect
 from sqlalchemy.dialects.postgresql import BYTEA
-from sqlalchemy.exc import DatabaseError, ProgrammingError
+from sqlalchemy.exc import DatabaseError
 
 import api_pb2
 import api_pb2_grpc
@@ -8839,11 +8839,12 @@ class TestPostgresqlTextTypeAwareDecryptionWithoutDefaults(BaseTransparentEncryp
         columns = ('value_str', 'value_bytes', 'value_int32', 'value_int64', 'value_null_str', 'value_null_int32',
                    'value_empty_str')
 
-        # DB driver exception is wrapped around ProgrammingError
-        with self.assertRaises(ProgrammingError):
-            self.engine2.execute(
-                sa.select([self.test_table])
-                    .where(self.test_table.c.id == data['id']))
+        result = self.engine2.execute(
+            sa.select([self.test_table])
+                .where(self.test_table.c.id == data['id']))
+        # acra change types for binary data columns and python driver can't decode to correct types
+        with self.assertRaises(UnicodeDecodeError):
+            row = result.fetchone()
 
         # direct connection should receive binary data according to real scheme
         result = self.engine_raw.execute(
@@ -9002,11 +9003,10 @@ class TestPostgresqlBinaryTypeAwareDecryptionWithoutDefaults(TestPostgresqlBinar
             self.skipTest("Test only for PostgreSQL with TLS")
 
     def testClientIDRead(self):
-        """
-        test decrypting with correct clientID and not decrypting with
+        """test decrypting with correct clientID and not decrypting with
         incorrect clientID or using direct connection to db
-        All result data should be valid for application. Not decrypted data
-        should be returned with a custom DB error
+        All result data should be valid for application. Not decrypted data should be returned as is and DB driver
+        should cause error
         """
         data = {
             'id': get_random_id(),
@@ -9029,8 +9029,9 @@ class TestPostgresqlBinaryTypeAwareDecryptionWithoutDefaults(TestPostgresqlBinar
             sa.select([self.test_table])
                 .where(self.test_table.c.id == sa.bindparam('id')), {'id': data['id']})
 
-        with self.assertRaises(asyncpg.exceptions.SyntaxOrAccessError):
-            self.executor2.execute_prepared_statement(query, args)[0]
+        # Check that raw bytes were returned, which would not be valid utf
+        with self.assertRaises(UnicodeDecodeError):
+            row = self.executor2.execute_prepared_statement(query, args)[0]
 
         row = self.raw_executor.execute_prepared_statement(query, args)[0]
         for column in columns:


### PR DESCRIPTION
One of the last PRs added support for type awareness. That allows defining types on values, which would be decrypted and returned from Acra, like string or int. It also added default values field in configs, which allows to specify which value to return, if some error (possibly decryption error) occurs.

This PR adds ability to chose, which action should be performed on (decryption) failure: either to return client specific error, like acra censor already can, or return default value. 

Default action, if type awareness is enabled, is "error". The user can specify the "default" case together with a default value.

## Checklist

- [x] Change is covered by automated tests
- [x] The [coding guidelines] are followed
- [ ] Public API has proper documentation in the [Acra documentation] site or has PR on [documentation repository] 
  with new changes
- [ ] CHANGELOG.md is updated (in case of notable or breaking changes)
- [x] CHANGELOG_DEV.md is updated
- [x] ~Benchmark results are attached (if applicable)~
- [ ] [Example projects and code samples] are up-to-date (in case of API changes)

[coding guidelines]: https://golang.org/doc/effective_go
[Example projects and code samples]: https://github.com/cossacklabs/acra-engineering-demo
[Acra documentation]: https://docs.cossacklabs.com/
[documentation repository]: https://github.com/cossacklabs/product-docs