### PR TITLE
Add KMS CreateKey waiter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -67,7 +67,6 @@ require (
 	github.com/go-playground/validator/v10 v10.4.1 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
-	github.com/hashicorp/go-cleanhttp v0.5.1 // indirect
 	github.com/hashicorp/go-hclog v0.16.2 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
@@ -82,6 +81,7 @@ require (
 	github.com/hashicorp/go-version v1.2.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/hashicorp/serf v0.8.2 // indirect
 	github.com/hashicorp/vault/sdk v0.3.0 // indirect
 	github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect

--- a/keystore/kms/aws/key_manager.go
+++ b/keystore/kms/aws/key_manager.go
@@ -3,9 +3,10 @@ package aws
 import (
 	"context"
 	"errors"
-	baseKMS "github.com/cossacklabs/acra/keystore/kms/base"
 	"strings"
 	"time"
+
+	baseKMS "github.com/cossacklabs/acra/keystore/kms/base"
 )
 
 // KeyManager is AWS implementation of kms.KeyManager

--- a/keystore/kms/aws/key_manager.go
+++ b/keystore/kms/aws/key_manager.go
@@ -10,9 +10,10 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const createAliasCheckAttempts = 10
-
+// ErrAliasIsNotAppliedToKey describe the error returned if AWS KMS cant applied alias for created key
 var ErrAliasIsNotAppliedToKey = errors.New("error creating alias for KMS key")
+
+const createAliasCheckAttempts = 10
 
 // KeyManager is AWS implementation of kms.KeyManager
 type KeyManager struct {

--- a/keystore/kms/aws/key_manager.go
+++ b/keystore/kms/aws/key_manager.go
@@ -7,7 +7,12 @@ import (
 	"time"
 
 	baseKMS "github.com/cossacklabs/acra/keystore/kms/base"
+	log "github.com/sirupsen/logrus"
 )
+
+const createAliasCheckAttempts = 10
+
+var ErrAliasIsNotAppliedToKey = errors.New("error creating alias for KMS key")
 
 // KeyManager is AWS implementation of kms.KeyManager
 type KeyManager struct {
@@ -46,19 +51,25 @@ func (k *KeyManager) CreateKey(ctx context.Context, metaData baseKMS.CreateKeyMe
 	}
 
 	// wait some time for alias to be active
-	for {
+	for i := 0; i < createAliasCheckAttempts; i++ {
 		keyExist, err := k.IsKeyExist(ctx, metaData.KeyName)
 		if err != nil {
 			return nil, err
 		}
 
 		if keyExist {
+			log.WithField("alias", getAliasedName(metaData.KeyName)).WithField("keyId", keyMetadata.KeyId).
+				Info("KMS key Alias created")
 			return &baseKMS.KeyMetadata{
 				KeyID: *keyMetadata.Arn,
 			}, nil
 		}
+
+		log.WithField("key", metaData.KeyName).WithField("attempt", i).Info("Key Alias existence checking")
 		time.Sleep(time.Millisecond * 100)
 	}
+
+	return nil, ErrAliasIsNotAppliedToKey
 }
 
 // IsKeyExist check if key is present on KMS

--- a/keystore/kms/base/key_making_wrapper.go
+++ b/keystore/kms/base/key_making_wrapper.go
@@ -7,7 +7,6 @@ import (
 	"github.com/cossacklabs/acra/zone"
 	"github.com/cossacklabs/themis/gothemis/keys"
 	log "github.com/sirupsen/logrus"
-	"time"
 )
 
 // KMS kek descriptions
@@ -194,18 +193,7 @@ func (k KeyMakingWrapper) createKMSKeyFromContext(keyContext keystore.KeyContext
 	if err != nil {
 		return err
 	}
+
 	log.WithField("keyID", resp.KeyID).WithField("key-name", string(keyID)).Info("KMS key created")
-
-	// wait some time for alias to be active
-	for {
-		keyExist, err = k.kmsKeyManager.IsKeyExist(ctx, string(keyID))
-		if err != nil {
-			return err
-		}
-
-		if keyExist {
-			return nil
-		}
-		time.Sleep(time.Millisecond * 100)
-	}
+	return nil
 }

--- a/keystore/kms/base/key_making_wrapper.go
+++ b/keystore/kms/base/key_making_wrapper.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cossacklabs/acra/zone"
 	"github.com/cossacklabs/themis/gothemis/keys"
 	log "github.com/sirupsen/logrus"
+	"time"
 )
 
 // KMS kek descriptions
@@ -194,5 +195,17 @@ func (k KeyMakingWrapper) createKMSKeyFromContext(keyContext keystore.KeyContext
 		return err
 	}
 	log.WithField("keyID", resp.KeyID).WithField("key-name", string(keyID)).Info("KMS key created")
-	return nil
+
+	// wait some time for alias to be active
+	for {
+		keyExist, err = k.kmsKeyManager.IsKeyExist(ctx, string(keyID))
+		if err != nil {
+			return err
+		}
+
+		if keyExist {
+			return nil
+		}
+		time.Sleep(time.Millisecond * 100)
+	}
 }


### PR DESCRIPTION
During playground actualization, faced a problem running Acra after KMS keys creating by `acra-keymaker`

```
acra-keymaker-ee_server-user1_1  | 2022-08-30T22:20:36.921200901Z time="2022-08-30T22:20:36Z" level=info msg="Initialized KMS AWS KeyManager"
acra-keymaker-ee_server-user1_1  | 2022-08-30T22:20:36.921550967Z time="2022-08-30T22:20:36Z" level=info msg="Initialized KMS AWS KeyManager"
acra-keymaker-ee_server-user1_1  | 2022-08-30T22:20:37.091789707Z time="2022-08-30T22:20:37Z" level=info msg="KMS key created" key-name=acra_fca9e56609eea6521d95f50dca9ebe45505642727ae179050ee4951f2327575535cd41226988c46790a0ba2e0b0b72542166e0f1561348ac25dc8b97803a52df keyID="arn:aws:kms:eu-west-1:533306693851:key/e6483ab7-7571-4572-8518-2ff1dc19cee4"
acra-keymaker-ee_server-user1_1  | 2022-08-30T22:20:37.119697236Z Generated storage encryption keypair
acra-keymaker-ee_server-user1_1  | 2022-08-30T22:20:37.127808014Z Generated HMAC key for searchable encryption
acra-keymaker-ee_server-user1_1  | 2022-08-30T22:20:37.137321380Z Generated storage symmetric key for clientID
acra-keymaker-ee_server-user1_1  | 2022-08-30T22:20:37.229231384Z time="2022-08-30T22:20:37Z" level=info msg="KMS key created" key-name=acra_audit_log keyID="arn:aws:kms:eu-west-1:533306693851:key/57ee0e00-cc09-4205-8d2f-b2fa2e7caba1"
acra-keymaker-ee_server-user1_1  | 2022-08-30T22:20:37.236369217Z panic: operation error KMS: Encrypt, https response error StatusCode: 400, RequestID: 19e09a64-1e4a-4cc0-866f-bb78973556e0, NotFoundException: Alias arn:aws:kms:eu-west-1:533306693851:alias/acra_audit_log is not found.
acra-keymaker-ee_server-user1_1  | 2022-08-30T22:20:37.236450141Z 
acra-keymaker-ee_server-user1_1  | 2022-08-30T22:20:37.236669041Z goroutine 1 [running]:
acra-keymaker-ee_server-user1_1  | 2022-08-30T22:20:37.236848072Z main.main()
acra-keymaker-ee_server-user1_1  | 2022-08-30T22:20:37.237165598Z       /acra/cmd/acra-keymaker/acra-keymaker.go:241 +0x1e39
```

Means the AWS needs some time to create alise on key to be active. This PR contains simple waiter logic.


<!-- Describe your changes here -->

## Checklist

- [ ] Change is covered by automated tests
- [ ] The [coding guidelines] are followed
- [ ] Public API has proper documentation in the [Acra documentation] site or has PR on [documentation repository] 
  with new changes
- [ ] CHANGELOG.md is updated (in case of notable or breaking changes)
- [ ] CHANGELOG_DEV.md is updated
- [ ] Benchmark results are attached (if applicable)
- [ ] [Example projects and code samples] are up-to-date (in case of API changes) 

[coding guidelines]: https://golang.org/doc/effective_go
[Example projects and code samples]: https://github.com/cossacklabs/acra-engineering-demo
[Acra documentation]: https://docs.cossacklabs.com/
[documentation repository]: https://github.com/cossacklabs/product-docs