### PR TITLE
[T2580] Fix handling null values in mysql

### DIFF
--- a/CHANGELOG_DEV.md
+++ b/CHANGELOG_DEV.md
@@ -1,3 +1,6 @@
+# 0.93.0 - 2022-05-23
+- Handle properly null values in MySQL
+
 # 0.93.0 - 2022-05-18
 - Reset placeholders in a connection state after `ReadyForQuery` packet.
 

--- a/crypto/envelope_detector.go
+++ b/crypto/envelope_detector.go
@@ -196,6 +196,9 @@ func (wrapper *OldContainerDetectorWrapper) OnCryptoEnvelope(ctx context.Context
 
 // OnColumn callback which finds serializedContainer or AcraStruct/AcraBlock for backward compatibility
 func (wrapper *OldContainerDetectorWrapper) OnColumn(ctx context.Context, inBuffer []byte) (context.Context, []byte, error) {
+	if inBuffer == nil {
+		return ctx, inBuffer, nil
+	}
 	// we should track that if incoming data contains any signs of new container and if it is we return data as is
 	// otherwise try to search for AcraBlock or AcraStruct to save backward compatibility
 	// so before any OnColumn we should reset hasMatchedEnvelope flag to track if its changed during EnvelopeDetector OnColumn via BackWrapper.OnCryptoEnvelope callback

--- a/decryptor/mysql/response_proxy.go
+++ b/decryptor/mysql/response_proxy.go
@@ -513,8 +513,14 @@ func (handler *Handler) processTextDataRow(ctx context.Context, rowData []byte, 
 		if err != nil {
 			return nil, err
 		}
-
-		decrCtx, value, err := handler.onColumnDecryption(ctx, i, value, false, fields[i])
+		var decrCtx context.Context
+		// skip processing if value is NULL/nil
+		if value == nil {
+			output = append(output, rowData[pos:pos+n]...)
+			pos += n
+			continue
+		}
+		decrCtx, value, err = handler.onColumnDecryption(ctx, i, value, false, fields[i])
 		if err != nil {
 			fieldLogger.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorGeneral).
 				WithError(err).Errorln("Failed to process column data")

--- a/tests/test.py
+++ b/tests/test.py
@@ -5654,13 +5654,8 @@ class TestEmptyValues(BaseTestCase):
         # check null values
         result = self.engine1.execute(sa.select([self.temp_table]).where(self.temp_table.c.id == null_value_id))
         row = result.fetchone()
-        if TEST_MYSQL:
-            # PyMySQL returns empty strings for NULL values
-            self.assertEqual(row['text'], '')
-            self.assertEqual(row['binary'], b'')
-        else:
-            self.assertIsNone(row['text'])
-            self.assertIsNone(row['binary'])
+        self.assertIsNone(row['text'])
+        self.assertIsNone(row['binary'])
 
         # check empty values
         result = self.engine1.execute(sa.select([self.temp_table]).where(self.temp_table.c.id == empty_value_id))
@@ -8667,7 +8662,7 @@ class TestMySQLTextFormatTypeAwareDecryptionWithDefaults(BaseBinaryMySQLTestCase
 
         # mysql.connector represent null value as empty string
         for column in null_columns:
-            self.assertEqual(row[column], '')
+            self.assertIsNone(row[column])
 
         row = self.executor2.execute(query)[0]
         for column in columns:
@@ -8675,7 +8670,7 @@ class TestMySQLTextFormatTypeAwareDecryptionWithDefaults(BaseBinaryMySQLTestCase
             self.assertIsInstance(row[column], type(default_expected_values[column]))
 
         for column in null_columns:
-            self.assertEqual(row[column], '')
+            self.assertIsNone(row[column])
 
         row = self.engine_raw.execute(sa.select([self.test_table])
                 .where(self.test_table.c.id == data['id'])).fetchone()
@@ -8973,7 +8968,7 @@ class TestMySQLTextTypeAwareDecryptionWithoutDefaults(BaseBinaryMySQLTestCase, B
 
         # mysql.connector represent null value as empty string
         for column in null_columns:
-            self.assertEqual(row[column], '')
+            self.assertIsNone(row[column])
 
         # field types should be rollbacked in case of invalid encoding
         row = self.executor2.execute(query)[0]
@@ -9511,7 +9506,7 @@ class TestMySQLTextTypeAwareDecryptionWithСiphertext(BaseBinaryMySQLTestCase, B
 
         # mysql.connector represent null value as empty string
         for column in null_columns:
-            self.assertEqual(row[column], '')
+            self.assertIsNone(row[column])
 
         # field types should be rollbacked in case of invalid encoding
         row = self.executor2.execute(query)[0]
@@ -9663,7 +9658,7 @@ class TestMySQLTextTypeAwareDecryptionWithError(BaseBinaryMySQLTestCase, BaseTra
 
         # mysql.connector represent null value as empty string
         for column in null_columns:
-            self.assertEqual(row[column], '')
+            self.assertIsNone(row[column])
 
         # we expect an exception because of decryption error
         with self.assertRaises(mysql.connector.errors.DatabaseError) as ex:

--- a/tests/test.py
+++ b/tests/test.py
@@ -8642,12 +8642,14 @@ class TestMySQLTextFormatTypeAwareDecryptionWithDefaults(BaseBinaryMySQLTestCase
             'value_int64': 64,
             'value_bytes': b'value_bytes',
             'value_str': 'value_str',
-            'value_empty_str': ''
+            'value_empty_str': '',
+            'value_null_str': None,
+            'value_null_int32': None,
         }
 
         self.schema_table.create(bind=self.engine_raw, checkfirst=True)
-        columns = ('value_bytes', 'value_int32', 'value_int64', 'value_empty_str', 'value_str')
-        null_columns = ('value_null_str', 'value_null_int32')
+        columns = ('value_bytes', 'value_int32', 'value_int64', 'value_empty_str', 'value_str', 'value_null_str',
+                   'value_null_int32')
 
         self.engine1.execute(self.test_table.insert(), data)
 
@@ -8660,17 +8662,11 @@ class TestMySQLTextFormatTypeAwareDecryptionWithDefaults(BaseBinaryMySQLTestCase
             self.assertEqual(data[column], row[column])
             self.assertIsInstance(row[column], type(data[column]))
 
-        # mysql.connector represent null value as empty string
-        for column in null_columns:
-            self.assertIsNone(row[column])
 
         row = self.executor2.execute(query)[0]
         for column in columns:
             self.assertEqual(row[column], default_expected_values[column])
             self.assertIsInstance(row[column], type(default_expected_values[column]))
-
-        for column in null_columns:
-            self.assertIsNone(row[column])
 
         row = self.engine_raw.execute(sa.select([self.test_table])
                 .where(self.test_table.c.id == data['id'])).fetchone()
@@ -8954,8 +8950,8 @@ class TestMySQLTextTypeAwareDecryptionWithoutDefaults(BaseBinaryMySQLTestCase, B
         }
         self.schema_table.create(bind=self.engine_raw, checkfirst=True)
         self.engine1.execute(self.test_table.insert(), data)
-        columns = ('value_str', 'value_bytes', 'value_int32', 'value_int64', 'value_empty_str')
-        null_columns = ('value_null_str', 'value_null_int32')
+        columns = ('value_str', 'value_bytes', 'value_int32', 'value_int64', 'value_empty_str', 'value_null_str',
+                   'value_null_int32')
 
         compile_kwargs = {"literal_binds": True}
         query = sa.select([self.test_table]).where(self.test_table.c.id == data['id'])
@@ -8965,10 +8961,6 @@ class TestMySQLTextTypeAwareDecryptionWithoutDefaults(BaseBinaryMySQLTestCase, B
         for column in columns:
             self.assertEqual(data[column], row[column])
             self.assertIsInstance(row[column], type(data[column]))
-
-        # mysql.connector represent null value as empty string
-        for column in null_columns:
-            self.assertIsNone(row[column])
 
         # field types should be rollbacked in case of invalid encoding
         row = self.executor2.execute(query)[0]
@@ -9492,8 +9484,8 @@ class TestMySQLTextTypeAwareDecryptionWithСiphertext(BaseBinaryMySQLTestCase, B
         }
         self.schema_table.create(bind=self.engine_raw, checkfirst=True)
         self.engine1.execute(self.test_table.insert(), data)
-        columns = ('value_str', 'value_bytes', 'value_int32', 'value_int64', 'value_empty_str')
-        null_columns = ('value_null_str', 'value_null_int32')
+        columns = ('value_str', 'value_bytes', 'value_int32', 'value_int64', 'value_empty_str', 'value_null_str',
+                   'value_null_int32')
 
         compile_kwargs = {"literal_binds": True}
         query = sa.select([self.test_table]).where(self.test_table.c.id == data['id'])
@@ -9503,10 +9495,6 @@ class TestMySQLTextTypeAwareDecryptionWithСiphertext(BaseBinaryMySQLTestCase, B
         for column in columns:
             self.assertEqual(data[column], row[column])
             self.assertIsInstance(row[column], type(data[column]))
-
-        # mysql.connector represent null value as empty string
-        for column in null_columns:
-            self.assertIsNone(row[column])
 
         # field types should be rollbacked in case of invalid encoding
         row = self.executor2.execute(query)[0]
@@ -9644,8 +9632,8 @@ class TestMySQLTextTypeAwareDecryptionWithError(BaseBinaryMySQLTestCase, BaseTra
         }
         self.schema_table.create(bind=self.engine_raw, checkfirst=True)
         self.engine1.execute(self.test_table.insert(), data)
-        columns = ('value_str', 'value_bytes', 'value_int32', 'value_int64', 'value_empty_str')
-        null_columns = ('value_null_str', 'value_null_int32')
+        columns = ('value_str', 'value_bytes', 'value_int32', 'value_int64', 'value_empty_str', 'value_null_str',
+                   'value_null_int32')
 
         compile_kwargs = {"literal_binds": True}
         query = sa.select([self.test_table]).where(self.test_table.c.id == data['id'])
@@ -9655,10 +9643,6 @@ class TestMySQLTextTypeAwareDecryptionWithError(BaseBinaryMySQLTestCase, BaseTra
         for column in columns:
             self.assertEqual(data[column], row[column])
             self.assertIsInstance(row[column], type(data[column]))
-
-        # mysql.connector represent null value as empty string
-        for column in null_columns:
-            self.assertIsNone(row[column])
 
         # we expect an exception because of decryption error
         with self.assertRaises(mysql.connector.errors.DatabaseError) as ex:


### PR DESCRIPTION
On decryption our envelope_detector returned `[]byte{}` on `nil` values instead leaving `nil`. MySQL encoded differently empty strings and NULL values. [NULL values should](https://dev.mysql.com/doc/internals/en/com-query-response.html#packet-ProtocolText::ResultsetRow) have 0xfb value. So on Acra side when it receive null value as 0xfb then it changed to empty array and encode it as LengthEncoded [String](https://dev.mysql.com/doc/internals/en/string.html#packet-Protocol::LengthEncodedString) or Integer that are incorrect.

So in this PR removed processing null data in crypto envelope. If it will be empty array, it will be returned as empty array too.

## Checklist

- [+] Change is covered by automated tests
- [+] The [coding guidelines] are followed
- [+] Public API has proper documentation in the [Acra documentation] site or has PR on [documentation repository] 
  with new changes
- [+] CHANGELOG.md is updated (in case of notable or breaking changes)
- [+] CHANGELOG_DEV.md is updated
- [+] Benchmark results are attached (if applicable)
- [+] [Example projects and code samples] are up-to-date (in case of API changes) 

[coding guidelines]: https://golang.org/doc/effective_go
[Example projects and code samples]: https://github.com/cossacklabs/acra-engineering-demo
[Acra documentation]: https://docs.cossacklabs.com/
[documentation repository]: https://github.com/cossacklabs/product-docs