### PR TITLE
Update params/columns data_types  for prepare packet

### DIFF
--- a/decryptor/mysql/prepared_statements.go
+++ b/decryptor/mysql/prepared_statements.go
@@ -2,11 +2,15 @@ package mysql
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"github.com/cossacklabs/acra/encryptor"
+	"github.com/cossacklabs/acra/logging"
 	tokens "github.com/cossacklabs/acra/pseudonymization/common"
 	"github.com/cossacklabs/acra/utils"
+	"net"
 	"strconv"
 
 	"github.com/cossacklabs/acra/decryptor/base"
@@ -280,4 +284,104 @@ func (m *mysqlBoundValue) Encode() (encoded []byte, err error) {
 	}
 
 	return encoded, outErr
+}
+
+// PreparedStatementFieldTracker track and replace DataType for column and param ColumnDefinition
+type PreparedStatementFieldTracker struct {
+	proxyHandler *Handler
+	// shared value that indicates number of param packet
+	paramsCounter int
+	columnsNum    uint16
+}
+
+// NewPreparedStatementFieldTracker create new PreparedStatementFieldTracker
+func NewPreparedStatementFieldTracker(handler *Handler, columnNum uint16) PreparedStatementFieldTracker {
+	return PreparedStatementFieldTracker{
+		proxyHandler: handler,
+		columnsNum:   columnNum,
+	}
+}
+
+// ParamsTrackHandler ResponseHandler used to track prepared statement params
+func (p *PreparedStatementFieldTracker) ParamsTrackHandler(ctx context.Context, packet *Packet, _, clientConnection net.Conn) error {
+	clientSession := base.ClientSessionFromContext(ctx)
+	if clientSession == nil {
+		p.proxyHandler.logger.Warningln("No packet without ClientSession in context")
+		return nil
+	}
+	items := encryptor.PlaceholderSettingsFromClientSession(clientSession)
+	if items == nil {
+		p.proxyHandler.logger.Debugln("No packet with registered recognized encryption settings")
+		return nil
+	}
+
+	p.proxyHandler.logger.Debugln("Parse param ColumnDefinition")
+	if packet.IsEOF() {
+		p.proxyHandler.resetQueryHandler()
+		// if columns_num > 0 column definition block will follow
+		// https://dev.mysql.com/doc/internals/en/com-stmt-prepare-response.html
+		if p.columnsNum > 0 {
+			p.proxyHandler.setQueryHandler(p.ColumnsTrackHandler)
+		}
+
+		if _, err := clientConnection.Write(packet.Dump()); err != nil {
+			p.proxyHandler.logger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorNetworkWrite).
+				Debugln("Can't proxy output")
+		}
+		return nil
+	}
+
+	field, err := ParseResultField(packet)
+	if err != nil {
+		p.proxyHandler.logger.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorProtocolProcessing).WithError(err).Errorln("Can't parse result field")
+		return err
+	}
+
+	setting, ok := items[p.paramsCounter]
+	if ok {
+		newFieldType, ok := mapEncryptedTypeToField(setting.GetEncryptedDataType())
+		if ok {
+			field.originType = field.Type
+			field.Type = Type(newFieldType)
+			field.changed = true
+		}
+	}
+
+	if _, err := clientConnection.Write(field.Dump()); err != nil {
+		p.proxyHandler.logger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorNetworkWrite).
+			Debugln("Can't proxy output")
+	}
+
+	p.paramsCounter++
+	return nil
+}
+
+// ColumnsTrackHandler ResponseHandler used to track prepared statement columns
+func (p *PreparedStatementFieldTracker) ColumnsTrackHandler(ctx context.Context, packet *Packet, _, clientConnection net.Conn) error {
+	p.proxyHandler.logger.Debugln("Parse column ColumnDefinition")
+	if packet.IsEOF() {
+		p.proxyHandler.resetQueryHandler()
+
+		if _, err := clientConnection.Write(packet.Dump()); err != nil {
+			p.proxyHandler.logger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorNetworkWrite).
+				Debugln("Can't proxy output")
+		}
+		return nil
+	}
+
+	field, err := ParseResultField(packet)
+	if err != nil {
+		p.proxyHandler.logger.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorProtocolProcessing).WithError(err).Errorln("Can't parse result field")
+		return err
+	}
+
+	// updating field type according to DataType provided in schemaStore
+	updateFieldEncodedType(field, p.proxyHandler.setting.TableSchemaStore())
+
+	if _, err := clientConnection.Write(field.Dump()); err != nil {
+		p.proxyHandler.logger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorNetworkWrite).
+			Debugln("Can't proxy output")
+	}
+
+	return nil
 }

--- a/decryptor/mysql/prepared_statements.go
+++ b/decryptor/mysql/prepared_statements.go
@@ -306,12 +306,12 @@ func NewPreparedStatementFieldTracker(handler *Handler, columnNum uint16) Prepar
 func (p *PreparedStatementFieldTracker) ParamsTrackHandler(ctx context.Context, packet *Packet, _, clientConnection net.Conn) error {
 	clientSession := base.ClientSessionFromContext(ctx)
 	if clientSession == nil {
-		p.proxyHandler.logger.Warningln("packet without ClientSession in context")
+		p.proxyHandler.logger.Warningln("Packet without ClientSession in context")
 	}
 
 	items := encryptor.PlaceholderSettingsFromClientSession(clientSession)
 	if items == nil {
-		p.proxyHandler.logger.Debugln("packet with registered recognized encryption settings")
+		p.proxyHandler.logger.Debugln("Packet with registered recognized encryption settings")
 	}
 
 	p.proxyHandler.logger.Debugln("Parse param ColumnDefinition")

--- a/decryptor/mysql/prepared_statements.go
+++ b/decryptor/mysql/prepared_statements.go
@@ -349,6 +349,7 @@ func (p *PreparedStatementFieldTracker) ParamsTrackHandler(ctx context.Context, 
 	if _, err := clientConnection.Write(field.Dump()); err != nil {
 		p.proxyHandler.logger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorNetworkWrite).
 			Debugln("Can't proxy output")
+		return err
 	}
 
 	p.paramsCounter++
@@ -380,6 +381,7 @@ func (p *PreparedStatementFieldTracker) ColumnsTrackHandler(ctx context.Context,
 	if _, err := clientConnection.Write(field.Dump()); err != nil {
 		p.proxyHandler.logger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorNetworkWrite).
 			Debugln("Can't proxy output")
+		return err
 	}
 
 	return nil

--- a/decryptor/mysql/prepared_statements.go
+++ b/decryptor/mysql/prepared_statements.go
@@ -6,16 +6,16 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"github.com/cossacklabs/acra/encryptor"
-	"github.com/cossacklabs/acra/logging"
-	tokens "github.com/cossacklabs/acra/pseudonymization/common"
-	"github.com/cossacklabs/acra/utils"
 	"net"
 	"strconv"
 
 	"github.com/cossacklabs/acra/decryptor/base"
+	"github.com/cossacklabs/acra/encryptor"
 	"github.com/cossacklabs/acra/encryptor/config"
+	"github.com/cossacklabs/acra/logging"
+	tokens "github.com/cossacklabs/acra/pseudonymization/common"
 	"github.com/cossacklabs/acra/sqlparser"
+	"github.com/cossacklabs/acra/utils"
 )
 
 // ErrStatementNotFound Err returned by prepared statement registry.
@@ -302,7 +302,7 @@ func NewPreparedStatementFieldTracker(handler *Handler, columnNum uint16) Prepar
 	}
 }
 
-// ParamsTrackHandler implements ResponseHandler to track prepare statement columns
+// ParamsTrackHandler implements ResponseHandler to track prepare statement params
 func (p *PreparedStatementFieldTracker) ParamsTrackHandler(ctx context.Context, packet *Packet, _, clientConnection net.Conn) error {
 	clientSession := base.ClientSessionFromContext(ctx)
 	if clientSession == nil {

--- a/decryptor/mysql/prepared_statements.go
+++ b/decryptor/mysql/prepared_statements.go
@@ -302,17 +302,16 @@ func NewPreparedStatementFieldTracker(handler *Handler, columnNum uint16) Prepar
 	}
 }
 
-// ParamsTrackHandler ResponseHandler used to track prepared statement params
+// ParamsTrackHandler implements ResponseHandler to track prepare statement columns
 func (p *PreparedStatementFieldTracker) ParamsTrackHandler(ctx context.Context, packet *Packet, _, clientConnection net.Conn) error {
 	clientSession := base.ClientSessionFromContext(ctx)
 	if clientSession == nil {
-		p.proxyHandler.logger.Warningln("No packet without ClientSession in context")
-		return nil
+		p.proxyHandler.logger.Warningln("packet without ClientSession in context")
 	}
+
 	items := encryptor.PlaceholderSettingsFromClientSession(clientSession)
 	if items == nil {
-		p.proxyHandler.logger.Debugln("No packet with registered recognized encryption settings")
-		return nil
+		p.proxyHandler.logger.Debugln("packet with registered recognized encryption settings")
 	}
 
 	p.proxyHandler.logger.Debugln("Parse param ColumnDefinition")
@@ -356,7 +355,7 @@ func (p *PreparedStatementFieldTracker) ParamsTrackHandler(ctx context.Context, 
 	return nil
 }
 
-// ColumnsTrackHandler ResponseHandler used to track prepared statement columns
+// ColumnsTrackHandler implements ResponseHandler to track prepared statement columns
 func (p *PreparedStatementFieldTracker) ColumnsTrackHandler(ctx context.Context, packet *Packet, _, clientConnection net.Conn) error {
 	p.proxyHandler.logger.Debugln("Parse column ColumnDefinition")
 	if packet.IsEOF() {

--- a/decryptor/mysql/prepared_statements_test.go
+++ b/decryptor/mysql/prepared_statements_test.go
@@ -47,9 +47,6 @@ func TestNewMysqlCopyTextBoundValue(t *testing.T) {
 // columnPacketHex is mysql test column packet with Name `id` and table `test_type_aware_decryption_without_defaults`
 var columnPacketHex = "0364656604746573742b746573745f747970655f61776172655f64656372797074696f6e5f776974686f75745f64656661756c74732b746573745f747970655f61776172655f64656372797074696f6e5f776974686f75745f64656661756c74730269640269640c3f000b000000030342000000"
 
-// paramPacketHex is mysql test param packet with Name `?` and table `test_type_aware_decryption_without_defaults`
-var paramPacketHex = "03646566000000013f000c3f0000000000fd8000000000"
-
 func TestColumnsTrackHandler(t *testing.T) {
 	data, err := hex.DecodeString(columnPacketHex)
 	if err != nil {
@@ -120,6 +117,9 @@ schemas:
 	}
 	wg.Wait()
 }
+
+// paramPacketHex is mysql test param packet with Name `?` and table `test_type_aware_decryption_without_defaults`
+var paramPacketHex = "03646566000000013f000c3f0000000000fd8000000000"
 
 func TestParamsTrackHandler(t *testing.T) {
 	data, err := hex.DecodeString(paramPacketHex)

--- a/decryptor/mysql/prepared_statements_test.go
+++ b/decryptor/mysql/prepared_statements_test.go
@@ -44,11 +44,11 @@ func TestNewMysqlCopyTextBoundValue(t *testing.T) {
 	})
 }
 
-// columnPacketHex is mysql test column packet with Name `id` and table `test_type_aware_decryption_without_defaults`
-var columnPacketHex = "0364656604746573742b746573745f747970655f61776172655f64656372797074696f6e5f776974686f75745f64656661756c74732b746573745f747970655f61776172655f64656372797074696f6e5f776974686f75745f64656661756c74730269640269640c3f000b000000030342000000"
+// columnPacketPayloadHex is mysql test column packet payload without header with Name `id` and table `test_type_aware_decryption_without_defaults`
+var columnPacketPayloadHex = "0364656604746573742b746573745f747970655f61776172655f64656372797074696f6e5f776974686f75745f64656661756c74732b746573745f747970655f61776172655f64656372797074696f6e5f776974686f75745f64656661756c74730269640269640c3f000b000000030342000000"
 
 func TestColumnsTrackHandler(t *testing.T) {
-	data, err := hex.DecodeString(columnPacketHex)
+	data, err := hex.DecodeString(columnPacketPayloadHex)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -118,11 +118,11 @@ schemas:
 	wg.Wait()
 }
 
-// paramPacketHex is mysql test param packet with Name `?` and table `test_type_aware_decryption_without_defaults`
-var paramPacketHex = "03646566000000013f000c3f0000000000fd8000000000"
+// paramPacketPayloadHex is mysql test param packet payload without header with Name `?` and table `test_type_aware_decryption_without_defaults`
+var paramPacketPayloadHex = "03646566000000013f000c3f0000000000fd8000000000"
 
 func TestParamsTrackHandler(t *testing.T) {
-	data, err := hex.DecodeString(paramPacketHex)
+	data, err := hex.DecodeString(paramPacketPayloadHex)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/decryptor/mysql/prepared_statements_test.go
+++ b/decryptor/mysql/prepared_statements_test.go
@@ -1,10 +1,17 @@
 package mysql
 
 import (
-	"reflect"
-	"testing"
-
+	"bytes"
+	"context"
+	"encoding/hex"
 	"github.com/cossacklabs/acra/decryptor/base"
+	"github.com/cossacklabs/acra/decryptor/base/mocks"
+	"github.com/cossacklabs/acra/encryptor/config"
+	"github.com/cossacklabs/acra/sqlparser"
+	"net"
+	"reflect"
+	"sync"
+	"testing"
 )
 
 func TestNewMysqlCopyTextBoundValue(t *testing.T) {
@@ -33,5 +40,173 @@ func TestNewMysqlCopyTextBoundValue(t *testing.T) {
 		if value != nil {
 			t.Fatal("BoundValue data should be nil")
 		}
+	})
+}
+
+// columnPacketHex is mysql test column packet with Name `id` and table `test_type_aware_decryption_without_defaults`
+var columnPacketHex = "0364656604746573742b746573745f747970655f61776172655f64656372797074696f6e5f776974686f75745f64656661756c74732b746573745f747970655f61776172655f64656372797074696f6e5f776974686f75745f64656661756c74730269640269640c3f000b000000030342000000"
+
+// paramPacketHex is mysql test param packet with Name `?` and table `test_type_aware_decryption_without_defaults`
+var paramPacketHex = "03646566000000013f000c3f0000000000fd8000000000"
+
+func TestColumnsTrackHandler(t *testing.T) {
+	data, err := hex.DecodeString(columnPacketHex)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	parser := sqlparser.New(sqlparser.ModeStrict)
+
+	testConfig := `
+schemas:
+  - table: test_type_aware_decryption_without_defaults
+    columns:
+      - id
+    encrypted:
+      - column: id
+        data_type: "str"
+`
+	schemaStore, err := config.MapTableSchemaStoreFromConfig([]byte(testConfig))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	setting := base.NewProxySetting(parser, schemaStore, nil, nil, nil, nil, false)
+	proxyHandler, err := NewMysqlProxy(&stubSession{}, parser, setting)
+	if err != nil {
+		t.Fatal()
+	}
+
+	fieldTracker := NewPreparedStatementFieldTracker(proxyHandler, 1)
+
+	fieldPacket := NewPacket()
+	fieldPacket.SetData(data)
+
+	server, client := net.Pipe()
+	defer client.Close()
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	// starting server connection read goroutine
+	go func() {
+		defer wg.Done()
+		resData := make([]byte, len(fieldPacket.data)+len(fieldPacket.header))
+		_, err := server.Read(resData)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		resPacket := NewPacket()
+		// without header which is 4 bytes
+		resPacket.SetData(resData[4:])
+		resDesc, err := ParseResultField(resPacket)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if resDesc.Type != TypeString {
+			t.Fatalf("result packet type should be %d (string) but was %d", TypeString, resDesc.Type)
+		}
+	}()
+
+	err = fieldTracker.ColumnsTrackHandler(context.Background(), fieldPacket, server, client)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wg.Wait()
+}
+
+func TestParamsTrackHandler(t *testing.T) {
+	data, err := hex.DecodeString(paramPacketHex)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	parser := sqlparser.New(sqlparser.ModeStrict)
+	nonEmptyStore := &tableSchemaStore{false}
+
+	setting := base.NewProxySetting(parser, nonEmptyStore, nil, nil, nil, nil, false)
+	proxyHandler, err := NewMysqlProxy(&stubSession{}, parser, setting)
+	if err != nil {
+		t.Fatal()
+	}
+
+	fieldTracker := NewPreparedStatementFieldTracker(proxyHandler, 1)
+
+	fieldPacket := NewPacket()
+	fieldPacket.SetData(data)
+
+	server, client := net.Pipe()
+	defer client.Close()
+
+	t.Run("ParamsTrackHandler success", func(t *testing.T) {
+		wg := sync.WaitGroup{}
+		wg.Add(1)
+		// starting server connection read goroutine
+		go func() {
+			defer wg.Done()
+			resData := make([]byte, len(fieldPacket.data)+len(fieldPacket.header))
+			_, err := server.Read(resData)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			resPacket := NewPacket()
+			// without header which is 4 bytes
+			resPacket.SetData(resData[4:])
+			resField, err := ParseResultField(resPacket)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if resField.Type != TypeLong {
+				t.Fatalf("result packet type should be %d (int32) but was %d", TypeLong, resField.Type)
+			}
+		}()
+
+		clientSession := &mocks.ClientSession{}
+		sessionData := make(map[int]config.ColumnEncryptionSetting, 2)
+		sessionData[0] = &config.BasicColumnEncryptionSetting{
+			DataType: "int32",
+		}
+		clientSession.On("GetData", "bind_encryption_settings").Return(sessionData, true)
+
+		ctx := base.SetClientSessionToContext(context.Background(), clientSession)
+		err = fieldTracker.ParamsTrackHandler(ctx, fieldPacket, server, client)
+		if err != nil {
+			t.Fatal(err)
+		}
+		wg.Wait()
+	})
+
+	t.Run("ParamsTrackHandler with nil items map", func(t *testing.T) {
+		wg := sync.WaitGroup{}
+		wg.Add(1)
+		// starting server connection read goroutine
+		go func() {
+			defer wg.Done()
+			resData := make([]byte, len(fieldPacket.data)+len(fieldPacket.header))
+			_, err := server.Read(resData)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			resPacket := NewPacket()
+			// without header which is 4 bytes
+			resPacket.SetData(resData[4:])
+			if !bytes.Equal(fieldPacket.GetData(), resData[4:]) {
+				t.Fatal("result packet should be as origin packet")
+			}
+		}()
+
+		clientSession := &mocks.ClientSession{}
+		clientSession.On("GetData", "bind_encryption_settings").Return(nil, true)
+
+		ctx := base.SetClientSessionToContext(context.Background(), clientSession)
+		err = fieldTracker.ParamsTrackHandler(ctx, fieldPacket, server, client)
+		if err != nil {
+			t.Fatal(err)
+		}
+		wg.Wait()
 	})
 }

--- a/decryptor/mysql/prepared_statements_test.go
+++ b/decryptor/mysql/prepared_statements_test.go
@@ -12,6 +12,7 @@ import (
 	"reflect"
 	"sync"
 	"testing"
+	"time"
 )
 
 func TestNewMysqlCopyTextBoundValue(t *testing.T) {
@@ -83,6 +84,10 @@ schemas:
 	fieldPacket.SetData(data)
 
 	server, client := net.Pipe()
+	deadline := time.Now().Add(time.Second)
+	client.SetWriteDeadline(deadline)
+	server.SetReadDeadline(deadline)
+
 	defer client.Close()
 
 	wg := sync.WaitGroup{}
@@ -137,6 +142,11 @@ func TestParamsTrackHandler(t *testing.T) {
 	fieldPacket.SetData(data)
 
 	server, client := net.Pipe()
+
+	deadline := time.Now().Add(time.Second)
+	client.SetWriteDeadline(deadline)
+	server.SetReadDeadline(deadline)
+
 	defer client.Close()
 
 	t.Run("ParamsTrackHandler success", func(t *testing.T) {

--- a/decryptor/mysql/response_proxy.go
+++ b/decryptor/mysql/response_proxy.go
@@ -773,6 +773,12 @@ func (handler *Handler) PreparedStatementResponseHandler(ctx context.Context, pa
 	}
 
 	handler.resetQueryHandler()
+	// if prams_num > 0 params definition block will follow
+	// https://dev.mysql.com/doc/internals/en/com-stmt-prepare-response.html
+	if response.ParamsNum > 0 {
+		fieldTracker := NewPreparedStatementFieldTracker(handler, response.ColumnsNum)
+		handler.setQueryHandler(fieldTracker.ParamsTrackHandler)
+	}
 	handler.logger.Debugln("Prepared Statement registered successfully")
 	return nil
 }


### PR DESCRIPTION
During conversation with @Lagovas about [#517 ](https://github.com/cossacklabs/acra/pull/517). We faced that we didnt change data_types for intermediate params/columns ColumnDefinition that are following after COM_STMT_PREPARE_OK packet. It wasnt noticed at previous PR because all driver ignore it and use only last metadata field from STMT_EXECUTE packet. But we do have to change it because some ORM might use these intermediate packet to make some cachin on its own side. 

- [x] Change is covered by automated tests
- [x] The [coding guidelines] are followed
- [x] Public API has proper documentation in the [Acra documentation] site or has PR on [documentation repository] 
  with new changes
- [x] CHANGELOG.md is updated (in case of notable or breaking changes)
- [x] CHANGELOG_DEV.md is updated
- [x] Benchmark results are attached (if applicable)
- [x] [Example projects and code samples] are up-to-date (in case of API changes) 

[coding guidelines]: https://golang.org/doc/effective_go
[Example projects and code samples]: https://github.com/cossacklabs/acra-engineering-demo
[Acra documentation]: https://docs.cossacklabs.com/
[documentation repository]: https://github.com/cossacklabs/product-docs