### PR TITLE
Don't abort connection in mysql after encoding error

### DIFF
--- a/CHANGELOG_DEV.md
+++ b/CHANGELOG_DEV.md
@@ -1,3 +1,6 @@
+# 0.93.0 - 2022-05-10
+- Don't abort connection of mysql after encoding error.
+
 # 0.93.0 - 2022-05-04
 - Add mysql support for `response_on_fail` options.
 

--- a/decryptor/mysql/response_proxy.go
+++ b/decryptor/mysql/response_proxy.go
@@ -296,9 +296,8 @@ func (handler *Handler) ProxyClientConnection(ctx context.Context, errCh chan<- 
 						"for connections AcraServer->Database and CA certificate which will be used to verify certificate " +
 						"from database")
 					handler.logger.Debugln("Send error to db")
-					errPacket := NewQueryInterruptedError(handler.clientProtocol41, QueryExecutionWasInterrupted)
-					packet.SetData(errPacket)
-					if _, err := handler.clientConnection.Write(packet.Dump()); err != nil {
+
+					if err := handler.sendClientError(QueryExecutionWasInterrupted, packet); err != nil {
 						handler.logger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorResponseConnectorCantWriteToClient).
 							Debugln("Can't write response with error to client")
 					}
@@ -395,9 +394,7 @@ func (handler *Handler) ProxyClientConnection(ctx context.Context, errCh chan<- 
 			if err := handler.acracensor.HandleQuery(query); err != nil {
 				censorSpan.End()
 				clientLog.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCensorQueryIsNotAllowed).Errorln("Error on AcraCensor check")
-				errPacket := NewQueryInterruptedError(handler.clientProtocol41, QueryExecutionWasInterrupted)
-				packet.SetData(errPacket)
-				if _, err := handler.clientConnection.Write(packet.Dump()); err != nil {
+				if err := handler.sendClientError(QueryExecutionWasInterrupted, packet); err != nil {
 					handler.logger.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorResponseConnectorCantWriteToClient).
 						Errorln("Can't write response with error to client")
 				}
@@ -860,10 +857,8 @@ func (handler *Handler) ProxyDatabaseConnection(ctx context.Context, errCh chan<
 
 		// EncodingError is the only one that we should forward to the client
 		if encodingError, ok := err.(*base.EncodingError); ok {
-			handler.logger.WithError(encodingError).Debugln("Sending encoding error to the client")
-			errPacket := NewQueryInterruptedError(handler.clientProtocol41, encodingError.Error())
-			packet.SetData(errPacket)
-			if _, err := handler.clientConnection.Write(packet.Dump()); err != nil {
+			handler.logger.WithError(err).Debugln("Sending encoding error to the client")
+			if err := handler.sendClientError(encodingError.Error(), packet); err != nil {
 				handler.logger.WithError(err).
 					WithField(logging.FieldKeyEventCode, logging.EventCodeErrorResponseConnectorCantWriteToClient).
 					Debugln("Can't write response with error to client")
@@ -881,6 +876,14 @@ func (handler *Handler) ProxyDatabaseConnection(ctx context.Context, errCh chan<
 			return
 		}
 	}
+}
+
+// sendClientError sends an `QueryInterruptedError` with a custom message
+func (handler *Handler) sendClientError(msg string, packet *Packet) error {
+	errPacket := NewQueryInterruptedError(handler.clientProtocol41, msg)
+	packet.SetData(errPacket)
+	_, err := handler.clientConnection.Write(packet.Dump())
+	return err
 }
 
 // AddClientIDObserver subscribe new observer for clientID changes

--- a/tests/encryptor_configs/transparent_type_aware_decryption.yaml
+++ b/tests/encryptor_configs/transparent_type_aware_decryption.yaml
@@ -153,3 +153,14 @@ schemas:
       - column: value_empty_str
         data_type: "str"
         response_on_fail: ciphertext
+
+  - table: test_proper_db_flushing_on_error
+    columns:
+      - id
+      - value_bytes
+
+    encrypted:
+      # We want to test the proper workflow, so one field will do the trick
+      - column: value_bytes
+        data_type: "bytes"
+        response_on_fail: error

--- a/tests/test.py
+++ b/tests/test.py
@@ -9755,6 +9755,110 @@ class TestPostgresqlConnectWithTLSPrefer(BaseTestCase):
         loop = asyncio.new_event_loop()  # create new to avoid concurrent usage of the loop in the current thread and allow parallel execution in the future
         loop.run_until_complete(_testPlainConnectionAfterDeny())
 
+class TestMySQLDbFlushingOnError(BaseBinaryMySQLTestCase, BaseTransparentEncryption):
+    encryptor_table = sa.Table(
+        'test_proper_db_flushing_on_error', sa.MetaData(),
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('value_bytes', sa.LargeBinary),
+    )
+    ENCRYPTOR_CONFIG = get_encryptor_config('tests/encryptor_configs/transparent_type_aware_decryption.yaml')
+
+    def checkSkip(self):
+        if not (TEST_MYSQL and TEST_WITH_TLS):
+            self.skipTest("Test only for MySQL with TLS")
+
+    def testConnectionIsNotAborted(self):
+        """
+        Test that connection is not closed in case of "encoding error". Test
+        that we can reuse connection for queries after.
+        """
+
+        self.encryptor_table.create(bind=self.engine_raw, checkfirst=True)
+        # Insert data that will trigger decryption error
+        corrupted_data = {
+            'id': get_random_id(),
+            'value_bytes': random_bytes(),
+        }
+        self.engine_raw.execute(self.encryptor_table.insert(), corrupted_data)
+
+        with self.engine1.connect() as conn:
+            # Insert some data
+            data = {
+                'id': get_random_id(),
+                'value_bytes': random_bytes(),
+            }
+            conn.execute(self.encryptor_table.insert(), data)
+
+            query = sa \
+                .select([self.encryptor_table]) \
+                .where(self.encryptor_table.c.id == data['id'])
+            row = conn.execute(query).fetchone()
+            self.assertEqual(data['value_bytes'], row['value_bytes'])
+
+            # Expect "encoding error"
+            ids = (data['id'], corrupted_data['id'])
+            query = sa \
+                .select([self.encryptor_table]) \
+                .where(self.encryptor_table.c.id.in_(ids))
+
+            with self.assertRaises(sa.exc.OperationalError) as ex:
+                conn.execute(query).fetchall()
+            self.assertEqual(ex.exception.orig.args, (1317, 'encoding error in column "value_bytes"'))
+
+            # Insert and select new data using the same connection to be sure
+            # it doesn't close or get out of sync
+            data = {
+                'id': get_random_id(),
+                'value_bytes': random_bytes(),
+            }
+            conn.execute(self.encryptor_table.insert(), data)
+
+            query = sa \
+                .select([self.encryptor_table]) \
+                .where(self.encryptor_table.c.id == data['id'])
+            row = conn.execute(query).fetchone()
+            self.assertEqual(data['value_bytes'], row['value_bytes'])
+
+    def testTransactionRollback(self):
+        """
+        Test that connection is not closed in case of "encoding error" and
+        sqlaclchemy can do rollback in transaction after that.
+        """
+
+        self.encryptor_table.create(bind=self.engine_raw, checkfirst=True)
+        # Insert data that will trigger decryption error
+        corrupted_data = {
+            'id': get_random_id(),
+            'value_bytes': random_bytes(),
+        }
+        self.engine_raw.execute(self.encryptor_table.insert(), corrupted_data)
+        data = {
+            'id': get_random_id(),
+            'value_bytes': random_bytes(),
+        }
+        select_data = sa \
+            .select([self.encryptor_table]) \
+            .where(self.encryptor_table.c.id == data['id'])
+
+        with self.assertRaises(sa.exc.OperationalError) as ex:
+            with self.engine1.begin() as conn:
+                conn.execute(self.encryptor_table.insert(), data)
+
+                row = conn.execute(select_data).fetchone()
+                self.assertEqual(data['value_bytes'], row['value_bytes'])
+
+                # Expect "encoding error"
+                ids = (data['id'], corrupted_data['id'])
+                query = sa \
+                    .select([self.encryptor_table]) \
+                    .where(self.encryptor_table.c.id.in_(ids))
+
+                conn.execute(query).fetchall()
+
+        self.assertEqual(ex.exception.orig.args, (1317, 'encoding error in column "value_bytes"'))
+        row = self.engine1.execute(select_data).fetchone()
+        self.assertEqual(row, None)
+
 
 if __name__ == '__main__':
     import xmlrunner


### PR DESCRIPTION
This PR implements flushing of db-packets till the end of response after the encoding error. This is done to clear the connection so it can be reused for other queries (like `rollback` for example).

This also adds a couple of tests that show the correctness of the execution. I also wanted to add test with query which produces mysql error after a couple of data packets, so we can check that acra throws "encoding error" earlier and eats the mysql one. But I just couldn't craft such query ._.
Mysql returns `null` in almost every error case (division by zero, unable to allocate `REPEAT('A', 1TB)`, etc). In cases where I could trigger a runtime error it is not possible to use acra, because query is complex. Maybe you can come up with an idea?  

## Checklist

- [x] Change is covered by automated tests
- [x] The [coding guidelines] are followed
- [x] Public API has proper documentation in the [Acra documentation] site or has PR on [documentation repository] 
  with new changes
- [x] ~CHANGELOG.md is updated (in case of notable or breaking changes)~
- [x] CHANGELOG_DEV.md is updated
- [x] ~Benchmark results are attached (if applicable)~
- [x] ~[Example projects and code samples] are up-to-date (in case of API changes)~

[coding guidelines]: https://golang.org/doc/effective_go
[Example projects and code samples]: https://github.com/cossacklabs/acra-engineering-demo
[Acra documentation]: https://docs.cossacklabs.com/
[documentation repository]: https://github.com/cossacklabs/product-docs