### PR TITLE
Add `make install_dev_deps`

### DIFF
--- a/CHANGELOG_DEV.md
+++ b/CHANGELOG_DEV.md
@@ -1,3 +1,6 @@
+# 0.93.0 - 2022-04-20
+- Add `make install_dev_deps` for development dependencies installation.
+
 # 0.93.0 - 2022-04-19
 - Fix output of `acra-keys list` for keystore v1: record duplication and wrong client id for log key.
 

--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ endef
 .PHONY: help \
     build install test_go test_python test test_all clean \
     docker-build docker-push docker-clean docker \
-    pkg deb rpm
+    pkg deb rpm install_dev_deps
 
 #----- Help --------------------------------------------------------------------
 
@@ -167,7 +167,7 @@ help:
 		/^## / { split($$0,a,/## /); comment = a[2] }\
 		/^[a-zA-Z-][a-zA-Z_-]*:.*?/ {\
 			if (length(comment) == 0) { next };\
-			printf "  $(COLOR_TARGET)%-15s$(COLOR_DEFAULT) %s\n", $$1, comment;\
+			printf "  $(COLOR_TARGET)%-16s$(COLOR_DEFAULT) %s\n", $$1, comment;\
 			comment = "" }'\
 		$(MAKEFILE_LIST)
 	@printf "\n$(COLOR_MENU)Properties allowed for overriding:$(COLOR_DEFAULT)\n"
@@ -243,6 +243,13 @@ clean:
 keys: install
 	@chmod +x scripts/generate-keys.sh
 	@scripts/generate-keys.sh
+
+## Install development dependencies
+install_dev_deps:
+	go install golang.org/x/tools/cmd/goyacc
+	go install github.com/swaggo/swag/cmd/swag@latest
+	go install github.com/tinylib/msgp@latest
+	go install github.com/vektra/mockery/v2@latest
 
 ##---- Docker ------------------------------------------------------------------
 


### PR DESCRIPTION
This command installs all tools required to successfully run the `go generate` command.

It's needed for the acra-ee deployment and testing.

## Checklist

- [x] ~Change is covered by automated tests~
- [x] ~The [coding guidelines] are followed~
- [x] ~Public API has proper documentation in the [Acra documentation] site or has PR on [documentation repository] 
  with new changes~
- [x] ~CHANGELOG.md is updated (in case of notable or breaking changes)~
- [x] CHANGELOG_DEV.md is updated
- [x] ~Benchmark results are attached (if applicable)~
- [x] ~[Example projects and code samples] are up-to-date (in case of API changes)~

[coding guidelines]: https://golang.org/doc/effective_go
[Example projects and code samples]: https://github.com/cossacklabs/acra-engineering-demo
[Acra documentation]: https://docs.cossacklabs.com/
[documentation repository]: https://github.com/cossacklabs/product-docs