### PR TITLE
Allow plain connection after ssl deny

### DIFF
--- a/CHANGELOG_DEV.md
+++ b/CHANGELOG_DEV.md
@@ -1,3 +1,6 @@
+# 0.93.0 - 2022-04-14
+- Fix processing of a plain startup message after the `ssl deny`.
+
 # 0.93.0 - 2022-04-07
 - Extend config with `on_fail` field, which indicates wheter to return error ("error") to a client, or default values ("default") in case of error.
 

--- a/decryptor/postgresql/pg_decryptor.go
+++ b/decryptor/postgresql/pg_decryptor.go
@@ -431,7 +431,11 @@ func (proxy *PgProxy) stopProxyClientConnection(logger *log.Entry) error {
 		return errors.New("can't stop background goroutine")
 	}
 
-	// TODO: why twice?
+	// Reset the deadline
+	// From the https://pkg.go.dev/net#Conn:
+	//
+	//   A zero value for t means I/O operations will not time out.
+	//
 	if err := proxy.clientConnection.SetDeadline(time.Time{}); err != nil {
 		logger.
 			WithError(err).

--- a/decryptor/postgresql/pg_decryptor.go
+++ b/decryptor/postgresql/pg_decryptor.go
@@ -97,7 +97,7 @@ const (
 	ReadyForQueryMessageType byte = 'Z'
 	RowDescriptionType       byte = 'T'
 	ParameterDescriptionType byte = 't'
-	TLSTimeout                    = time.Second * 2
+	ClientStopTimeout             = time.Second * 2
 )
 
 // Specific for PgSQL values of data format
@@ -112,11 +112,11 @@ type PgProxy struct {
 	session                 base.ClientSession
 	clientConnection        net.Conn
 	dbConnection            net.Conn
-	TLSCh                   chan bool
+	stopClient              bool
+	ClientStopResponse      chan bool
 	ctx                     context.Context
 	queryObserverManager    base.QueryObserverManager
 	censor                  acracensor.AcraCensorInterface
-	tlsSwitch               bool
 	decryptionObserver      base.ColumnDecryptionObserver
 	protocolState           *PgProtocolState
 	setting                 base.ProxySetting
@@ -152,7 +152,7 @@ func NewPgProxy(session base.ClientSession, parser *sqlparser.Parser, setting ba
 		session:                 session,
 		clientConnection:        session.ClientConnection(),
 		dbConnection:            session.DatabaseConnection(),
-		TLSCh:                   make(chan bool),
+		ClientStopResponse:      make(chan bool),
 		ctx:                     session.Context(),
 		queryObserverManager:    observerManager,
 		setting:                 setting,
@@ -220,9 +220,9 @@ func (proxy *PgProxy) ProxyClientConnection(ctx context.Context, errCh chan<- ba
 		spanEndFunc()
 
 		if err = packet.ReadClientPacket(); err != nil {
-			if proxy.tlsSwitch {
-				proxy.tlsSwitch = false
-				proxy.TLSCh <- true
+			if proxy.stopClient {
+				proxy.stopClient = false
+				proxy.ClientStopResponse <- true
 				return
 			}
 			// log message with debug level because only here we expect and can meet errors with closed connections io.EOF
@@ -408,6 +408,41 @@ func (proxy *PgProxy) sendClientError(msg string, logger *log.Entry) error {
 	return nil
 }
 
+// stopClientThread sends a signal to a client thread to stop. Returns error in
+// case of an error or timeout. Is used to stop and reload client with TLS
+func (proxy *PgProxy) stopClientThread(logger *log.Entry) error {
+	proxy.stopClient = true
+	// stop reading from client in goroutine
+	if err := proxy.clientConnection.SetDeadline(time.Now()); err != nil {
+		logger.
+			WithError(err).
+			WithField(logging.FieldKeyEventCode, logging.EventCodeErrorDecryptorCantSetDeadlineToClientConnection).
+			Errorln("Can't set deadline")
+		return err
+	}
+
+	select {
+	case <-proxy.ClientStopResponse:
+	case <-time.NewTimer(ClientStopTimeout).C:
+		logger.
+			// TODO: which event code
+			WithField(logging.FieldKeyEventCode, logging.EventCodeErrorDecryptorCantInitializeTLS).
+			Errorln("Can't stop background goroutine")
+		return errors.New("can't stop background goroutine")
+	}
+
+	// TODO: why twice?
+	if err := proxy.clientConnection.SetDeadline(time.Time{}); err != nil {
+		logger.
+			WithError(err).
+			WithField(logging.FieldKeyEventCode, logging.EventCodeErrorDecryptorCantSetDeadlineToClientConnection).
+			Errorln("Can't set deadline")
+		return err
+	}
+	logger.Debugln("Stop client connection")
+	return nil
+}
+
 // handleSSLRequest return wrapped with tls (client's, db's connections, nil) or (nil, nil, error)
 func (proxy *PgProxy) handleSSLRequest(packet *PacketHandler, logger *log.Entry) (net.Conn, net.Conn, error) {
 	// if server allow SSLRequest than we wrap our connections with tls
@@ -418,25 +453,7 @@ func (proxy *PgProxy) handleSSLRequest(packet *PacketHandler, logger *log.Entry)
 		return nil, nil, network.ErrEmptyTLSConfig
 	}
 	logger.Debugln("Start tls proxy")
-	proxy.tlsSwitch = true
-	// stop reading from client in goroutine
-	if err := proxy.clientConnection.SetDeadline(time.Now()); err != nil {
-		logger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorDecryptorCantSetDeadlineToClientConnection).
-			Errorln("Can't set deadline")
-		return nil, nil, err
-	}
-	select {
-	case <-proxy.TLSCh:
-		proxy.TLSCh = nil
-		break
-	case <-time.NewTimer(TLSTimeout).C:
-		logger.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorDecryptorCantInitializeTLS).Errorln("Can't stop background goroutine to start tls handshake")
-		return nil, nil, errors.New("can't stop background goroutine")
-	}
-	logger.Debugln("Stop client connection")
-	if err := proxy.clientConnection.SetDeadline(time.Time{}); err != nil {
-		logger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorDecryptorCantSetDeadlineToClientConnection).
-			Errorln("Can't set deadline")
+	if err := proxy.stopClientThread(logger); err != nil {
 		return nil, nil, err
 	}
 	logger.Debugln("Init tls with client")

--- a/decryptor/postgresql/pg_decryptor.go
+++ b/decryptor/postgresql/pg_decryptor.go
@@ -408,9 +408,9 @@ func (proxy *PgProxy) sendClientError(msg string, logger *log.Entry) error {
 	return nil
 }
 
-// stopClientThread sends a signal to a client thread to stop. Returns error in
+// stopProxyClientConnection sends a signal to a client thread to stop. Returns error in
 // case of an error or timeout. Is used to stop and reload client with TLS
-func (proxy *PgProxy) stopClientThread(logger *log.Entry) error {
+func (proxy *PgProxy) stopProxyClientConnection(logger *log.Entry) error {
 	proxy.stopClient = true
 	// stop reading from client in goroutine
 	if err := proxy.clientConnection.SetDeadline(time.Now()); err != nil {
@@ -453,7 +453,7 @@ func (proxy *PgProxy) handleSSLRequest(packet *PacketHandler, logger *log.Entry)
 		return nil, nil, network.ErrEmptyTLSConfig
 	}
 	logger.Debugln("Start tls proxy")
-	if err := proxy.stopClientThread(logger); err != nil {
+	if err := proxy.stopProxyClientConnection(logger); err != nil {
 		return nil, nil, err
 	}
 	logger.Debugln("Init tls with client")
@@ -600,7 +600,7 @@ func (proxy *PgProxy) ProxyDatabaseConnection(ctx context.Context, errCh chan<- 
 				logger.Debugln("Deny ssl request")
 				// In case of deny ssl, the client can send plain startup message
 				// again. To handle this, we reload client thread to reset the state
-				if err := proxy.stopClientThread(logger); err != nil {
+				if err := proxy.stopProxyClientConnection(logger); err != nil {
 					errCh <- base.NewDBProxyError(err)
 					return
 				}

--- a/tests/test.py
+++ b/tests/test.py
@@ -9399,9 +9399,10 @@ class TestMySQLBinaryTypeAwareDecryptionWithoutDefaults(TestMySQLTextTypeAwareDe
             value = utils.memoryview_to_bytes(row[column])
             self.assertIsInstance(value, bytearray, column)
             self.assertNotEqual(data[column], value, column)
+
 class TestPostgresqlConnectWithTLSPrefer(BaseTestCase):
     def checkSkip(self):
-        if TEST_WITH_TLS:
+        if TEST_WITH_TLS or not TEST_POSTGRESQL:
             self.skipTest("running tests with TLS")
 
     def with_tls(self):


### PR DESCRIPTION
Right now, if some clients receive `SSL deny` from the server, they can try to start plain connection by sending plain `Startup message`. The last one would then be served not as a startup, but as a general one, which will hang a connection.

This PR fixes this by reloading client thread after `ssl deny` to expect startup message again.

There are a couple of `TODO`s, which I hope you will help me to resolve.

## Checklist

- [x] Change is covered by automated tests
- [x] The [coding guidelines] are followed
- [x] ~Public API has proper documentation in the [Acra documentation] site or has PR on [documentation repository]~
  with new changes
- [x] ~CHANGELOG.md is updated (in case of notable or breaking changes)~
- [x] CHANGELOG_DEV.md is updated
- [x] ~Benchmark results are attached (if applicable)~
- [x] ~[Example projects and code samples] are up-to-date (in case of API changes)~

[coding guidelines]: https://golang.org/doc/effective_go
[Example projects and code samples]: https://github.com/cossacklabs/acra-engineering-demo
[Acra documentation]: https://docs.cossacklabs.com/
[documentation repository]: https://github.com/cossacklabs/product-docs