### PR TITLE
Substitute oid in parse

### DIFF
--- a/CHANGELOG_DEV.md
+++ b/CHANGELOG_DEV.md
@@ -1,3 +1,6 @@
+# 0.93.0 - 202-05-19
+- Replace OID in Parse packets, if they are specified.
+
 # 0.93.0 - 2022-05-18
 - Reset placeholders in a connection state after `ReadyForQuery` packet.
 

--- a/decryptor/postgresql/packet_handler.go
+++ b/decryptor/postgresql/packet_handler.go
@@ -322,6 +322,17 @@ func (packet *PacketHandler) GetParseData() (*ParsePacket, error) {
 	return parse, nil
 }
 
+// SetParsePacket replace ParsePacket
+// Use this only if IsParse() is true.
+func (packet *PacketHandler) SetParsePacket(parsePacket *ParsePacket) error {
+	packet.logger.Debugln("SetParseData")
+	newParse := parsePacket.Marshal()
+	packet.descriptionBuf.Reset()
+	packet.descriptionBuf.Write(newParse)
+	packet.updatePacketLength(len(newParse))
+	return nil
+}
+
 // GetBindData returns parsed Bind packet data.
 // Use this only if IsBind() is true.
 func (packet *PacketHandler) GetBindData() (*BindPacket, error) {

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,6 @@
 pythemis
 psycopg2==2.8.6
+psycopg==3.0.13
 asyncpg==0.23.0
 SQLAlchemy==1.4.15
 PyMySQL==1.0.2

--- a/tests/test.py
+++ b/tests/test.py
@@ -10135,7 +10135,7 @@ class Psycopg3ExecutorMixin:
         self.executor2 = executor(
             TEST_TLS_CLIENT_2_KEY, TEST_TLS_CLIENT_2_CERT)
         self.raw_executor = executor(
-            TEST_TLS_CLIENT_KEY, TEST_TLS_CLIENT_CERT, TEST_DB_PORT)
+            TEST_TLS_CLIENT_KEY, TEST_TLS_CLIENT_CERT, DB_PORT)
 
 
 class TestPostgresqlTypeAwareDecryptionWithDefaultsPsycopg3(Psycopg3ExecutorMixin,

--- a/tests/test.py
+++ b/tests/test.py
@@ -10135,7 +10135,7 @@ class Psycopg3ExecutorMixin:
         self.executor2 = executor(
             TEST_TLS_CLIENT_2_KEY, TEST_TLS_CLIENT_2_CERT)
         self.raw_executor = executor(
-            TEST_TLS_CLIENT_KEY, TEST_TLS_CLIENT_CERT, 5432)
+            TEST_TLS_CLIENT_KEY, TEST_TLS_CLIENT_CERT, TEST_DB_PORT)
 
 
 class TestPostgresqlTypeAwareDecryptionWithDefaultsPsycopg3(Psycopg3ExecutorMixin,


### PR DESCRIPTION
This PR fixes substitution of OID in packets. Before, it substituted them in the data messages, which are returned by select. But there is another place where they can arrive - in parse packets. We missed it, because they are optional and most frontends do not specify them.

To test it, I've added a new dependency to our python tests - psycopg3. The first stable version was released on [2021-10-13](https://www.psycopg.org/articles/2021/10/13/psycopg-30-released/), but I think we can start to use it because of its support of various features. For example in this case, this frontend sets the type of parameters in the parse packets. Also it helped to discover bug with encoding of i32, so in some cases tests could fall. I will fix it as soon as possible.

## Checklist

- [x] Change is covered by automated tests
- [x] The [coding guidelines] are followed
- [x] ~Public API has proper documentation in the [Acra documentation] site or has PR on [documentation repository] 
  with new changes~
- [x] ~CHANGELOG.md is updated (in case of notable or breaking changes)~
- [x] CHANGELOG_DEV.md is updated
- [x] ~Benchmark results are attached (if applicable)~
- [x] ~[Example projects and code samples] are up-to-date (in case of API changes)~

[coding guidelines]: https://golang.org/doc/effective_go
[Example projects and code samples]: https://github.com/cossacklabs/acra-engineering-demo
[Acra documentation]: https://docs.cossacklabs.com/
[documentation repository]: https://github.com/cossacklabs/product-docs
