### PR TITLE
Fix mockery version downgrade

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,7 +249,7 @@ install_dev_deps:
 	go install golang.org/x/tools/cmd/goyacc
 	go install github.com/swaggo/swag/cmd/swag@latest
 	go install github.com/tinylib/msgp@latest
-	go install github.com/vektra/mockery/v2@latest
+	go install github.com/vektra/mockery/v2@v2.12.3
 
 ##---- Docker ------------------------------------------------------------------
 

--- a/Makefile
+++ b/Makefile
@@ -245,6 +245,7 @@ keys: install
 	@scripts/generate-keys.sh
 
 ## Install development dependencies
+## TODO: upgrade mockery to latest when Acra will support minimal version 1.18
 install_dev_deps:
 	go install golang.org/x/tools/cmd/goyacc
 	go install github.com/swaggo/swag/cmd/swag@latest

--- a/docker/ci-py-go-themis.dockerfile
+++ b/docker/ci-py-go-themis.dockerfile
@@ -37,6 +37,8 @@ COPY go.mod /image.scripts/
 RUN chmod +x /image.scripts/*.sh
 
 # Install Go
+## TODO: upgrade mockery (Makefile:install_dev_deps) to latest when Acra will support minimal version 1.18
+
 RUN GO_VERSIONS='1.15.2 1.16.9 1.17.3' \
     GO_TARBALL_CLEAN=1 \
     /image.scripts/install_go.sh


### PR DESCRIPTION
Makefile contains installing the latest mockery version which requires go 1.18. Acra should support at least three latest versions. Just downgrade the mockery version to be able to build Acra with a version lower than 1.18.


<!-- Describe your changes here -->

## Checklist

- [ ] Change is covered by automated tests
- [ ] The [coding guidelines] are followed
- [ ] Public API has proper documentation in the [Acra documentation] site or has PR on [documentation repository] 
  with new changes
- [ ] CHANGELOG.md is updated (in case of notable or breaking changes)
- [ ] CHANGELOG_DEV.md is updated
- [ ] Benchmark results are attached (if applicable)
- [ ] [Example projects and code samples] are up-to-date (in case of API changes) 

[coding guidelines]: https://golang.org/doc/effective_go
[Example projects and code samples]: https://github.com/cossacklabs/acra-engineering-demo
[Acra documentation]: https://docs.cossacklabs.com/
[documentation repository]: https://github.com/cossacklabs/product-docs