### PR TITLE
Remove cyrillic symbols from tests

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -9445,7 +9445,8 @@ class TestMySQLBinaryTypeAwareDecryptionWithoutDefaults(TestMySQLTextTypeAwareDe
             self.assertIsInstance(value, bytearray, column)
             self.assertNotEqual(data[column], value, column)
 
-class TestMySQLTextTypeAwareDecryptionWithСiphertext(BaseBinaryMySQLTestCase, BaseTransparentEncryption):
+
+class TestMySQLTextTypeAwareDecryptionWithCiphertext(BaseBinaryMySQLTestCase, BaseTransparentEncryption):
     # test table used for queries and data mapping into python types
     test_table = sa.Table(
         # use new object of metadata to avoid name conflict
@@ -9532,7 +9533,8 @@ class TestMySQLTextTypeAwareDecryptionWithСiphertext(BaseBinaryMySQLTestCase, B
             self.assertIsInstance(value, bytes, column)
             self.assertNotEqual(data[column], value, column)
 
-class TestMySQLBinaryTypeAwareDecryptionWithСiphertext(TestMySQLTextTypeAwareDecryptionWithСiphertext):
+
+class TestMySQLBinaryTypeAwareDecryptionWithCiphertext(TestMySQLTextTypeAwareDecryptionWithCiphertext):
     def checkSkip(self):
         if not (TEST_MYSQL and TEST_WITH_TLS):
             self.skipTest("Test only for MySQL with TLS")


### PR DESCRIPTION
Ukrainization is good, but only on the battlefield and during destruction of the rashists :)

I've configured my code editor to highlight the cyrillic symbols, so it shouldn't happen anymore...

## Checklist

- [x] ~Change is covered by automated tests~
- [x] ~The [coding guidelines] are followed~
- [x] ~Public API has proper documentation in the [Acra documentation] site or has PR on [documentation repository] 
  with new changes~
- [x] ~CHANGELOG.md is updated (in case of notable or breaking changes)~
- [x] ~CHANGELOG_DEV.md is updated~
- [x] ~Benchmark results are attached (if applicable)~
- [x] ~[Example projects and code samples] are up-to-date (in case of API changes)~

[coding guidelines]: https://golang.org/doc/effective_go
[Example projects and code samples]: https://github.com/cossacklabs/acra-engineering-demo
[Acra documentation]: https://docs.cossacklabs.com/
[documentation repository]: https://github.com/cossacklabs/product-docs