### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/CHANGELOG_DEV.md
+++ b/CHANGELOG_DEV.md
@@ -5,6 +5,7 @@
   - OCSP: `--tls_ocsp_client_check_only_leaf_certificate`, `--tls_ocsp_client_from_cert`, `--tls_ocsp_client_required`, `--tls_ocsp_database_check_only_leaf_certificate`, `--tls_ocsp_database_from_cert`, `--tls_ocsp_database_required`
 - Updated `go` version in `go.mod` to 1.17.
 - Replace `os.Setenv` with `t.Setenv` in tests.
+- Replace `ioutil.TempDir` with `t.TempDir` in tests.
 
 # 0.94.0 - 2022-08-03
 - Fixed reloading on SIGHUP signal

--- a/cmd/acra-keys/keys/generate_test.go
+++ b/cmd/acra-keys/keys/generate_test.go
@@ -43,11 +43,10 @@ func TestRotateSymmetricZoneKey(t *testing.T) {
 
 	t.Setenv(keystore.AcraMasterKeyVarName, base64.StdEncoding.EncodeToString(masterKey))
 
-	dirName, err := ioutil.TempDir("", "")
-	if err != nil {
+	dirName := t.TempDir()
+	if err := os.Chmod(dirName, 0700); err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(dirName)
 
 	var keyStore keystore.KeyMaking
 

--- a/cmd/acra-keys/keys/read-keys_redis_test.go
+++ b/cmd/acra-keys/keys/read-keys_redis_test.go
@@ -23,8 +23,6 @@ import (
 	"encoding/base64"
 	"flag"
 	"io"
-	"io/ioutil"
-	"os"
 	"strconv"
 	"testing"
 
@@ -175,11 +173,7 @@ func TestReadCMD_Redis_V1(t *testing.T) {
 
 	t.Setenv(keystore.AcraMasterKeyVarName, base64.StdEncoding.EncodeToString(masterKey))
 
-	dirName, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dirName)
+	dirName := t.TempDir()
 
 	t.Run("read storage-public key", func(t *testing.T) {
 		readCmd := &ReadKeySubcommand{

--- a/cmd/acra-keys/keys/read-keys_test.go
+++ b/cmd/acra-keys/keys/read-keys_test.go
@@ -20,7 +20,6 @@ import (
 	"encoding/base64"
 	"flag"
 	"io"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -31,11 +30,10 @@ import (
 )
 
 func TestReadCMD_FS_V2(t *testing.T) {
-	dirName, err := ioutil.TempDir("", "")
-	if err != nil {
+	dirName := t.TempDir()
+	if err := os.Chmod(dirName, 0700); err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(dirName)
 
 	clientID := []byte("testclientid")
 	zoneID := []byte("DDDDDDDDHCzqZAZNbBvybWLR")
@@ -148,11 +146,10 @@ func TestReadCMD_FS_V1(t *testing.T) {
 
 	t.Setenv(keystore.AcraMasterKeyVarName, base64.StdEncoding.EncodeToString(masterKey))
 
-	dirName, err := ioutil.TempDir("", "")
-	if err != nil {
+	dirName := t.TempDir()
+	if err := os.Chmod(dirName, 0700); err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(dirName)
 
 	t.Run("read storage-public key", func(t *testing.T) {
 		readCmd := &ReadKeySubcommand{

--- a/cmd/acra-keys/keys/read-keys_tls_redis_test.go
+++ b/cmd/acra-keys/keys/read-keys_tls_redis_test.go
@@ -24,8 +24,6 @@ import (
 	"encoding/base64"
 	"flag"
 	"io"
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"strconv"
 	"testing"
@@ -224,11 +222,7 @@ func TestReadCMD_TLSRedis_V1(t *testing.T) {
 
 	t.Setenv(keystore.AcraMasterKeyVarName, base64.StdEncoding.EncodeToString(masterKey))
 
-	dirName, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dirName)
+	dirName := t.TempDir()
 
 	t.Run("read storage-public key", func(t *testing.T) {
 		readCmd := &ReadKeySubcommand{

--- a/keystore/v2/keystore/filesystem/backend/filesystem_test.go
+++ b/keystore/v2/keystore/filesystem/backend/filesystem_test.go
@@ -17,7 +17,6 @@
 package backend
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -26,22 +25,16 @@ import (
 )
 
 func TestFilesystem(t *testing.T) {
-	testDirs := make([]string, 0)
 	tests.TestBackend(t, func(t *testing.T) api.Backend {
-		testRootDir, err := ioutil.TempDir(os.TempDir(), "fs-tests")
-		if err != nil {
-			t.Fatalf("failed to create tempdir: %v", err)
+		testRootDir := t.TempDir()
+		if err := os.Chmod(testRootDir, 0700); err != nil {
+			t.Fatal(err)
 		}
-		testDirs = append(testDirs, testRootDir)
+
 		backend, err := CreateDirectoryBackend(testRootDir)
 		if err != nil {
 			t.Fatalf("failed to create backend: %v", err)
 		}
 		return backend
 	})
-	defer func() {
-		for _, dir := range testDirs {
-			os.RemoveAll(dir)
-		}
-	}()
 }

--- a/keystore/v2/keystore/filesystem/keyRing_test.go
+++ b/keystore/v2/keystore/filesystem/keyRing_test.go
@@ -27,7 +27,5 @@ func TestKeyRingInMemory(t *testing.T) {
 }
 
 func TestKeyRingFilesystem(t *testing.T) {
-	newFilesystemKeyStore, cleanup := testFilesystemKeyStore(t)
-	defer cleanup()
-	tests.TestKeyRing(t, newFilesystemKeyStore)
+	tests.TestKeyRing(t, testFilesystemKeyStore)
 }

--- a/keystore/v2/keystore/filesystem/key_test.go
+++ b/keystore/v2/keystore/filesystem/key_test.go
@@ -27,7 +27,5 @@ func TestKeyInMemory(t *testing.T) {
 }
 
 func TestKeyFilesystem(t *testing.T) {
-	newFilesystemKeyStore, cleanup := testFilesystemKeyStore(t)
-	defer cleanup()
-	tests.TestKey(t, newFilesystemKeyStore)
+	tests.TestKey(t, testFilesystemKeyStore)
 }

--- a/keystore/v2/keystore/importV1_test.go
+++ b/keystore/v2/keystore/importV1_test.go
@@ -18,8 +18,6 @@ package keystore
 
 import (
 	"crypto/subtle"
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -46,11 +44,7 @@ func equalPublicKeys(a, b *keys.PublicKey) bool {
 
 func TestImportKeyStoreV1(t *testing.T) {
 	// Prepare root keystore directory (for both versions)
-	rootDirectory, err := ioutil.TempDir(os.TempDir(), "import_test")
-	if err != nil {
-		t.Fatalf("failed to create key directory: %v", err)
-	}
-	defer os.RemoveAll(rootDirectory)
+	rootDirectory := t.TempDir()
 	keyDirV1 := filepath.Join(rootDirectory, "v1")
 	keyDirV2 := filepath.Join(rootDirectory, "v2")
 


### PR DESCRIPTION
A testing cleanup. 

This pull request replaces `ioutil.TempDir` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

This saves us at least 2 lines (error check, and cleanup) on every instance, or in some cases adds cleanup that we forgot.

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := ioutil.TempDir("", "")
	if err != nil {
		t.Fatal(err)
	}
	defer os.RemoveAll(tmpDir)

	// now
	tmpDir := t.TempDir()
}
```

## Checklist

- [x] Change is covered by automated tests
- [x] The [coding guidelines] are followed
- [ ] Public API has proper documentation in the [Acra documentation] site or has PR on [documentation repository] 
  with new changes
- [ ] CHANGELOG.md is updated (in case of notable or breaking changes)
- [x] CHANGELOG_DEV.md is updated
- [ ] Benchmark results are attached (if applicable)
- [ ] [Example projects and code samples] are up-to-date (in case of API changes) 

[coding guidelines]: https://golang.org/doc/effective_go
[Example projects and code samples]: https://github.com/cossacklabs/acra-engineering-demo
[Acra documentation]: https://docs.cossacklabs.com/
[documentation repository]: https://github.com/cossacklabs/product-docs