### PR TITLE
Deprecate `tokenize` option

### DIFF
--- a/CHANGELOG_DEV.md
+++ b/CHANGELOG_DEV.md
@@ -1,3 +1,6 @@
+# 0.93.0 - 2022-04-14
+- Deprecate `tokenized` option and use non-empty `token_type` to indicate tokenization.
+
 # 0.93.0 - 2022-04-07
 - Extend config with `on_fail` field, which indicates wheter to return error ("error") to a client, or default values ("default") in case of error.
 

--- a/decryptor/postgresql/data_encoder_test.go
+++ b/decryptor/postgresql/data_encoder_test.go
@@ -63,7 +63,6 @@ func TestEncodingDecodingProcessorBinaryIntData(t *testing.T) {
 		accessContext.SetColumnInfo(columnInfo)
 		ctx := base.SetAccessContextToContext(context.Background(), accessContext)
 		testSetting := config.BasicColumnEncryptionSetting{
-			Tokenized: true,
 			DataType:  sizeToTokenType[tcase.binarySize],
 			TokenType: sizeToTokenType[tcase.binarySize]}
 		ctx = encryptor.NewContextWithEncryptionSetting(ctx, &testSetting)
@@ -149,15 +148,15 @@ func TestTextMode(t *testing.T) {
 		// decoder expects valid string and pass as is, so no errors. but on encode operation it expects valid int literal
 		{input: []byte("some data"), decodedData: []byte("some data"), encodedData: []byte("some data"),
 			decodeErr: nil, encodeErr: nil,
-			setting:    &config.BasicColumnEncryptionSetting{Tokenized: true, DataType: "int32"},
+			setting:    &config.BasicColumnEncryptionSetting{TokenType: "int32", DataType: "int32"},
 			logMessage: `Can't decode int value and no default value`},
 
 		{input: []byte("123"), decodedData: []byte("123"), encodedData: []byte("123"), decodeErr: nil, encodeErr: nil,
-			setting: &config.BasicColumnEncryptionSetting{Tokenized: true, DataType: "int32"}},
+			setting: &config.BasicColumnEncryptionSetting{TokenType: "int32", DataType: "int32"}},
 
 		// encryption/decryption integer data, not tokenization
 		{input: []byte("some data"), decodedData: []byte("some data"), encodedData: []byte("some data"), decodeErr: nil, encodeErr: nil,
-			setting:    &config.BasicColumnEncryptionSetting{Tokenized: false, DataType: "int32"},
+			setting:    &config.BasicColumnEncryptionSetting{DataType: "int32"},
 			logMessage: `Can't decode int value and no default value`},
 
 		// encryption/decryption integer data, not tokenization
@@ -168,7 +167,7 @@ func TestTextMode(t *testing.T) {
 			decodeErr:   nil,
 			encodeErr:   nil,
 			setting: &config.BasicColumnEncryptionSetting{
-				Tokenized:        false,
+				TokenType:        "int32",
 				DataType:         "int32",
 				ResponseOnFail:   common2.ResponseOnFailDefault,
 				DefaultDataValue: &strDefaultValue,
@@ -177,25 +176,25 @@ func TestTextMode(t *testing.T) {
 
 		// invalid binary hex value that should be returned as is. Also encoded into hex due to invalid hex value
 		{input: []byte("\\xTT"), decodedData: []byte("\\xTT"), encodedData: []byte("\\x5c785454"), decodeErr: nil, encodeErr: nil,
-			setting: &config.BasicColumnEncryptionSetting{Tokenized: false, DataType: "bytes"}},
+			setting: &config.BasicColumnEncryptionSetting{DataType: "bytes"}},
 		// printable valid value returned as is
 		{input: []byte("valid string"), decodedData: []byte("valid string"), encodedData: []byte("valid string"), decodeErr: nil, encodeErr: nil,
-			setting: &config.BasicColumnEncryptionSetting{Tokenized: false, DataType: "bytes"}},
+			setting: &config.BasicColumnEncryptionSetting{DataType: "bytes"}},
 		{input: []byte("valid string"), decodedData: []byte("valid string"), encodedData: []byte("valid string"), decodeErr: nil, encodeErr: nil,
-			setting: &config.BasicColumnEncryptionSetting{Tokenized: false, DataType: "str"}},
+			setting: &config.BasicColumnEncryptionSetting{DataType: "str"}},
 
 		// empty values
 		{input: []byte{}, decodedData: []byte{}, encodedData: []byte{}, decodeErr: nil, encodeErr: nil,
-			setting: &config.BasicColumnEncryptionSetting{Tokenized: false, DataType: "bytes"}},
+			setting: &config.BasicColumnEncryptionSetting{DataType: "bytes"}},
 		// empty values
 		{input: nil, decodedData: nil, encodedData: nil, decodeErr: nil, encodeErr: nil,
-			setting: &config.BasicColumnEncryptionSetting{Tokenized: false, DataType: "bytes"}},
+			setting: &config.BasicColumnEncryptionSetting{DataType: "bytes"}},
 		// empty values
 		{input: []byte{}, decodedData: []byte{}, encodedData: []byte{}, decodeErr: nil, encodeErr: nil,
-			setting: &config.BasicColumnEncryptionSetting{Tokenized: false, DataType: "str"}},
+			setting: &config.BasicColumnEncryptionSetting{DataType: "str"}},
 		// empty values
 		{input: nil, decodedData: nil, encodedData: nil, decodeErr: nil, encodeErr: nil,
-			setting: &config.BasicColumnEncryptionSetting{Tokenized: false, DataType: "str"}},
+			setting: &config.BasicColumnEncryptionSetting{DataType: "str"}},
 	}
 
 	columnInfo := base.NewColumnInfo(0, "", false, 4, 0, 0)
@@ -407,7 +406,7 @@ func TestSkipWithoutColumnInfo(t *testing.T) {
 	testData := []byte("some data")
 	accessContext := &base.AccessContext{}
 	ctx := base.SetAccessContextToContext(context.Background(), accessContext)
-	testSetting := config.BasicColumnEncryptionSetting{Tokenized: true, TokenType: "int32"}
+	testSetting := config.BasicColumnEncryptionSetting{TokenType: "int32"}
 	ctx = encryptor.NewContextWithEncryptionSetting(ctx, &testSetting)
 	for _, subscriber := range []base.DecryptionSubscriber{encoder, decoder} {
 		_, data, err := subscriber.OnColumn(ctx, testData)

--- a/encryptor/config/encryptionSettings.go
+++ b/encryptor/config/encryptionSettings.go
@@ -125,15 +125,22 @@ var validSettings = map[SettingMask]struct{}{
 	// TOKENIZATION
 	// default clientID
 	SettingTokenizationFlag | SettingTokenTypeFlag | SettingReEncryptionFlag | SettingAcraBlockEncryptionFlag: {},
+	SettingTokenTypeFlag | SettingReEncryptionFlag | SettingAcraBlockEncryptionFlag:                           {},
 
 	SettingTokenizationFlag | SettingTokenTypeFlag | SettingConsistentTokenizationFlag | SettingReEncryptionFlag:                                  {},
 	SettingTokenizationFlag | SettingTokenTypeFlag | SettingConsistentTokenizationFlag | SettingReEncryptionFlag | SettingAcraBlockEncryptionFlag: {},
+	SettingTokenTypeFlag | SettingConsistentTokenizationFlag | SettingReEncryptionFlag:                                                            {},
+	SettingTokenTypeFlag | SettingConsistentTokenizationFlag | SettingReEncryptionFlag | SettingAcraBlockEncryptionFlag:                           {},
 	// specified clientID
 	SettingTokenizationFlag | SettingTokenTypeFlag | SettingClientIDFlag | SettingReEncryptionFlag | SettingAcraBlockEncryptionFlag:                                     {},
 	SettingTokenizationFlag | SettingTokenTypeFlag | SettingConsistentTokenizationFlag | SettingClientIDFlag | SettingReEncryptionFlag | SettingAcraBlockEncryptionFlag: {},
+	SettingTokenTypeFlag | SettingClientIDFlag | SettingReEncryptionFlag | SettingAcraBlockEncryptionFlag:                                                               {},
+	SettingTokenTypeFlag | SettingConsistentTokenizationFlag | SettingClientIDFlag | SettingReEncryptionFlag | SettingAcraBlockEncryptionFlag:                           {},
 	// specified zoneID
 	SettingTokenizationFlag | SettingTokenTypeFlag | SettingZoneIDFlag | SettingReEncryptionFlag | SettingAcraBlockEncryptionFlag:                                     {},
 	SettingTokenizationFlag | SettingTokenTypeFlag | SettingConsistentTokenizationFlag | SettingZoneIDFlag | SettingReEncryptionFlag | SettingAcraBlockEncryptionFlag: {},
+	SettingTokenTypeFlag | SettingZoneIDFlag | SettingReEncryptionFlag | SettingAcraBlockEncryptionFlag:                                                               {},
+	SettingTokenTypeFlag | SettingConsistentTokenizationFlag | SettingZoneIDFlag | SettingReEncryptionFlag | SettingAcraBlockEncryptionFlag:                           {},
 }
 
 // Token type names as expected in the configuration file.
@@ -188,6 +195,10 @@ type BasicColumnEncryptionSetting struct {
 	ResponseOnFail common2.ResponseOnFail `yaml:"response_on_fail"`
 
 	// Data pseudonymization (tokenization)
+
+	// Tokenized is DEPRECATED, but left to provide backwards compatibility.
+	// Was used to enable tokenization. Right now the `TokenType` serves that
+	// purpose: if it's not empty, tokenization is enabled.
 	Tokenized              bool   `yaml:"tokenized"`
 	ConsistentTokenization bool   `yaml:"consistent_tokenization"`
 	TokenType              string `yaml:"token_type"`
@@ -308,7 +319,7 @@ func (s *BasicColumnEncryptionSetting) Init() (err error) {
 		return fmt.Errorf("invalid default value: %w", err)
 	}
 
-	if s.Tokenized {
+	if s.Tokenized || s.TokenType != "" {
 		s.settingMask |= SettingTokenizationFlag
 		s.settingMask |= SettingTokenTypeFlag
 		if s.ConsistentTokenization {
@@ -379,7 +390,7 @@ func (s *BasicColumnEncryptionSetting) ZoneID() []byte {
 
 // IsTokenized returns true if the column should be tokenized.
 func (s *BasicColumnEncryptionSetting) IsTokenized() bool {
-	return s.Tokenized
+	return s.Tokenized || s.TokenType != ""
 }
 
 // IsConsistentTokenization returns true if column tokens should be consistent.

--- a/encryptor/config/schemaStore_test.go
+++ b/encryptor/config/schemaStore_test.go
@@ -1114,3 +1114,31 @@ schemas:
 		}
 	}
 }
+
+func TestInvalidTokenizationCombinations(t *testing.T) {
+	type testcase struct {
+		name   string
+		config string
+	}
+	testcases := []testcase{
+		{"Tokenized: false and token_type non empty",
+			`
+schemas:
+  - table: test_table
+    columns:
+      - data
+    encrypted:
+      - column: data
+        tokenized: false
+        token_type: str
+    `},
+	}
+
+	for _, tcase := range testcases {
+		_, err := MapTableSchemaStoreFromConfig([]byte(tcase.config))
+
+		if err == nil {
+			t.Fatalf("[%s] expected error, found nil\n", tcase.name)
+		}
+	}
+}

--- a/encryptor/config/schemaStore_test.go
+++ b/encryptor/config/schemaStore_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	common2 "github.com/cossacklabs/acra/encryptor/config/common"
@@ -1058,6 +1059,58 @@ schemas:
 
 		if err == nil {
 			t.Fatalf("[%s] expected error, found nil\n", tcase.name)
+		}
+	}
+}
+
+func TestDeprecateTokenized(t *testing.T) {
+	tokenTypes := []string{
+		"str", "email", "int64", "int32", "bytes",
+	}
+
+	for _, token := range tokenTypes {
+		config := fmt.Sprintf(`
+schemas:
+  - table: test_table
+    columns:
+      - data
+    encrypted:
+      - column: data
+        tokenized: true
+        token_type: %s
+`, token)
+		_, err := MapTableSchemaStoreFromConfig([]byte(config))
+		if err != nil {
+			t.Fatalf("[tokenize: true, token_type: %s] %s", token, err)
+		}
+
+		config = fmt.Sprintf(`
+schemas:
+  - table: test_table
+    columns:
+      - data
+    encrypted:
+      - column: data
+        token_type: %s
+`, token)
+		_, err = MapTableSchemaStoreFromConfig([]byte(config))
+		if err != nil {
+			t.Fatalf("[token_type: %s] %s", token, err)
+		}
+
+		config = fmt.Sprintf(`
+schemas:
+  - table: test_table
+    columns:
+      - data
+    encrypted:
+      - column: data
+        consistent_tokenization: true
+        token_type: %s
+`, token)
+		_, err = MapTableSchemaStoreFromConfig([]byte(config))
+		if err != nil {
+			t.Fatalf("[consistent_tokenization: true, token_type: %s] %s", token, err)
 		}
 	}
 }


### PR DESCRIPTION
This PR deprecates `tokenize` from encryptor config. It is still present, but it's role is taken by `token_type` - if it's not empty, the tokenization is enabled.

Also, forbids the `tokenize: false and token_type: <something>` pair.

## Checklist

- [x] Change is covered by automated tests
- [x] The [coding guidelines] are followed
- [ ] Public API has proper documentation in the [Acra documentation] site or has PR on [documentation repository] 
  with new changes
- [x] ~CHANGELOG.md is updated (in case of notable or breaking changes)~
- [x] CHANGELOG_DEV.md is updated
- [x] ~Benchmark results are attached (if applicable)~
- [x] ~[Example projects and code samples] are up-to-date (in case of API changes)~

[coding guidelines]: https://golang.org/doc/effective_go
[Example projects and code samples]: https://github.com/cossacklabs/acra-engineering-demo
[Acra documentation]: https://docs.cossacklabs.com/
[documentation repository]: https://github.com/cossacklabs/product-docs