### PR TITLE
Ignore legacy keys when caching keys on startup

### DIFF
--- a/keystore/filesystem/server_keystore.go
+++ b/keystore/filesystem/server_keystore.go
@@ -57,6 +57,7 @@ const (
 	poisonPrivateKey   = "poison_key"
 	poisonPublicKey    = "poison_key.pub"
 	poisonSymmetricKey = "poison_key_sym"
+	legacyWebConfigKey = "auth_key"
 )
 
 // ErrUnrecognizedKeyPurpose describe key mismatch error
@@ -835,6 +836,11 @@ func (store *KeyStore) DescribeKeyFile(fileInfo os.FileInfo) (*keystore.KeyDescr
 		return &keystore.KeyDescription{
 			ID:      poisonSymmetricKey,
 			Purpose: PurposePoisonRecordSymmetricKey,
+		}, nil
+	case legacyWebConfigKey:
+		return &keystore.KeyDescription{
+			ID:      fileInfo.Name(),
+			Purpose: PurposeLegacy,
 		}, nil
 	}
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -6184,6 +6184,7 @@ class TestAcraIgnoresLegacyKeys(AcraCatchLogsMixin, BaseTestCase):
     """
 
     legacy_key_files = [
+        'auth_key',
         'testclientid',
         'testclientid.pub',
         'testclientid_server',


### PR DESCRIPTION
Ignore Acra WebConfig keys as well.
This key generation is also deprecated.

This PR adds what I forgot to include in #510 previously.

<!-- Describe your changes here -->

## Checklist

- [x] Change is covered by automated tests
- [x] The [coding guidelines] are followed
- [x] ~Public API has proper documentation in the [Acra documentation] site or has PR on [documentation repository] 
  with new changes~
- [x] ~CHANGELOG.md is updated (in case of notable or breaking changes)~
- [x] ~CHANGELOG_DEV.md is updated~
- [x] ~Benchmark results are attached (if applicable)~
- [x] ~[Example projects and code samples] are up-to-date (in case of API changes)~

[coding guidelines]: https://golang.org/doc/effective_go
[Example projects and code samples]: https://github.com/cossacklabs/acra-engineering-demo
[Acra documentation]: https://docs.cossacklabs.com/
[documentation repository]: https://github.com/cossacklabs/product-docs