### PR TITLE
Update python extended example

### DIFF
--- a/examples/python/common.py
+++ b/examples/python/common.py
@@ -8,7 +8,7 @@ from sqlalchemy import create_engine
 
 def register_common_cli_params(parser):
     parser.add_argument('--db_name', type=str,
-                        default=get_default('db_name', 'acra'),
+                        default=get_default('db_name', 'test'),
                         help='Database name')
     parser.add_argument('--db_user', type=str,
                         default=get_default('db_user','test'),

--- a/examples/python/data.json
+++ b/examples/python/data.json
@@ -1,30 +1,38 @@
-[{
-"token_i32": 1234,
-"token_i64": 645664,
-"token_str": "078-05-1111",
-"token_bytes": "byt13es",
-"token_email": "john_wed@cl.com",
-"data": "John Wed, Senior Relationshop Manager",
-"masking": "$112000",
-"searchable": "john_wed@cl.com"
-},
-{
-"token_i32": 1235,
-"token_i64": 645665,
-"token_str": "078-05-1112",
-"token_bytes": "byt13es2",
-"token_email": "april_cassini@cl.com",
-"data": "April Cassini, Marketing Manager",
-"masking": "$168000",
-"searchable": "april_cassini@cl.com"
-},
-{
-"token_i32": 1236,
-"token_i64": 645667,
-"token_str": "078-05-1117",
-"token_bytes": "byt13es3",
-"token_email": "george_clooney@cl.com",
-"data": "George Clooney, Famous Actor",
-"masking": "$780000",
-"searchable": "george_clooney@cl.com"
-}]
+[
+  {
+    "token_i32": 1234,
+    "data_i32": "1234",
+    "token_i64": 645664,
+    "data_i64": "645664",
+    "token_str": "078-05-1111",
+    "token_bytes": "byt13es",
+    "token_email": "john_wed@cl.com",
+    "data_str": "John Wed, Senior Relationshop Manager",
+    "masking": "$112000",
+    "searchable": "john_wed@cl.com"
+  },
+  {
+    "token_i32": 1234,
+    "data_i32": "1234",
+    "token_i64": 645664,
+    "data_i64": "645664",
+    "token_str": "078-05-1112",
+    "token_bytes": "byt13es2",
+    "token_email": "april_cassini@cl.com",
+    "data_str": "April Cassini, Marketing Manager",
+    "masking": "$168000",
+    "searchable": "april_cassini@cl.com"
+  },
+  {
+    "token_i32": 1234,
+    "data_i32": "1234",
+    "token_i64": 645664,
+    "data_i64": "645664",
+    "token_str": "078-05-1117",
+    "token_bytes": "byt13es3",
+    "token_email": "george_clooney@cl.com",
+    "data_str": "George Clooney, Famous Actor",
+    "masking": "$780000",
+    "searchable": "george_clooney@cl.com"
+  }
+]

--- a/examples/python/extended_encryptor_config_with_zone.yaml
+++ b/examples/python/extended_encryptor_config_with_zone.yaml
@@ -5,16 +5,19 @@ schemas:
   - table: test
     columns:
       - id
-      - data
+      - data_str
       - masking
       - token_i32
+      - data_i32
       - token_i64
+      - data_i64
       - token_str
       - token_bytes
       - token_email
     encrypted:
       - column: data
         zone_id: DDDDDDDDHHNqiSYFXkpxopYZ
+        data_type: "str"
       - column: masking
         masking: "xxxx"
         plaintext_length: 3
@@ -24,9 +27,15 @@ schemas:
         token_type: int32
         tokenized: true
         zone_id: DDDDDDDDHHNqiSYFXkpxopYZ
+      - column: data_i32
+        data_type: "int32"
+        zone_id: DDDDDDDDHHNqiSYFXkpxopYZ
       - column: token_i64
         token_type: int64
         tokenized: true
+        zone_id: DDDDDDDDHHNqiSYFXkpxopYZ
+      - column: data_i64
+        data_type: "int64"
         zone_id: DDDDDDDDHHNqiSYFXkpxopYZ
       - column: token_bytes
         token_type: bytes

--- a/examples/python/extended_encryptor_config_without_zone.yaml
+++ b/examples/python/extended_encryptor_config_without_zone.yaml
@@ -5,25 +5,33 @@ schemas:
   - table: test
     columns:
       - id
-      - data
+      - data_str
       - masking
       - token_i32
+      - data_i32
       - token_i64
+      - data_i64
       - token_str
       - token_bytes
       - token_email
     encrypted:
-      - column: data
+      - column: data_str
+        data_type: "str"
       - column: masking
         masking: "xxxx"
         plaintext_length: 3
         plaintext_side: "left"
+        data_type: "str"
       - column: token_i32
         token_type: int32
         tokenized: true
+      - column: data_i32
+        data_type: "int32"
       - column: token_i64
         token_type: int64
         tokenized: true
+      - column: data_i64
+        data_type: "int64"
       - column: token_bytes
         token_type: bytes
         tokenized: true

--- a/examples/python/extended_example_with_zone.py
+++ b/examples/python/extended_example_with_zone.py
@@ -16,19 +16,36 @@ import argparse
 import json
 import ssl
 
+from sqlalchemy import (Table, Column, Integer, MetaData, select, LargeBinary, Text, BigInteger, literal)
 from sqlalchemy.dialects import postgresql
 
-from sqlalchemy import (Table, Column, Integer, MetaData, select, LargeBinary, Text, BigInteger, literal)
 from common import get_engine, get_default, get_zone, register_common_cli_params
 
 metadata = MetaData()
 test_table = Table(
-    'test', metadata,
+    'test', MetaData(),
     Column('id', Integer, primary_key=True, nullable=False),
-    Column('data', LargeBinary, nullable=True),
+    Column('data_str', Text, nullable=True),
     Column('masking', LargeBinary, nullable=True),
     Column('token_i32', Integer, nullable=True),
+    Column('data_i32', Integer, nullable=True),
     Column('token_i64', BigInteger, nullable=True),
+    Column('data_i64', BigInteger, nullable=True),
+    Column('token_str', Text, nullable=True),
+    Column('token_bytes', LargeBinary, nullable=True),
+    Column('token_email', Text, nullable=True),
+)
+
+# _schema_test_table used to generate table in the database with binary column types
+_schema_test_table = Table(
+    'test', metadata,
+    Column('id', Integer, primary_key=True, nullable=False),
+    Column('data_str', LargeBinary, nullable=True),
+    Column('masking', LargeBinary, nullable=True),
+    Column('token_i32', Integer, nullable=True),
+    Column('data_i32', LargeBinary, nullable=True),
+    Column('token_i64', BigInteger, nullable=True),
+    Column('data_i64', LargeBinary, nullable=True),
     Column('token_str', Text, nullable=True),
     Column('token_bytes', LargeBinary, nullable=True),
     Column('token_email', Text, nullable=True),
@@ -51,7 +68,7 @@ def print_data(connection, zone_id, columns):
             query = select(table_columns)
             extra_columns = [i.name for i in test_table.columns if i.name not in default_columns]
     except AttributeError:
-        print("\n\n{0}\nprobably you used incorrect column name\n{0}\n\n".format('*'*30))
+        print("\n\n{0}\nprobably you used incorrect column name\n{0}\n\n".format('*' * 30))
         raise
         exit(1)
 
@@ -82,7 +99,7 @@ def write_data(data, connection):
     if isinstance(data, dict):
         rows = [data]
     for row in rows:
-        for k in ('data', 'token_bytes', 'masking'):
+        for k in ('data_str', 'data_i64', 'data_i32', 'email', 'token_bytes', 'masking'):
             row[k] = row[k].encode('ascii')
         connection.execute(
             test_table.insert(), row)

--- a/examples/python/extended_example_without_zone.py
+++ b/examples/python/extended_example_without_zone.py
@@ -15,19 +15,35 @@
 import argparse
 import json
 
-from sqlalchemy.dialects import postgresql
 from sqlalchemy import (Table, Column, Integer, MetaData, select, LargeBinary, Text, BigInteger)
-from common import get_engine, get_default, register_common_cli_params
+from sqlalchemy.dialects import postgresql
 
+from common import get_engine, get_default, register_common_cli_params
 
 metadata = MetaData()
 test_table = Table(
-    'test', metadata,
+    'test', MetaData(),
     Column('id', Integer, primary_key=True, nullable=False),
-    Column('data', LargeBinary, nullable=True),
+    Column('data_str', Text, nullable=True),
     Column('masking', LargeBinary, nullable=True),
     Column('token_i32', Integer, nullable=True),
+    Column('data_i32', Integer, nullable=True),
     Column('token_i64', BigInteger, nullable=True),
+    Column('data_i64', BigInteger, nullable=True),
+    Column('token_str', Text, nullable=True),
+    Column('token_bytes', LargeBinary, nullable=True),
+    Column('token_email', Text, nullable=True),
+)
+# _schema_test_table used to generate table in the database with binary column types
+_schema_test_table = Table(
+    'test', metadata,
+    Column('id', Integer, primary_key=True, nullable=False),
+    Column('data_str', LargeBinary, nullable=True),
+    Column('masking', LargeBinary, nullable=True),
+    Column('token_i32', Integer, nullable=True),
+    Column('data_i32', LargeBinary, nullable=True),
+    Column('token_i64', BigInteger, nullable=True),
+    Column('data_i64', LargeBinary, nullable=True),
     Column('token_str', Text, nullable=True),
     Column('token_bytes', LargeBinary, nullable=True),
     Column('token_email', Text, nullable=True),
@@ -61,7 +77,7 @@ def print_data(connection, columns, table=test_table):
             query = select(table_columns)
             extra_columns = [i.name for i in table.columns if i.name not in default_columns]
     except AttributeError:
-        print("\n\n{0}\nprobably you used incorrect column name\n{0}\n\n".format('*'*30))
+        print("\n\n{0}\nprobably you used incorrect column name\n{0}\n\n".format('*' * 30))
         raise
         exit(1)
 
@@ -92,7 +108,7 @@ def write_data(data, connection, table=test_table):
     if isinstance(data, dict):
         rows = [data]
     for row in rows:
-        for k in ('data', 'email', 'token_bytes', 'masking'):
+        for k in ('data_str', 'data_i64', 'data_i32', 'email', 'token_bytes', 'masking'):
             if k in row:
                 row[k] = row[k].encode('ascii')
         connection.execute(


### PR DESCRIPTION
As part of acra-engineering demo Type Awareness feature we need to extend python examples to support it. 

Since python examples from acra are used inside acra-engendering demo, this PR is part of acra-eng demo modification. 

This PR contains little extends of encryptor configs with new `data_type` fields. Important part is adding one more schema inside py files. These are needed to construct table inside DB(with raw fields) and another for making queries (with defined type)

## Checklist

- [X] Change is covered by automated tests
- [X] The [coding guidelines] are followed
- [X] Public API has proper documentation in the [Acra documentation] site or has PR on [documentation repository] 
  with new changes
- [X] CHANGELOG.md is updated (in case of notable or breaking changes)
- [X] CHANGELOG_DEV.md is updated
- [X] Benchmark results are attached (if applicable)
- [X] [Example projects and code samples] are up-to-date (in case of API changes) 

[coding guidelines]: https://golang.org/doc/effective_go
[Example projects and code samples]: https://github.com/cossacklabs/acra-engineering-demo
[Acra documentation]: https://docs.cossacklabs.com/
[documentation repository]: https://github.com/cossacklabs/product-docs