### PR TITLE
Do not abort connection after encoding error in postgresql

### DIFF
--- a/CHANGELOG_DEV.md
+++ b/CHANGELOG_DEV.md
@@ -1,3 +1,6 @@
+# 0.93.0 - 2022-05-13
+- Don't abort connection of postgres after encoding error.
+
 # 0.93.0 - 2022-05-10
 - Don't abort connection of mysql after encoding error.
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -9859,6 +9859,8 @@ class TestDbFlushingOnError(BaseTransparentEncryption):
 
                 conn.execute(query).fetchall()
 
+        # Most db-drivers do a rollback after an exception, so check
+        # that our data is not saved due to the rollback.
         row = self.engine1.execute(select_data).fetchone()
         self.assertEqual(row, None)
 
@@ -10004,6 +10006,8 @@ class TestPostgresqlDbFlushingOnError(BaseTransparentEncryption):
 
             self.assertEqual(ex.exception.message,
                              'encoding error in column "value_bytes"')
+            # Most db-drivers do a rollback after an exception, so check
+            # that our data is not saved due to the rollback.
             row = await conn.fetchrow(select_query, data['id'])
             self.assertEqual(row, None)
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -9859,6 +9859,110 @@ class TestMySQLDbFlushingOnError(BaseBinaryMySQLTestCase, BaseTransparentEncrypt
         row = self.engine1.execute(select_data).fetchone()
         self.assertEqual(row, None)
 
+class TestPostgresqlDbFlushingOnError(BaseTransparentEncryption):
+    encryptor_table = sa.Table(
+        'test_proper_db_flushing_on_error', sa.MetaData(),
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('value_bytes', sa.LargeBinary),
+    )
+    ENCRYPTOR_CONFIG = get_encryptor_config('tests/encryptor_configs/transparent_type_aware_decryption.yaml')
+
+    def checkSkip(self):
+        if not (TEST_POSTGRESQL and TEST_WITH_TLS):
+            self.skipTest("Test only for Postgres with TLS")
+
+    def testConnectionIsNotAborted(self):
+        """
+        Test that connection is not closed in case of "encoding error". Test
+        that we can reuse connection for queries after.
+        """
+
+        self.encryptor_table.create(bind=self.engine_raw, checkfirst=True)
+        # Insert data that will trigger decryption error
+        corrupted_data = {
+            'id': get_random_id(),
+            'value_bytes': random_bytes(),
+        }
+        self.engine_raw.execute(self.encryptor_table.insert(), corrupted_data)
+
+        with self.engine1.connect() as conn:
+            # Insert some data
+            data = {
+                'id': get_random_id(),
+                'value_bytes': random_bytes(),
+            }
+            conn.execute(self.encryptor_table.insert(), data)
+
+            query = sa \
+                .select([self.encryptor_table]) \
+                .where(self.encryptor_table.c.id == data['id'])
+            row = conn.execute(query).fetchone()
+            self.assertEqual(data['value_bytes'], row['value_bytes'])
+
+            # Expect "encoding error"
+            ids = (data['id'], corrupted_data['id'])
+            query = sa \
+                .select([self.encryptor_table]) \
+                .where(self.encryptor_table.c.id.in_(ids))
+
+            with self.assertRaises(sa.exc.DatabaseError) as ex:
+                conn.execute(query).fetchall()
+        
+            self.assertEqual(ex.exception.orig.args, ('encoding error in column "value_bytes"\n',))
+
+            # Insert and select new data using the same connection to be sure
+            # it doesn't close or get out of sync
+            data = {
+                'id': get_random_id(),
+                'value_bytes': random_bytes(),
+            }
+            conn.execute(self.encryptor_table.insert(), data)
+
+            query = sa \
+                .select([self.encryptor_table]) \
+                .where(self.encryptor_table.c.id == data['id'])
+            row = conn.execute(query).fetchone()
+            self.assertEqual(data['value_bytes'], row['value_bytes'])
+
+    def testTransactionRollback(self):
+        """
+        Test that connection is not closed in case of "encoding error" and
+        sqlaclchemy can do rollback in transaction after that.
+        """
+
+        self.encryptor_table.create(bind=self.engine_raw, checkfirst=True)
+        # Insert data that will trigger decryption error
+        corrupted_data = {
+            'id': get_random_id(),
+            'value_bytes': random_bytes(),
+        }
+        self.engine_raw.execute(self.encryptor_table.insert(), corrupted_data)
+        data = {
+            'id': get_random_id(),
+            'value_bytes': random_bytes(),
+        }
+        select_data = sa \
+            .select([self.encryptor_table]) \
+            .where(self.encryptor_table.c.id == data['id'])
+
+        with self.assertRaises(sa.exc.DatabaseError) as ex:
+            with self.engine1.begin() as conn:
+                conn.execute(self.encryptor_table.insert(), data)
+
+                row = conn.execute(select_data).fetchone()
+                self.assertEqual(data['value_bytes'], row['value_bytes'])
+
+                # Expect "encoding error"
+                ids = (data['id'], corrupted_data['id'])
+                query = sa \
+                    .select([self.encryptor_table]) \
+                    .where(self.encryptor_table.c.id.in_(ids))
+
+                conn.execute(query).fetchall()
+
+        self.assertEqual(ex.exception.orig.args, ('encoding error in column "value_bytes"\n',))
+        row = self.engine1.execute(select_data).fetchone()
+        self.assertEqual(row, None)
 
 if __name__ == '__main__':
     import xmlrunner

--- a/tests/test.py
+++ b/tests/test.py
@@ -9956,7 +9956,7 @@ class TestPostgresqlDbFlushingOnError(BaseTransparentEncryption):
             row = await conn.fetchrow(select_query, data['id'])
             self.assertEqual(data['value_bytes'], row['value_bytes'])
 
-        loop = asyncio.get_event_loop()
+        loop = asyncio.new_event_loop()
         loop.run_until_complete(test())
 
     def testTransactionPreparedRollback(self):
@@ -10008,7 +10008,7 @@ class TestPostgresqlDbFlushingOnError(BaseTransparentEncryption):
             row = await conn.fetchrow(select_query, data['id'])
             self.assertEqual(row, None)
 
-        loop = asyncio.get_event_loop()
+        loop = asyncio.new_event_loop()
         loop.run_until_complete(test())
 
     def testPreparedCursor(self):
@@ -10074,7 +10074,7 @@ class TestPostgresqlDbFlushingOnError(BaseTransparentEncryption):
             row = await conn.fetchrow(select_query, data['id'])
             self.assertEqual(row, None)
 
-        loop = asyncio.get_event_loop()
+        loop = asyncio.new_event_loop()
         loop.run_until_complete(test())
 
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -9942,11 +9942,9 @@ class TestPostgresqlDbFlushingOnError(BaseTransparentEncryption):
 
             stmt = await conn.prepare(select_two_query)
 
-            with self.assertRaises(asyncpg.exceptions.SyntaxOrAccessError) as ex:
+            with self.assertRaisesRegex(asyncpg.exceptions.SyntaxOrAccessError,
+                                        'encoding error in column "value_bytes"'):
                 await stmt.fetch(corrupted_data['id'], data['id'])
-
-            self.assertEqual(ex.exception.message,
-                             'encoding error in column "value_bytes"')
 
             # Insert and select new data using the same connection to be sure
             # it doesn't close or get out of sync
@@ -9993,7 +9991,8 @@ class TestPostgresqlDbFlushingOnError(BaseTransparentEncryption):
                 WHERE id = $1
             """
 
-            with self.assertRaises(asyncpg.exceptions.SyntaxOrAccessError) as ex:
+            with self.assertRaisesRegex(asyncpg.exceptions.SyntaxOrAccessError,
+                                        'encoding error in column "value_bytes"'):
                 async with conn.transaction():
                     await conn.execute(insert_query, data['id'], data['value_bytes'])
 
@@ -10004,8 +10003,6 @@ class TestPostgresqlDbFlushingOnError(BaseTransparentEncryption):
                     # Expect encoding error
                     await stmt.fetch(corrupted_data['id'])
 
-            self.assertEqual(ex.exception.message,
-                             'encoding error in column "value_bytes"')
             # Most db-drivers do a rollback after an exception, so check
             # that our data is not saved due to the rollback.
             row = await conn.fetchrow(select_query, data['id'])
@@ -10046,7 +10043,8 @@ class TestPostgresqlDbFlushingOnError(BaseTransparentEncryption):
                 WHERE id = $1
             """
 
-            with self.assertRaises(asyncpg.exceptions.SyntaxOrAccessError) as ex:
+            with self.assertRaisesRegex(asyncpg.exceptions.SyntaxOrAccessError,
+                                        'encoding error in column "value_bytes"'):
                 async with conn.transaction():
                     await conn.execute(insert_query, data['id'], data['value_bytes'])
                     row = await conn.fetchrow(select_query, data['id'])
@@ -10073,8 +10071,6 @@ class TestPostgresqlDbFlushingOnError(BaseTransparentEncryption):
                         if len(rows) == 0:
                             break
 
-            self.assertEqual(ex.exception.message,
-                             'encoding error in column "value_bytes"')
             row = await conn.fetchrow(select_query, data['id'])
             self.assertEqual(row, None)
 


### PR DESCRIPTION
This PR implement skipping postgres packets from database after encoding error, almost in the same way as the previous PR does for mysql. It also adds a bunch of tests for different cases:
- Simple queries
- Extended queries (and prepared statements, that are basically the same under the hood).
- Batched extended queries (when database sends `n` packets and waits for the next request)

The only issue with postgres is that a state of transaction is stored at database side, and changes in case of some errors (even parsing ones). When the state is changed, `commit` is basically `rollback`:
```
test=# begin;
BEGIN
test=*# select 1/0;
ERROR:  division by zero
test=!# commit;
ROLLBACK
```

But our error will not trigger that:
```
test=# begin;
BEGIN
test=*# select value_bytes from testtype;
ERROR:  encoding error in column "value_bytes"
test=# commit;
COMMIT
```
So, for now I will mention it in the docs. Currently there is no straight and simple solution.

P.S. `test.py` crossed the milestone of 10 thousands lines, so my congratulations! It takes 5 second for my formatter to proceed the file. That's what I call success. 

## Checklist

- [x] Change is covered by automated tests
- [x] The [coding guidelines] are followed
- [x] Public API has proper documentation in the [Acra documentation] site or has PR on [documentation repository] 
  with new changes
- [x] ~CHANGELOG.md is updated (in case of notable or breaking changes)~
- [x] ~CHANGELOG_DEV.md is updated~
- [x] ~Benchmark results are attached (if applicable)~
- [x] ~[Example projects and code samples] are up-to-date (in case of API changes)~

[coding guidelines]: https://golang.org/doc/effective_go
[Example projects and code samples]: https://github.com/cossacklabs/acra-engineering-demo
[Acra documentation]: https://docs.cossacklabs.com/
[documentation repository]: https://github.com/cossacklabs/product-docs