### PR TITLE
Handle binary char set introducer

### DIFF
--- a/CHANGELOG_DEV.md
+++ b/CHANGELOG_DEV.md
@@ -1,3 +1,6 @@
+# 0.93.0 - 2022-05-23
+- Add support for mysql `_binary` charset.
+
 # 0.93.0 - 2022-05-18
 - Reset placeholders in a connection state after `ReadyForQuery` packet.
 

--- a/encryptor/queryDataEncryptor.go
+++ b/encryptor/queryDataEncryptor.go
@@ -157,6 +157,10 @@ func UpdateExpressionValue(ctx context.Context, expr sqlparser.Expr, coder DBDat
 	switch val := expr.(type) {
 	case *sqlparser.UnaryExpr:
 		return UpdateUnaryExpressionValue(ctx, expr.(*sqlparser.UnaryExpr), coder, updateFunc)
+	// Update Parenthese expression like  `('AAAA')` just by processing inner
+	// expression 'AAAA'.
+	case *sqlparser.ParenExpr:
+		return UpdateExpressionValue(ctx, expr.(*sqlparser.ParenExpr).Expr, coder, updateFunc)
 	case *sqlparser.SQLVal:
 		switch val.Type {
 		case sqlparser.StrVal, sqlparser.HexVal, sqlparser.PgEscapeString, sqlparser.IntVal:

--- a/tests/test.py
+++ b/tests/test.py
@@ -9719,7 +9719,7 @@ class TestMySQLTextCharsetLiterals(TestMySQLTextTypeAwareDecryptionWithoutDefaul
     def testClientIDRead(self):
         """
         We don't directly support charset introducers[1], but at least make
-        sure it can handle _binary.
+        sure it can handle _binary in paretheses.
 
         [1]: https://dev.mysql.com/doc/refman/8.0/en/charset-introducer.html
         """
@@ -9748,6 +9748,41 @@ class TestMySQLTextCharsetLiterals(TestMySQLTextTypeAwareDecryptionWithoutDefaul
         self.assertEqual(row['value_bytes'], b'binary_string')
 
         # direct connection should receive binary data according to real scheme
+        result = self.engine_raw.execute(query)
+        row = result.fetchone()
+        self.assertNotEqual(row['value_bytes'], b'binary_string')
+
+    def testClientIDReadRawSql(self):
+        """
+        We don't directly support charset introducers[1], but at least make
+        sure it can handle _binary.
+
+        [1]: https://dev.mysql.com/doc/refman/8.0/en/charset-introducer.html
+        """
+
+        self.schema_table.create(bind=self.engine_raw, checkfirst=True)
+        id = get_random_id()
+        # DON'T EVER, EVER DO THIS
+        # Do not use direct string interpolation for sql values
+        # This is just a test example.
+        #
+        # Also, insert value_empty_str because it can't be null
+        insert = f"""
+            INSERT INTO {self.test_table.name}(id, value_bytes, value_empty_str)
+            VALUES ({id}, _binary 'binary_string', '')
+        """
+        self.engine1.execute(insert)
+
+        columns = [self.test_table.c.id, self.test_table.c.value_bytes]
+
+        query = sa.select(columns).where(self.test_table.c.id == id)
+        query = str(query.compile(compile_kwargs={"literal_binds": True}))
+
+        row = self.executor1.execute(query)[0]
+        self.assertEqual(row['id'], id)
+        self.assertEqual(row['value_bytes'], b'binary_string')
+
+        # direct connection should receive encrypted data
         result = self.engine_raw.execute(query)
         row = result.fetchone()
         self.assertNotEqual(row['value_bytes'], b'binary_string')


### PR DESCRIPTION
This small PR adds support of mysql _binary charset introducer, which is used at least by java frontend. I would like to add other charsets, but they are not supported by the parser yet. So, if there is no need, I wouldn't do that.

## Checklist

- [x] Change is covered by automated tests
- [x] The [coding guidelines] are followed
- [x] Public API has proper documentation in the [Acra documentation] site or has PR on [documentation repository] 
  with new changes
- [x] ~CHANGELOG.md is updated (in case of notable or breaking changes)~
- [x] CHANGELOG_DEV.md is updated
- [x] ~Benchmark results are attached (if applicable)~
- [x] ~[Example projects and code samples] are up-to-date (in case of API changes)~

[coding guidelines]: https://golang.org/doc/effective_go
[Example projects and code samples]: https://github.com/cossacklabs/acra-engineering-demo
[Acra documentation]: https://docs.cossacklabs.com/
[documentation repository]: https://github.com/cossacklabs/product-docs