### PR TITLE
Fix multiple prepared stmt registraion

### DIFF
--- a/CHANGELOG_DEV.md
+++ b/CHANGELOG_DEV.md
@@ -1,3 +1,6 @@
+# 0.93.0 - 2022-05-17
+- Don't register prepared statements twice.
+
 # 0.93.0 - 2022-05-13
 - Don't abort connection of postgres after encoding error.
 

--- a/decryptor/postgresql/pg_decryptor_test.go
+++ b/decryptor/postgresql/pg_decryptor_test.go
@@ -431,12 +431,20 @@ const nullLen = 1
 
 func writeParsePacket(w io.Writer, name string, stmt string) error {
 	packet := ParsePacket{
-		name:      []byte(name),
-		query:     []byte(stmt),
+		name:      append([]byte(name), 0x00),
+		query:     append([]byte(stmt), 0x00),
 		paramsNum: []byte{0x00, 0x00},
 		params:    []objectID{},
 	}
-	_, err := w.Write(packet.Marshal())
+	serialized := packet.Marshal()
+	length := len(serialized) + 4
+	if _, err := w.Write([]byte{'P'}); err != nil {
+		return err
+	}
+	if err := writeUint32(w, uint32(length)); err != nil {
+		return err
+	}
+	_, err := w.Write(serialized)
 	return err
 }
 

--- a/decryptor/postgresql/pg_decryptor_test.go
+++ b/decryptor/postgresql/pg_decryptor_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"encoding/binary"
 	"encoding/hex"
 	"io"
 	"net"
@@ -178,4 +179,250 @@ func TestPreparedStatementRegistering(t *testing.T) {
 	if queryObserver.bind != sqlparser.String(parseQueryStatement) {
 		t.Fatalf("'%s' != '%s'\n", parseQuery, statement.QueryText())
 	}
+}
+
+func TestMultiplePrepareAtOnce(t *testing.T) {
+	logger := logrus.NewEntry(logrus.New())
+	parser := sqlparser.New(sqlparser.ModeDefault)
+	ctx := context.Background()
+
+	beginSQL := "BEGIN"
+	beginName := "__cossack_begin__"
+
+	selectSQL := "SELECT 1"
+	selectName := "__cossack_select__"
+
+	// Build two "parse" packets to simulate delivery of them at once
+	clientBuffer := bytes.NewBuffer([]byte{})
+	clientWriter := bufio.NewWriter(clientBuffer)
+	if err := writePrepare(clientWriter, beginName, beginSQL); err != nil {
+		t.Fatal(err)
+	}
+	if err := writePrepare(clientWriter, selectName, selectSQL); err != nil {
+		t.Fatal(err)
+	}
+	if err := clientWriter.Flush(); err != nil {
+		t.Fatal(err)
+	}
+	clientPacketHandler, err := NewClientSidePacketHandler(clientBuffer, nil, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	clientPacketHandler.started = true
+
+	// two responses one by one
+	dbBuffer := bytes.NewBuffer([]byte{})
+	dbWriter := bufio.NewWriter(dbBuffer)
+	if err := writeZeroPrepareResponse(dbWriter); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeZeroPrepareResponse(dbWriter); err != nil {
+		t.Fatal(err)
+	}
+	if err := dbWriter.Flush(); err != nil {
+		t.Fatal(err)
+	}
+	dbPacketHandler, err := NewDbSidePacketHandler(dbBuffer, nil, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	connectionSession, err := common.NewClientSession(ctx, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	proxySetting := base.NewProxySetting(parser, nil, nil, nil, acracensor.NewAcraCensor(), nil, false)
+	proxy, err := NewPgProxy(connectionSession, parser, proxySetting)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Client packets are handled first, before responses arrive
+	for {
+		err := clientPacketHandler.ReadClientPacket()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = proxy.handleClientPacket(ctx, clientPacketHandler, logger)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Then we handle responses
+	for {
+		err := dbPacketHandler.ReadPacket()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = proxy.handleDatabasePacket(ctx, dbPacketHandler, logger)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	registry := proxy.session.PreparedStatementRegistry()
+	beginStmt, err := registry.StatementByName(beginName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	selectStmt, err := registry.StatementByName(selectName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if beginSQL != beginStmt.QueryText() {
+		t.Fatalf("%q != %q\n", beginSQL, beginStmt.QueryText())
+	}
+
+	if selectSQL != selectStmt.QueryText() {
+		t.Fatalf("%q != %q\n", selectSQL, selectStmt.QueryText())
+	}
+}
+
+//
+// Utils for crafting the packets
+//
+
+func writeUint32(w io.Writer, val uint32) error {
+	int32Buff := [4]byte{}
+	binary.BigEndian.PutUint32(int32Buff[:], val)
+	_, err := w.Write(int32Buff[:])
+	return err
+}
+
+func writeUint16(w io.Writer, val uint16) error {
+	int16Buff := [2]byte{}
+	binary.BigEndian.PutUint16(int16Buff[:], val)
+	_, err := w.Write(int16Buff[:])
+	return err
+}
+
+func writeNullString(w io.Writer, str string) error {
+	if _, err := w.Write([]byte(str)); err != nil {
+		return err
+	}
+
+	_, err := w.Write([]byte{0x00})
+	return err
+}
+
+const sizeLen = 4
+const nullLen = 1
+
+func writeParsePacket(w io.Writer, name string, stmt string) error {
+	const paramsLen = 2
+
+	_, err := w.Write([]byte{'P'})
+	if err != nil {
+		return err
+	}
+
+	size := sizeLen + len(name) + nullLen + len(stmt) + nullLen + paramsLen
+	err = writeUint32(w, uint32(size))
+	if err != nil {
+		return err
+	}
+
+	err = writeNullString(w, name)
+	if err != nil {
+		return err
+	}
+
+	err = writeNullString(w, stmt)
+	if err != nil {
+		return err
+	}
+
+	err = writeUint16(w, uint16(size))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func writeDescribePacket(w io.Writer, name string) error {
+	describeType := []byte{'S'}
+
+	_, err := w.Write([]byte{'D'})
+	if err != nil {
+		return err
+	}
+	size := sizeLen + len(describeType) + len(name) + nullLen
+	err = writeUint32(w, uint32(size))
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(describeType)
+	if err != nil {
+		return err
+	}
+	return writeNullString(w, name)
+}
+
+func writeSyncPacket(w io.Writer) error {
+	_, err := w.Write([]byte{
+		'S',                    // tag
+		0x00, 0x00, 0x00, 0x04, // length
+	})
+	return err
+}
+
+// writePrepare writes sequence of Prepare packets into w:
+// - Parse
+// - Describe
+// - Sync
+func writePrepare(w io.Writer, name string, stmt string) error {
+	if err := writeParsePacket(w, name, stmt); err != nil {
+		return err
+	}
+	if err := writeDescribePacket(w, name); err != nil {
+		return err
+	}
+	return writeSyncPacket(w)
+}
+
+func writeParseComplete(w io.Writer) error {
+	_, err := w.Write([]byte{
+		'1',                    // tag
+		0x00, 0x00, 0x00, 0x04, // length
+	})
+	return err
+}
+
+func writeZeroParamDescription(w io.Writer) error {
+	_, err := w.Write([]byte{
+		't',                    // tag
+		0x00, 0x00, 0x00, 0x06, // length
+		0x00, 0x00, // number of params
+	})
+	return err
+}
+
+func writeZeroRowDescription(w io.Writer) error {
+	_, err := w.Write([]byte{
+		'n',                    // tag
+		0x00, 0x00, 0x00, 0x04, // length
+	})
+	return err
+}
+
+// writeZeroPrepareResponse writes response for parse-sequence:
+// Parse complete
+// Parameter description (with 0 params)
+// Row description (with 0 params)
+func writeZeroPrepareResponse(w io.Writer) error {
+	if err := writeParseComplete(w); err != nil {
+		return err
+	}
+	if err := writeZeroParamDescription(w); err != nil {
+		return err
+	}
+	return writeZeroRowDescription(w)
 }

--- a/decryptor/postgresql/pg_decryptor_test.go
+++ b/decryptor/postgresql/pg_decryptor_test.go
@@ -417,13 +417,6 @@ func writeUint32(w io.Writer, val uint32) error {
 	return err
 }
 
-func writeUint16(w io.Writer, val uint16) error {
-	int16Buff := [2]byte{}
-	binary.BigEndian.PutUint16(int16Buff[:], val)
-	_, err := w.Write(int16Buff[:])
-	return err
-}
-
 func writeNullString(w io.Writer, str string) error {
 	if _, err := w.Write([]byte(str)); err != nil {
 		return err
@@ -437,34 +430,14 @@ const sizeLen = 4
 const nullLen = 1
 
 func writeParsePacket(w io.Writer, name string, stmt string) error {
-	const paramsLen = 2
-
-	_, err := w.Write([]byte{'P'})
-	if err != nil {
-		return err
+	packet := ParsePacket{
+		name:      []byte(name),
+		query:     []byte(stmt),
+		paramsNum: []byte{0x00, 0x00},
+		params:    []objectID{},
 	}
-
-	size := sizeLen + len(name) + nullLen + len(stmt) + nullLen + paramsLen
-	err = writeUint32(w, uint32(size))
-	if err != nil {
-		return err
-	}
-
-	err = writeNullString(w, name)
-	if err != nil {
-		return err
-	}
-
-	err = writeNullString(w, stmt)
-	if err != nil {
-		return err
-	}
-
-	err = writeUint16(w, uint16(size))
-	if err != nil {
-		return err
-	}
-	return nil
+	_, err := w.Write(packet.Marshal())
+	return err
 }
 
 func writeDescribePacket(w io.Writer, name string) error {


### PR DESCRIPTION
This PR solves double registration of prepared statements. They are registered twice: after `Parse` and `ParseComplete`, but because of a race condition, the pending statement can be replaced by another. Then, this triggers registration of a `nil` value as a statement.

To solve the problem, this PR removes the second registration.

There is one issue though: prepared statements are never cleaned, even ones that contain errors. This requires a large redesigning of the whole packet processing protocol. So, for now, we have a small _memory leakage_ in a connection. But on practice this should not be an issue.

## Checklist

- [x] Change is covered by automated tests
- [x] The [coding guidelines] are followed
- [x] ~Public API has proper documentation in the [Acra documentation] site or has PR on [documentation repository] 
  with new changes~
- [x] ~CHANGELOG.md is updated (in case of notable or breaking changes)~
- [x] CHANGELOG_DEV.md is updated
- [x] ~Benchmark results are attached (if applicable)~
- [x] ~[Example projects and code samples] are up-to-date (in case of API changes)~

[coding guidelines]: https://golang.org/doc/effective_go
[Example projects and code samples]: https://github.com/cossacklabs/acra-engineering-demo
[Acra documentation]: https://docs.cossacklabs.com/
[documentation repository]: https://github.com/cossacklabs/product-docs