### PR TITLE
Remove placeholders from connection when done

### DIFF
--- a/CHANGELOG_DEV.md
+++ b/CHANGELOG_DEV.md
@@ -1,3 +1,6 @@
+# 0.93.0 - 2022-05-18
+- Reset placeholders in a connection state after `ReadyForQuery` packet.
+
 # 0.93.0 - 2022-05-13
 - Don't abort connection of postgres after encoding error.
 

--- a/decryptor/postgresql/pg_decryptor.go
+++ b/decryptor/postgresql/pg_decryptor.go
@@ -722,6 +722,11 @@ func (proxy *PgProxy) handleDatabasePacket(ctx context.Context, packet *PacketHa
 	case ParameterDescriptionPacket:
 		return proxy.handleParameterDescription(ctx, packet, logger)
 
+	case ReadyForQueryPacket:
+		logger.Debugln("ReadyForQueryPacket")
+		encryptor.DeletePlaceholderSettingsFromClientSession(proxy.session)
+		return nil
+
 	default:
 		// Forward all other uninteresting packets to the client without processing.
 		return nil

--- a/decryptor/postgresql/pg_decryptor.go
+++ b/decryptor/postgresql/pg_decryptor.go
@@ -685,6 +685,12 @@ func (proxy *PgProxy) ProxyDatabaseConnection(ctx context.Context, errCh chan<- 
 			last := packetHandler.IsReadyForQuery()
 			if last {
 				state = stateServe
+				// Process the ReadyForQuery packet to reset the state of the
+				// protocol and do necessary cleanup
+				if err := proxy.handleDatabasePacket(packetCtx, packetHandler, logger); err != nil {
+					errCh <- base.NewDBProxyError(err)
+					return
+				}
 			}
 			logger.WithField("last", last).Debugln("Skipping the packet")
 		}

--- a/decryptor/postgresql/pg_decryptor.go
+++ b/decryptor/postgresql/pg_decryptor.go
@@ -39,9 +39,9 @@ import (
 	"go.opencensus.io/trace"
 )
 
-// ReadyForQueryPacket - 'Z' ReadyForQuery, 0 0 0 5 length, 'I' idle status
+// ReadyForQuery - 'Z' ReadyForQuery, 0 0 0 5 length, 'I' idle status
 // https://www.postgresql.org/docs/9.3/static/protocol-message-formats.html
-var ReadyForQueryPacket = []byte{'Z', 0, 0, 0, 5, 'I'}
+var ReadyForQuery = []byte{'Z', 0, 0, 0, 5, 'I'}
 
 // TerminatePacket sent by client to close connection with db
 // https://www.postgresql.org/docs/9.4/static/protocol-message-formats.html
@@ -416,8 +416,8 @@ func (proxy *PgProxy) sendClientError(msg string, logger *log.Entry) error {
 	if err := base.CheckReadWrite(n, len(errorMessage), err); err != nil {
 		return err
 	}
-	n, err = proxy.clientConnection.Write(ReadyForQueryPacket)
-	if err := base.CheckReadWrite(n, len(ReadyForQueryPacket), err); err != nil {
+	n, err = proxy.clientConnection.Write(ReadyForQuery)
+	if err := base.CheckReadWrite(n, len(ReadyForQuery), err); err != nil {
 		return err
 	}
 	return nil

--- a/decryptor/postgresql/protocol.go
+++ b/decryptor/postgresql/protocol.go
@@ -49,6 +49,7 @@ const (
 	DataPacket
 	RowDescriptionPacket
 	ParameterDescriptionPacket
+	ReadyForQueryPacket
 	OtherPacket
 )
 
@@ -202,7 +203,7 @@ func (p *PgProtocolState) HandleDatabasePacket(packet *PacketHandler) error {
 		// so here we only set it to `nil`
 		p.pendingBind = nil
 
-		p.lastPacketType = OtherPacket
+		p.lastPacketType = ReadyForQueryPacket
 		return nil
 	}
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -9927,11 +9927,10 @@ class TestPostgresqlDbFlushingOnError(BaseTransparentEncryption):
                 WHERE id = $1
             """
 
-            # TODO(G1gg1L3s): uncomment when T2572 is fixed
-            # await conn.execute(insert_query, data['id'], data['value_bytes'])
-            #
-            # row = await conn.fetchrow(select_query, data['id'])
-            # self.assertEqual(data['value_bytes'], row['value_bytes'])
+            await conn.execute(insert_query, data['id'], data['value_bytes'])
+            
+            row = await conn.fetchrow(select_query, data['id'])
+            self.assertEqual(data['value_bytes'], row['value_bytes'])
 
             # Expect "encoding error"
             select_two_query = """


### PR DESCRIPTION
This PR solves interference problem of placeholders. They are saved in the connection, but were never removed, only replaced. That means, they could affect other queries on the same connection.

Solve this, by removing the placeholders at the end of the query: when `ReadyForQuery` arrives. 

I didn't write a new test for this, because 1) it already existed as a part of another test and 2) it's really hard to reproduce.
 
## Checklist

- [x] Change is covered by automated tests
- [x] The [coding guidelines] are followed
- [x] ~Public API has proper documentation in the [Acra documentation] site or has PR on [documentation repository] 
  with new changes~
- [x] ~CHANGELOG.md is updated (in case of notable or breaking changes)~
- [x] CHANGELOG_DEV.md is updated
- [x] ~Benchmark results are attached (if applicable)~
- [x] ~[Example projects and code samples] are up-to-date (in case of API changes)~

[coding guidelines]: https://golang.org/doc/effective_go
[Example projects and code samples]: https://github.com/cossacklabs/acra-engineering-demo
[Acra documentation]: https://docs.cossacklabs.com/
[documentation repository]: https://github.com/cossacklabs/product-docs