### PR TITLE
test: use `T.Setenv` to set env vars in tests

### DIFF
--- a/CHANGELOG_DEV.md
+++ b/CHANGELOG_DEV.md
@@ -4,6 +4,7 @@
   - CRL: `--tls_crl_client_cache_size`, `--tls_crl_client_cache_time`, `--tls_crl_client_check_only_leaf_certificate`, `--tls_crl_client_from_cert`, `--tls_crl_database_cache_size`, `--tls_crl_database_cache_time`, `--tls_crl_database_check_only_leaf_certificate`, `--tls_crl_database_from_cert`, `--tls_ocsp_client_check_only_leaf_certificate`
   - OCSP: `--tls_ocsp_client_check_only_leaf_certificate`, `--tls_ocsp_client_from_cert`, `--tls_ocsp_client_required`, `--tls_ocsp_database_check_only_leaf_certificate`, `--tls_ocsp_database_from_cert`, `--tls_ocsp_database_required`
 - Updated `go` version in `go.mod` to 1.17.
+- Replace `os.Setenv` with `t.Setenv` in tests.
 
 # 0.94.0 - 2022-08-03
 - Fixed reloading on SIGHUP signal

--- a/cmd/acra-keys/keys/generate_test.go
+++ b/cmd/acra-keys/keys/generate_test.go
@@ -41,7 +41,7 @@ func TestRotateSymmetricZoneKey(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	os.Setenv(keystore.AcraMasterKeyVarName, base64.StdEncoding.EncodeToString(masterKey))
+	t.Setenv(keystore.AcraMasterKeyVarName, base64.StdEncoding.EncodeToString(masterKey))
 
 	dirName, err := ioutil.TempDir("", "")
 	if err != nil {

--- a/cmd/acra-keys/keys/read-keys_redis_test.go
+++ b/cmd/acra-keys/keys/read-keys_redis_test.go
@@ -22,7 +22,6 @@ package keys
 import (
 	"encoding/base64"
 	"flag"
-	storage2 "github.com/cossacklabs/acra/pseudonymization/storage"
 	"io"
 	"io/ioutil"
 	"os"
@@ -34,6 +33,7 @@ import (
 	"github.com/cossacklabs/acra/keystore/keyloader"
 	"github.com/cossacklabs/acra/keystore/keyloader/env_loader"
 	keystoreV2 "github.com/cossacklabs/acra/keystore/v2/keystore"
+	storage2 "github.com/cossacklabs/acra/pseudonymization/storage"
 )
 
 func TestReadCMD_Redis_V2(t *testing.T) {
@@ -71,7 +71,7 @@ func TestReadCMD_Redis_V2(t *testing.T) {
 		}
 	}
 
-	os.Setenv(keystore.AcraMasterKeyVarName, base64.StdEncoding.EncodeToString(masterKey))
+	t.Setenv(keystore.AcraMasterKeyVarName, base64.StdEncoding.EncodeToString(masterKey))
 
 	t.Run("read storage-public key", func(t *testing.T) {
 		readCmd := &ReadKeySubcommand{
@@ -173,7 +173,7 @@ func TestReadCMD_Redis_V1(t *testing.T) {
 		}
 	}
 
-	os.Setenv(keystore.AcraMasterKeyVarName, base64.StdEncoding.EncodeToString(masterKey))
+	t.Setenv(keystore.AcraMasterKeyVarName, base64.StdEncoding.EncodeToString(masterKey))
 
 	dirName, err := ioutil.TempDir("", "")
 	if err != nil {

--- a/cmd/acra-keys/keys/read-keys_test.go
+++ b/cmd/acra-keys/keys/read-keys_test.go
@@ -19,13 +19,13 @@ package keys
 import (
 	"encoding/base64"
 	"flag"
-	"github.com/cossacklabs/acra/keystore/keyloader"
 	"io"
 	"io/ioutil"
 	"os"
 	"testing"
 
 	"github.com/cossacklabs/acra/keystore"
+	"github.com/cossacklabs/acra/keystore/keyloader"
 	"github.com/cossacklabs/acra/keystore/keyloader/env_loader"
 	keystoreV2 "github.com/cossacklabs/acra/keystore/v2/keystore"
 )
@@ -53,7 +53,7 @@ func TestReadCMD_FS_V2(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	os.Setenv(keystore.AcraMasterKeyVarName, base64.StdEncoding.EncodeToString(masterKey))
+	t.Setenv(keystore.AcraMasterKeyVarName, base64.StdEncoding.EncodeToString(masterKey))
 
 	t.Run("read storage-public key", func(t *testing.T) {
 		readCmd := &ReadKeySubcommand{
@@ -146,7 +146,7 @@ func TestReadCMD_FS_V1(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	os.Setenv(keystore.AcraMasterKeyVarName, base64.StdEncoding.EncodeToString(masterKey))
+	t.Setenv(keystore.AcraMasterKeyVarName, base64.StdEncoding.EncodeToString(masterKey))
 
 	dirName, err := ioutil.TempDir("", "")
 	if err != nil {

--- a/cmd/acra-keys/keys/read-keys_tls_redis_test.go
+++ b/cmd/acra-keys/keys/read-keys_tls_redis_test.go
@@ -23,10 +23,6 @@ import (
 	"crypto/tls"
 	"encoding/base64"
 	"flag"
-	"github.com/cossacklabs/acra/keystore/keyloader/env_loader"
-	"github.com/cossacklabs/acra/network"
-	"github.com/cossacklabs/acra/pseudonymization/storage"
-	"github.com/cossacklabs/acra/utils/tests"
 	"io"
 	"io/ioutil"
 	"os"
@@ -34,11 +30,14 @@ import (
 	"strconv"
 	"testing"
 
-	keystoreV2 "github.com/cossacklabs/acra/keystore/v2/keystore"
-
 	"github.com/cossacklabs/acra/cmd"
 	"github.com/cossacklabs/acra/keystore"
 	"github.com/cossacklabs/acra/keystore/keyloader"
+	"github.com/cossacklabs/acra/keystore/keyloader/env_loader"
+	keystoreV2 "github.com/cossacklabs/acra/keystore/v2/keystore"
+	"github.com/cossacklabs/acra/network"
+	"github.com/cossacklabs/acra/pseudonymization/storage"
+	"github.com/cossacklabs/acra/utils/tests"
 )
 
 func newClientTLSConfig(t *testing.T) *tls.Config {
@@ -123,7 +122,7 @@ func TestReadCMD_TLSRedis_V2(t *testing.T) {
 		}
 	}
 
-	os.Setenv(keystore.AcraMasterKeyVarName, base64.StdEncoding.EncodeToString(masterKey))
+	t.Setenv(keystore.AcraMasterKeyVarName, base64.StdEncoding.EncodeToString(masterKey))
 
 	t.Run("read storage-public key", func(t *testing.T) {
 		readCmd := &ReadKeySubcommand{
@@ -223,7 +222,7 @@ func TestReadCMD_TLSRedis_V1(t *testing.T) {
 		}
 	}
 
-	os.Setenv(keystore.AcraMasterKeyVarName, base64.StdEncoding.EncodeToString(masterKey))
+	t.Setenv(keystore.AcraMasterKeyVarName, base64.StdEncoding.EncodeToString(masterKey))
 
 	dirName, err := ioutil.TempDir("", "")
 	if err != nil {

--- a/keystore/keyloader/kms/kms_loader_test.go
+++ b/keystore/keyloader/kms/kms_loader_test.go
@@ -3,7 +3,6 @@ package kms
 import (
 	"crypto/rand"
 	"encoding/base64"
-	"os"
 	"testing"
 
 	"github.com/cossacklabs/acra/keystore"
@@ -21,8 +20,7 @@ func TestSuccessMasterKeyLoading(t *testing.T) {
 
 	masterKey := base64.StdEncoding.EncodeToString(key)
 
-	os.Setenv(keystore.AcraMasterKeyVarName, masterKey)
-	defer os.Unsetenv(keystore.AcraMasterKeyVarName)
+	t.Setenv(keystore.AcraMasterKeyVarName, masterKey)
 
 	kmsKeyManager.On("ID").Return("mocked KMS encryptor")
 	kmsKeyManager.On("Decrypt", mock.Anything, []byte(AcraMasterKeyKEKID), key, []byte(nil)).Return([]byte(masterKey), nil)

--- a/keystore/keystore_test.go
+++ b/keystore/keystore_test.go
@@ -19,7 +19,6 @@ package keystore
 import (
 	"bytes"
 	"encoding/base64"
-	"os"
 	"testing"
 )
 
@@ -83,16 +82,12 @@ func TestValidateID(t *testing.T) {
 }
 
 func TestGetMasterKeyFromEnvironment(t *testing.T) {
-	if err := os.Setenv(AcraMasterKeyVarName, ""); err != nil {
-		t.Fatal(err)
-	}
+	t.Setenv(AcraMasterKeyVarName, "")
 	if _, err := GetMasterKeyFromEnvironment(); err != ErrEmptyMasterKey {
 		t.Fatal("expected ErrEmptyMasterKey")
 	}
 	key := []byte("some key")
-	if err := os.Setenv(AcraMasterKeyVarName, base64.StdEncoding.EncodeToString(key)); err != nil {
-		t.Fatal(err)
-	}
+	t.Setenv(AcraMasterKeyVarName, base64.StdEncoding.EncodeToString(key))
 
 	if _, err := GetMasterKeyFromEnvironment(); err != ErrMasterKeyIncorrectLength {
 		t.Fatal("expected ErrMasterKeyIncorrectLength error")
@@ -102,9 +97,7 @@ func TestGetMasterKeyFromEnvironment(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Setenv(AcraMasterKeyVarName, base64.StdEncoding.EncodeToString(key)); err != nil {
-		t.Fatal(err)
-	}
+	t.Setenv(AcraMasterKeyVarName, base64.StdEncoding.EncodeToString(key))
 
 	if envKey, err := GetMasterKeyFromEnvironment(); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
This PR replaces `os.Setenv` with `t.Setenv`. Starting from Go 1.17, we can use `t.Setenv` to set environment variable in test. The environment variable is automatically restored to its original value when the test and all its subtests complete. This ensures that each test does not start with leftover environment variables from previous completed tests.

This saves us at least 2 lines (error check, and unsetting the env var) on every instance.

```go
func TestFoo(t *testing.T) {
	// before
	key := "ENV"
	originalEnv := os.Getenv(key)
	
	if err := os.Setenv(key, "new value"); err != nil {
		t.Fatal(err)
	}
	defer func() {
		if err := os.Setenv(key, originalEnv); err != nil {
			t.Logf("failed to set env %s back to original value: %v", key, err)
		}
	}()
	
	// after
	t.Setenv(key, "new value")
}
```

## Checklist

- [x] Change is covered by automated tests
- [x] The [coding guidelines] are followed
- [ ] Public API has proper documentation in the [Acra documentation] site or has PR on [documentation repository] 
  with new changes
- [ ] CHANGELOG.md is updated (in case of notable or breaking changes)
- [x] CHANGELOG_DEV.md is updated
- [ ] Benchmark results are attached (if applicable)
- [ ] [Example projects and code samples] are up-to-date (in case of API changes) 

[coding guidelines]: https://golang.org/doc/effective_go
[Example projects and code samples]: https://github.com/cossacklabs/acra-engineering-demo
[Acra documentation]: https://docs.cossacklabs.com/
[documentation repository]: https://github.com/cossacklabs/product-docs