### PR TITLE
Don't escape space characters in strings

### DIFF
--- a/CHANGELOG_DEV.md
+++ b/CHANGELOG_DEV.md
@@ -1,3 +1,6 @@
+## 0.93.0 - 2022-04-14
+- Don't encode into hex space ascii characters
+
 ## 0.93.0 - 2022-04-06
 - MySQL transparent decryption with replacing type's metadata
 - Refactored MySQL internal data encoding/decoding structure by implementing separate `DataDecoderProcessor` and `DataEncoderProcessor`

--- a/decryptor/postgresql/data_encoder_test.go
+++ b/decryptor/postgresql/data_encoder_test.go
@@ -3,6 +3,7 @@ package postgresql
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"errors"
 	"github.com/cossacklabs/acra/decryptor/base"
 	"github.com/cossacklabs/acra/encryptor"
@@ -326,6 +327,8 @@ func TestEncodingDecodingTextFormat(t *testing.T) {
 	}
 	testcases := []testcase{
 		{inputValue: []byte(`valid string`), outputValue: []byte(`valid string`), binValue: []byte(`valid string`), tokenType: common.TokenType_String},
+		{inputValue: []byte("\n\t~ []!@#$%^&*()_+[]"), outputValue: []byte("\n\t~ []!@#$%^&*()_+[]"), binValue: []byte("\n\t~ []!@#$%^&*()_+[]"), tokenType: common.TokenType_String},
+		{inputValue: []byte{0, 1, 2, 3}, outputValue: []byte(`\x` + hex.EncodeToString([]byte{0, 1, 2, 3})), binValue: []byte{0, 1, 2, 3}, tokenType: common.TokenType_String},
 		{inputValue: []byte(`valid string`), outputValue: []byte(`valid string`), binValue: []byte(`valid string`), tokenType: common.TokenType_Email},
 		// input hex encoded value that looks like a valid string should be returned as string literal
 		{inputValue: []byte(`\x76616c696420737472696e67`), outputValue: []byte(`valid string`), binValue: []byte(`valid string`), tokenType: common.TokenType_Bytes},

--- a/utils/escape_format.go
+++ b/utils/escape_format.go
@@ -28,8 +28,8 @@ func IsPrintableEscapeChar(c byte) bool {
 	return false
 }
 
-// IsPrintablePostgresqlString returns true if it's valid ASCII or utf8 string except '\' character that used as escape
-// character in strings
+// IsPrintablePostgresqlString returns true if it's valid ASCII printable + space characters, or utf8 printable string
+//except '\' character that used as escape character in strings
 func IsPrintablePostgresqlString(data []byte) bool {
 	if len(data) == 0 {
 		return true
@@ -38,7 +38,7 @@ func IsPrintablePostgresqlString(data []byte) bool {
 	stringValue := BytesToString(data)
 	// '\' is special case because PostgreSQL escapes it
 	for _, c := range stringValue {
-		if c == '\\' || !unicode.IsPrint(c) {
+		if !(unicode.IsSpace(c) || unicode.IsPrint(c)) || c == '\\' {
 			return false
 		}
 	}


### PR DESCRIPTION
Found that valid strings with `\n` characters for string types we encode as hex values and then it rendered incorrectly in web apps. In this PR update our check of printable characters that skipped for encoding. Also found that postgresql sends unicode values in another way then simple latin strings (with encoding into hex). But I didn't find how to fix it correctly, so I created T2531 for futher investigations. And this PR just short fix that should fix obvious and frequent cases.

## Checklist

- [X] Change is covered by automated tests
- [X] The [coding guidelines] are followed
- ~~[ ] Public API has proper documentation in the [Acra documentation] site or has PR on [documentation repository] 
  with new changes~~
- ~~[ ] CHANGELOG.md is updated (in case of notable or breaking changes)~~
- [X] CHANGELOG_DEV.md is updated
- ~~[ ] Benchmark results are attached (if applicable)~~
- ~~[ ] [Example projects and code samples] are up-to-date (in case of API changes)~~

[coding guidelines]: https://golang.org/doc/effective_go
[Example projects and code samples]: https://github.com/cossacklabs/acra-engineering-demo
[Acra documentation]: https://docs.cossacklabs.com/
[documentation repository]: https://github.com/cossacklabs/product-docs