### PR TITLE
Process sequence of pending packets

### DIFF
--- a/CHANGELOG_DEV.md
+++ b/CHANGELOG_DEV.md
@@ -1,3 +1,6 @@
+# 0.94.0 - 2022-09-19
+- Accumulate packets in a queue and handle paired packets in the correct order. Fixes issue with incorrectly linked Bind packet to inappropriate Parse packet and nil dereferences.
+
 # 0.94.0 - 2022-08-25
 - Add support of Hashicorp Consul for `encryptor_config loading`. 
 - Introduce new Hashicorp Consul flags: `consul_connection_api_string` and `consul_kv_config_path` and corresponded `consul` TLS configuration flags.

--- a/decryptor/postgresql/packet_handler.go
+++ b/decryptor/postgresql/packet_handler.go
@@ -478,6 +478,9 @@ const WithoutMessageType = 0
 // ErrUnsupportedPacketType error when recognized unsupported message type or new added to postgresql wire protocol
 var ErrUnsupportedPacketType = errors.New("unsupported postgresql message type")
 
+// ErrNilPendingPacket error when took nil instead of pending packet
+var ErrNilPendingPacket = errors.New("nil pending packet")
+
 // ReadClientPacket read and recognize packets that may be sent only from client/frontend.
 //
 // There are two types of messages: startup and general ones.

--- a/decryptor/postgresql/pending_packets.go
+++ b/decryptor/postgresql/pending_packets.go
@@ -58,6 +58,9 @@ func (packets *pendingPacketsList) Remove(packet interface{}) error {
 			return ErrRemoveFromEmptyPendingList
 		}
 		currentElement := packetList.Front()
+		if currentElement == nil {
+			return nil
+		}
 		if currentElement.Value != packet {
 			return errors.New("removing not current packet")
 		}
@@ -76,6 +79,9 @@ func (packets *pendingPacketsList) RemoveCurrent(packet interface{}) error {
 			return ErrRemoveFromEmptyPendingList
 		}
 		currentElement := packetList.Front()
+		if currentElement == nil {
+			return nil
+		}
 		packetList.Remove(currentElement)
 		return nil
 	}
@@ -104,6 +110,25 @@ func (packets *pendingPacketsList) GetPendingPacket(packet interface{}) (interfa
 			return nil, nil
 		}
 		currentElement := packetList.Front()
+		if currentElement == nil {
+			return nil, nil
+		}
+		return currentElement.Value, nil
+	}
+	return nil, ErrUnsupportedPendingPacketType
+}
+
+func (packets *pendingPacketsList) GetLast(packet interface{}) (interface{}, error) {
+	switch packet.(type) {
+	case *ParsePacket, *BindPacket, *ExecutePacket, *pgproto3.RowDescription, *pgproto3.ParameterDescription:
+		packetList, ok := packets.lists[reflect.TypeOf(packet)]
+		if !ok {
+			return nil, nil
+		}
+		currentElement := packetList.Back()
+		if currentElement == nil {
+			return nil, nil
+		}
 		return currentElement.Value, nil
 	}
 	return nil, ErrUnsupportedPendingPacketType

--- a/decryptor/postgresql/pending_packets.go
+++ b/decryptor/postgresql/pending_packets.go
@@ -24,6 +24,7 @@ import (
 	"reflect"
 )
 
+// pendingPacketsList stores objects per their type and provides API similar to queue
 type pendingPacketsList struct {
 	lists map[reflect.Type]*list.List
 }
@@ -32,7 +33,10 @@ func newPendingPacketsList() *pendingPacketsList {
 	return &pendingPacketsList{lists: make(map[reflect.Type]*list.List)}
 }
 
+// ErrUnsupportedPendingPacketType error after using unknown type of structure
 var ErrUnsupportedPendingPacketType = errors.New("unsupported pending packet type")
+
+// ErrRemoveFromEmptyPendingList error after trying to remove object from empty list
 var ErrRemoveFromEmptyPendingList = errors.New("removing from empty pending list")
 
 // Add packet to pending list of packets of this type
@@ -51,8 +55,8 @@ func (packets *pendingPacketsList) Add(packet interface{}) error {
 	return ErrUnsupportedPendingPacketType
 }
 
-// RemoveCurrent removes first in the list pending packet
-func (packets *pendingPacketsList) RemoveCurrent(packet interface{}) error {
+// RemoveNextPendingPacket removes first in the list pending packet
+func (packets *pendingPacketsList) RemoveNextPendingPacket(packet interface{}) error {
 	switch packet.(type) {
 	case *ParsePacket, *BindPacket, *ExecutePacket, *pgproto3.RowDescription, *pgproto3.ParameterDescription:
 		packetList, ok := packets.lists[reflect.TypeOf(packet)]
@@ -85,6 +89,7 @@ func (packets *pendingPacketsList) RemoveAll(packet interface{}) error {
 	return ErrUnsupportedPendingPacketType
 }
 
+// GetPendingPacket returns next pending packet
 func (packets *pendingPacketsList) GetPendingPacket(packet interface{}) (interface{}, error) {
 	switch packet.(type) {
 	case *ParsePacket, *BindPacket, *ExecutePacket, *pgproto3.RowDescription, *pgproto3.ParameterDescription:
@@ -102,7 +107,8 @@ func (packets *pendingPacketsList) GetPendingPacket(packet interface{}) (interfa
 	return nil, ErrUnsupportedPendingPacketType
 }
 
-func (packets *pendingPacketsList) GetLast(packet interface{}) (interface{}, error) {
+// GetLastPending return last added pending packet
+func (packets *pendingPacketsList) GetLastPending(packet interface{}) (interface{}, error) {
 	switch packet.(type) {
 	case *ParsePacket, *BindPacket, *ExecutePacket, *pgproto3.RowDescription, *pgproto3.ParameterDescription:
 		packetList, ok := packets.lists[reflect.TypeOf(packet)]

--- a/decryptor/postgresql/pending_packets.go
+++ b/decryptor/postgresql/pending_packets.go
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2022, Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package postgresql
+
+import (
+	"container/list"
+	"errors"
+	"github.com/jackc/pgx/pgproto3"
+	"reflect"
+)
+
+type pendingPacketsList struct {
+	lists map[reflect.Type]*list.List
+}
+
+func newPendingPacketsList() *pendingPacketsList {
+	return &pendingPacketsList{lists: make(map[reflect.Type]*list.List)}
+}
+
+var ErrUnsupportedPendingPacketType = errors.New("unsupported pending packet type")
+var ErrRemoveFromEmptyPendingList = errors.New("removing from empty pending list")
+
+// Add packet to pending list of packets of this type
+func (packets *pendingPacketsList) Add(packet interface{}) error {
+	switch packet.(type) {
+	case *ParsePacket, *BindPacket, *ExecutePacket, *pgproto3.RowDescription, *pgproto3.ParameterDescription:
+		packetList, ok := packets.lists[reflect.TypeOf(packet)]
+		if !ok {
+			packetList = list.New()
+			packets.lists[reflect.TypeOf(packet)] = packetList
+		}
+		packetList.PushBack(packet)
+		return nil
+	}
+	return ErrUnsupportedPendingPacketType
+}
+
+// Remove packet from list of pending packets only if it is current pending packet
+func (packets *pendingPacketsList) Remove(packet interface{}) error {
+	switch packet.(type) {
+	case *ParsePacket, *BindPacket, *ExecutePacket, *pgproto3.RowDescription, *pgproto3.ParameterDescription:
+		packetList, ok := packets.lists[reflect.TypeOf(packet)]
+		if !ok {
+			return ErrRemoveFromEmptyPendingList
+		}
+		currentElement := packetList.Front()
+		if currentElement.Value != packet {
+			return errors.New("removing not current packet")
+		}
+		packetList.Remove(currentElement)
+		return nil
+	}
+	return ErrUnsupportedPendingPacketType
+}
+
+// RemoveCurrent removes first in the list pending packet
+func (packets *pendingPacketsList) RemoveCurrent(packet interface{}) error {
+	switch packet.(type) {
+	case *ParsePacket, *BindPacket, *ExecutePacket, *pgproto3.RowDescription, *pgproto3.ParameterDescription:
+		packetList, ok := packets.lists[reflect.TypeOf(packet)]
+		if !ok {
+			return ErrRemoveFromEmptyPendingList
+		}
+		currentElement := packetList.Front()
+		packetList.Remove(currentElement)
+		return nil
+	}
+	return ErrUnsupportedPendingPacketType
+}
+
+// RemoveAll pending packets of packet's type
+func (packets *pendingPacketsList) RemoveAll(packet interface{}) error {
+	switch packet.(type) {
+	case *ParsePacket, *BindPacket, *ExecutePacket, *pgproto3.RowDescription, *pgproto3.ParameterDescription:
+		packetList, ok := packets.lists[reflect.TypeOf(packet)]
+		if !ok {
+			return nil
+		}
+		packetList.Init()
+		return nil
+	}
+	return ErrUnsupportedPendingPacketType
+}
+
+func (packets *pendingPacketsList) GetPendingPacket(packet interface{}) (interface{}, error) {
+	switch packet.(type) {
+	case *ParsePacket, *BindPacket, *ExecutePacket, *pgproto3.RowDescription, *pgproto3.ParameterDescription:
+		packetList, ok := packets.lists[reflect.TypeOf(packet)]
+		if !ok {
+			return nil, nil
+		}
+		currentElement := packetList.Front()
+		return currentElement.Value, nil
+	}
+	return nil, ErrUnsupportedPendingPacketType
+}

--- a/decryptor/postgresql/pending_packets_test.go
+++ b/decryptor/postgresql/pending_packets_test.go
@@ -12,7 +12,7 @@ func Test_newPendingPackets(t *testing.T) {
 		t.Fatal("Packet should be nil")
 	}
 
-	if packet, err := pendingPackets.GetLast(&BindPacket{}); err != nil {
+	if packet, err := pendingPackets.GetLastPending(&BindPacket{}); err != nil {
 		t.Fatal(err)
 	} else if packet != nil {
 		t.Fatal("Packet should be nil")
@@ -30,7 +30,7 @@ func Test_newPendingPackets(t *testing.T) {
 		t.Fatal("Unexpected value")
 	}
 
-	if packet, err := pendingPackets.GetLast(&BindPacket{}); err != nil {
+	if packet, err := pendingPackets.GetLastPending(&BindPacket{}); err != nil {
 		t.Fatal(err)
 	} else if packet == nil {
 		t.Fatal("Packet should not be nil")
@@ -50,7 +50,7 @@ func Test_newPendingPackets(t *testing.T) {
 		t.Fatal("Unexpected value")
 	}
 
-	if packet, err := pendingPackets.GetLast(&BindPacket{}); err != nil {
+	if packet, err := pendingPackets.GetLastPending(&BindPacket{}); err != nil {
 		t.Fatal(err)
 	} else if packet == nil {
 		t.Fatal("Packet should not be nil")
@@ -58,7 +58,7 @@ func Test_newPendingPackets(t *testing.T) {
 		t.Fatal("Unexpected value")
 	}
 
-	if err := pendingPackets.RemoveCurrent(&BindPacket{}); err != nil {
+	if err := pendingPackets.RemoveNextPendingPacket(&BindPacket{}); err != nil {
 		t.Fatal(err)
 	}
 	if packet, err := pendingPackets.GetPendingPacket(&BindPacket{}); err != nil {
@@ -69,7 +69,7 @@ func Test_newPendingPackets(t *testing.T) {
 		t.Fatal("Unexpected value")
 	}
 
-	if packet, err := pendingPackets.GetLast(&BindPacket{}); err != nil {
+	if packet, err := pendingPackets.GetLastPending(&BindPacket{}); err != nil {
 		t.Fatal(err)
 	} else if packet == nil {
 		t.Fatal("Packet should not be nil")
@@ -86,7 +86,7 @@ func Test_newPendingPackets(t *testing.T) {
 		t.Fatal("Packet should be nil")
 	}
 
-	if packet, err := pendingPackets.GetLast(&BindPacket{}); err != nil {
+	if packet, err := pendingPackets.GetLastPending(&BindPacket{}); err != nil {
 		t.Fatal(err)
 	} else if packet != nil {
 		t.Fatal("Packet should be nil")

--- a/decryptor/postgresql/pending_packets_test.go
+++ b/decryptor/postgresql/pending_packets_test.go
@@ -1,0 +1,94 @@
+package postgresql
+
+import (
+	"testing"
+)
+
+func Test_newPendingPackets(t *testing.T) {
+	pendingPackets := newPendingPacketsList()
+	if packet, err := pendingPackets.GetPendingPacket(&BindPacket{}); err != nil {
+		t.Fatal(err)
+	} else if packet != nil {
+		t.Fatal("Packet should be nil")
+	}
+
+	if packet, err := pendingPackets.GetLast(&BindPacket{}); err != nil {
+		t.Fatal(err)
+	} else if packet != nil {
+		t.Fatal("Packet should be nil")
+	}
+
+	if err := pendingPackets.Add(&BindPacket{portal: "portal1"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if packet, err := pendingPackets.GetPendingPacket(&BindPacket{}); err != nil {
+		t.Fatal(err)
+	} else if packet == nil {
+		t.Fatal("Packet should not be nil")
+	} else if packet.(*BindPacket).portal != "portal1" {
+		t.Fatal("Unexpected value")
+	}
+
+	if packet, err := pendingPackets.GetLast(&BindPacket{}); err != nil {
+		t.Fatal(err)
+	} else if packet == nil {
+		t.Fatal("Packet should not be nil")
+	} else if packet.(*BindPacket).portal != "portal1" {
+		t.Fatal("Unexpected value")
+	}
+
+	if err := pendingPackets.Add(&BindPacket{portal: "portal2"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if packet, err := pendingPackets.GetPendingPacket(&BindPacket{}); err != nil {
+		t.Fatal(err)
+	} else if packet == nil {
+		t.Fatal("Packet should not be nil")
+	} else if packet.(*BindPacket).portal != "portal1" {
+		t.Fatal("Unexpected value")
+	}
+
+	if packet, err := pendingPackets.GetLast(&BindPacket{}); err != nil {
+		t.Fatal(err)
+	} else if packet == nil {
+		t.Fatal("Packet should not be nil")
+	} else if packet.(*BindPacket).portal != "portal2" {
+		t.Fatal("Unexpected value")
+	}
+
+	if err := pendingPackets.RemoveCurrent(&BindPacket{}); err != nil {
+		t.Fatal(err)
+	}
+	if packet, err := pendingPackets.GetPendingPacket(&BindPacket{}); err != nil {
+		t.Fatal(err)
+	} else if packet == nil {
+		t.Fatal("Packet should not be nil")
+	} else if packet.(*BindPacket).portal != "portal2" {
+		t.Fatal("Unexpected value")
+	}
+
+	if packet, err := pendingPackets.GetLast(&BindPacket{}); err != nil {
+		t.Fatal(err)
+	} else if packet == nil {
+		t.Fatal("Packet should not be nil")
+	} else if packet.(*BindPacket).portal != "portal2" {
+		t.Fatal("Unexpected value")
+	}
+
+	if err := pendingPackets.RemoveAll(&BindPacket{}); err != nil {
+		t.Fatal(err)
+	}
+	if packet, err := pendingPackets.GetPendingPacket(&BindPacket{}); err != nil {
+		t.Fatal(err)
+	} else if packet != nil {
+		t.Fatal("Packet should be nil")
+	}
+
+	if packet, err := pendingPackets.GetLast(&BindPacket{}); err != nil {
+		t.Fatal(err)
+	} else if packet != nil {
+		t.Fatal("Packet should be nil")
+	}
+}

--- a/decryptor/postgresql/pg_decryptor.go
+++ b/decryptor/postgresql/pg_decryptor.go
@@ -741,7 +741,7 @@ func (proxy *PgProxy) handleDatabasePacket(ctx context.Context, packet *PacketHa
 			return err
 		}
 		defer func() {
-			if err := proxy.protocolState.forgetPendingBind(); err != nil {
+			if err := proxy.protocolState.zeroizePendingBind(); err != nil {
 				logger.WithError(err).Errorln("Can't forget pending Bind packet")
 			}
 		}()

--- a/decryptor/postgresql/pg_decryptor.go
+++ b/decryptor/postgresql/pg_decryptor.go
@@ -304,17 +304,12 @@ func (proxy *PgProxy) handleClientPacket(ctx context.Context, packet *PacketHand
 		if err != nil || censored {
 			return censored, err
 		}
-		// we get last registered in HandleClientPacket, continue to process it
-		pendingParse, err := proxy.protocolState.LastParse()
-		if err != nil {
-			logger.WithError(err).Errorln("Can't get pending Parse packet")
-			return false, err
-		}
 		// Register prepared statement, though it can produce an error on the db
 		// side. In that case, it should have been removed from the registry,
 		// but for now it is not implemented yet. Therefore, connection with a
 		// large number of prepared statements with errors tend to leak memory,
 		// but on practice it is not that noticeable.
+		pendingParse := proxy.protocolState.pendingParse
 		if err = proxy.registerPreparedStatement(packet, pendingParse, logger); err != nil {
 			return false, err
 		}
@@ -349,11 +344,7 @@ func (proxy *PgProxy) handleQueryPacket(ctx context.Context, packet *PacketHandl
 		} else {
 			log := logger.WithField("sql", queryWithHiddenValues)
 			if proxy.protocolState.LastPacketType() == ParseStatementPacket {
-				preparedStatement, err := proxy.protocolState.LastParse()
-				if err != nil {
-					log.WithError(err).Errorln("Can't get pending Parse packet")
-					return false, err
-				}
+				preparedStatement := proxy.protocolState.PendingParse()
 				log = log.WithField("prepared_name", preparedStatement.Name())
 			}
 			log.Debugln("New query")
@@ -738,16 +729,8 @@ func (proxy *PgProxy) handleDatabasePacket(ctx context.Context, packet *PacketHa
 		return proxy.handleQueryDataPacket(ctx, packet, logger)
 
 	case ParseCompletePacket:
-		pendingParse, err := proxy.protocolState.PendingParse()
-		if err != nil {
-			logger.WithError(err).Errorln("Can't get pending Parse packet")
-			return err
-		}
-		log.WithField("parse", pendingParse).Debugln("ParseComplete")
-		if err := proxy.protocolState.forgetPendingParse(); err != nil {
-			log.WithError(err).Errorln("Can't forget pending Parse packet")
-			return err
-		}
+		log.WithField("parse", proxy.protocolState.pendingParse).Debugln("ParseComplete")
+		proxy.protocolState.forgetPendingParse()
 		return nil
 
 	case BindCompletePacket:
@@ -901,13 +884,12 @@ func (proxy *PgProxy) handleQueryDataPacket(ctx context.Context, packet *PacketH
 		}
 		// default values Text
 		format := 0
-		pendingBind, err := proxy.protocolState.PendingBind()
+		pendingBind, err := proxy.protocolState.pendingPackets.GetPendingPacket(&BindPacket{})
 		if err != nil {
-			logger.WithError(err).Errorln("Can't get pending Bind packet")
-			return err
+			panic(err)
 		}
 		if pendingBind != nil {
-			boundFormat, err := GetParameterFormatByIndex(i, pendingBind.resultFormats)
+			boundFormat, err := GetParameterFormatByIndex(i, pendingBind.(*BindPacket).resultFormats)
 			if err != nil {
 				logger.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCodingPostgresqlCantParseColumnsDescription).
 					WithError(err).Errorln("Can't get format for column")

--- a/decryptor/postgresql/pg_decryptor.go
+++ b/decryptor/postgresql/pg_decryptor.go
@@ -894,7 +894,9 @@ func (proxy *PgProxy) handleQueryDataPacket(ctx context.Context, packet *PacketH
 		format := 0
 		pendingBind, err := proxy.protocolState.pendingPackets.GetPendingPacket(&BindPacket{})
 		if err != nil {
-			panic(err)
+			logger.WithField(logging.FieldKeyEventCode, logging.EventCodeErrorDBProtocolError).
+				WithError(err).Errorln("Can't get pending Bind packet")
+			return err
 		}
 		if pendingBind != nil {
 			boundFormat, err := GetParameterFormatByIndex(i, pendingBind.(*BindPacket).resultFormats)

--- a/decryptor/postgresql/protocol.go
+++ b/decryptor/postgresql/protocol.go
@@ -20,17 +20,15 @@ import (
 	"github.com/cossacklabs/acra/decryptor/base"
 	"github.com/cossacklabs/acra/logging"
 	"github.com/cossacklabs/acra/sqlparser"
-	"github.com/jackc/pgx/pgproto3"
 )
 
 // PgProtocolState keeps track of PostgreSQL protocol state.
 type PgProtocolState struct {
 	parser *sqlparser.Parser
 
-	lastPacketType              PacketType
-	pendingPackets              *pendingPacketsList
-	pendingQuery                base.OnQueryObject
-	pendingParameterDescription *pgproto3.ParameterDescription
+	lastPacketType PacketType
+	pendingPackets *pendingPacketsList
+	pendingQuery   base.OnQueryObject
 }
 
 // PacketType describes how to handle a message packet.
@@ -158,7 +156,6 @@ func (p *PgProtocolState) HandleClientPacket(packet *PacketHandler) error {
 				WithError(err).Errorln("Can't save parse packet")
 			return err
 		}
-		p.pendingParameterDescription = nil
 		return nil
 	}
 
@@ -218,11 +215,6 @@ func (p *PgProtocolState) HandleDatabasePacket(packet *PacketHandler) error {
 
 	if packet.IsParameterDescription() {
 		p.lastPacketType = ParameterDescriptionPacket
-		parameterDescription, err := packet.GetParameterDescriptionData()
-		if err != nil {
-			return err
-		}
-		p.pendingParameterDescription = parameterDescription
 		return nil
 	}
 

--- a/decryptor/postgresql/protocol.go
+++ b/decryptor/postgresql/protocol.go
@@ -237,18 +237,10 @@ func (p *PgProtocolState) HandleDatabasePacket(packet *PacketHandler) error {
 func (p *PgProtocolState) forgetPendingParse() {
 	// Query content is sensitive so we should securely remove it from memory
 	// once we're sure that it's not needed anymore.
-	pendingParse, err := p.pendingPackets.GetPendingPacket(&ParsePacket{})
-	if err != nil {
-		log.WithError(err).Errorln("Can't get pending Parse packet")
-		return err
+	if p.pendingParse != nil {
+		p.pendingParse.Zeroize()
 	}
-	if pendingParse != nil {
-		pendingParse.(*ParsePacket).Zeroize()
-	}
-	if err := p.pendingPackets.RemoveCurrent(pendingParse.(*ParsePacket)); err != nil {
-		return err
-	}
-	return nil
+	p.pendingParse = nil
 }
 
 func (p *PgProtocolState) forgetPendingBind() error {

--- a/decryptor/postgresql/protocol.go
+++ b/decryptor/postgresql/protocol.go
@@ -27,6 +27,8 @@ type PgProtocolState struct {
 	parser *sqlparser.Parser
 
 	lastPacketType PacketType
+	// some packets have pairs request/response and we save data from request only after receiving successful response
+	// here we save requests that wait acceptance by database
 	pendingPackets *pendingPacketsList
 	pendingQuery   base.OnQueryObject
 }

--- a/decryptor/postgresql/protocol.go
+++ b/decryptor/postgresql/protocol.go
@@ -30,7 +30,6 @@ type PgProtocolState struct {
 	lastPacketType              PacketType
 	pendingPackets              *pendingPacketsList
 	pendingQuery                base.OnQueryObject
-	pendingRowDescription       *pgproto3.RowDescription
 	pendingParameterDescription *pgproto3.ParameterDescription
 }
 
@@ -126,11 +125,6 @@ func (p *PgProtocolState) PendingExecute() (*ExecutePacket, error) {
 	return packet.(*ExecutePacket), nil
 }
 
-// PendingRowDescription returns the pending query parameters, if any.
-func (p *PgProtocolState) PendingRowDescription() *pgproto3.RowDescription {
-	return p.pendingRowDescription
-}
-
 // HandleClientPacket observes a packet from client to the database,
 // extracts query information from it, and anticipates future database responses.
 func (p *PgProtocolState) HandleClientPacket(packet *PacketHandler) error {
@@ -219,11 +213,6 @@ func (p *PgProtocolState) HandleDatabasePacket(packet *PacketHandler) error {
 
 	if packet.IsRowDescription() {
 		p.lastPacketType = RowDescriptionPacket
-		rowDescription, err := packet.GetRowDescriptionData()
-		if err != nil {
-			return err
-		}
-		p.pendingRowDescription = rowDescription
 		return nil
 	}
 

--- a/decryptor/postgresql/protocol.go
+++ b/decryptor/postgresql/protocol.go
@@ -79,7 +79,7 @@ func (p *PgProtocolState) PendingParse() (*ParsePacket, error) {
 
 // LastParse returns the last added ParsePacket
 func (p *PgProtocolState) LastParse() (*ParsePacket, error) {
-	packet, err := p.pendingPackets.GetLast(&ParsePacket{})
+	packet, err := p.pendingPackets.GetLastPending(&ParsePacket{})
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +103,7 @@ func (p *PgProtocolState) PendingBind() (*BindPacket, error) {
 
 // LastBind returns the last added BindPacket
 func (p *PgProtocolState) LastBind() (*BindPacket, error) {
-	packet, err := p.pendingPackets.GetLast(&BindPacket{})
+	packet, err := p.pendingPackets.GetLastPending(&BindPacket{})
 	if err != nil {
 		return nil, err
 	}
@@ -263,7 +263,7 @@ func (p *PgProtocolState) forgetPendingParse() error {
 	}
 	if pendingParse != nil {
 		pendingParse.(*ParsePacket).Zeroize()
-		if err := p.pendingPackets.RemoveCurrent(pendingParse.(*ParsePacket)); err != nil {
+		if err := p.pendingPackets.RemoveNextPendingPacket(pendingParse.(*ParsePacket)); err != nil {
 			return err
 		}
 	}
@@ -280,7 +280,7 @@ func (p *PgProtocolState) forgetPendingBind() error {
 	}
 	if pendingBind != nil {
 		pendingBind.(*BindPacket).Zeroize()
-		if err := p.pendingPackets.RemoveCurrent(pendingBind.(*BindPacket)); err != nil {
+		if err := p.pendingPackets.RemoveNextPendingPacket(pendingBind.(*BindPacket)); err != nil {
 			return err
 		}
 	}
@@ -308,7 +308,7 @@ func (p *PgProtocolState) forgetPendingExecute() error {
 	}
 	if pendingPacket != nil {
 		pendingPacket.(*ExecutePacket).Zeroize()
-		if err := p.pendingPackets.RemoveCurrent(pendingPacket.(*ExecutePacket)); err != nil {
+		if err := p.pendingPackets.RemoveNextPendingPacket(pendingPacket.(*ExecutePacket)); err != nil {
 			return err
 		}
 	}

--- a/tests/test.py
+++ b/tests/test.py
@@ -1571,11 +1571,6 @@ class BaseTestCase(PrometheusMixin, unittest.TestCase):
             popen_kwargs = {}
         cli_args = sorted(['--{}={}'.format(k, v) for k, v in args.items() if v is not None])
         print("acra-server args: {}".format(' '.join(cli_args)))
-        args['version'] = '0.93.0'
-        dump_yaml_config(args, '/tmp/test.yaml')
-        if self.EXTERNAL_ACRA:
-            return ProcessStub()
-
         process = fork(lambda: subprocess.Popen([self.get_acraserver_bin_path()] + cli_args,
                                                      **popen_kwargs))
         try:
@@ -1629,7 +1624,8 @@ class BaseTestCase(PrometheusMixin, unittest.TestCase):
     def setUp(self):
         self.checkSkip()
         try:
-            self.acra = self.fork_acra()
+            if not self.EXTERNAL_ACRA:
+                self.acra = self.fork_acra()
 
             base_args = get_connect_args(port=self.ACRASERVER_PORT, sslmode=SSLMODE)
 
@@ -9147,7 +9143,6 @@ class TestMySQLTextFormatTypeAwareDecryptionWithDefaultsWithConsulEncryptorConfi
 
 class TestPostgresqlBinaryFormatTypeAwareDecryptionWithDefaults(
         BaseBinaryPostgreSQLTestCase, TestPostgresqlTextFormatTypeAwareDecryptionWithDefaults):
-    EXTERNAL_ACRA = False
     def testClientIDRead(self):
         """test decrypting with correct clientID and not decrypting with
         incorrect clientID or using direct connection to db

--- a/tests/test.py
+++ b/tests/test.py
@@ -991,7 +991,7 @@ class AsyncpgExecutor(QueryExecutor):
 
     def _set_text_format(self, conn):
         """Force text format to numeric types."""
-        loop = asyncio.new_event_loop()
+        loop = asyncio.get_event_loop()
         for pg_type in ['int2', 'int4', 'int8']:
             loop.run_until_complete(
                 conn.set_type_codec(pg_type,
@@ -1012,7 +1012,7 @@ class AsyncpgExecutor(QueryExecutor):
     def execute_prepared_statement(self, query, args=None):
         if not args:
             args = []
-        loop = asyncio.new_event_loop()
+        loop = asyncio.get_event_loop()
         conn = self._connect(loop)
         if self.connection_args.format == self.TextFormat:
             self._set_text_format(conn)
@@ -1028,7 +1028,7 @@ class AsyncpgExecutor(QueryExecutor):
     def execute(self, query, args=None):
         if not args:
             args = []
-        loop = asyncio.new_event_loop()
+        loop = asyncio.get_event_loop()
         conn = self._connect(loop)
         if self.connection_args.format == self.TextFormat:
             self._set_text_format(conn)
@@ -1038,7 +1038,6 @@ class AsyncpgExecutor(QueryExecutor):
             return result
         finally:
             loop.run_until_complete(conn.close(timeout=STATEMENT_TIMEOUT))
-            loop.close()
 
 
 class Psycopg2Executor(QueryExecutor):


### PR DESCRIPTION
What was the problem? DB drivers can send set of packets in one TCP packet. And usually, they are related to each other and look like Parse + Bind + Describe + Execute + Sync. Driver registers query in Parse, then binds data, then asks to describe types, executes query and commit state. Acra registers PreparedStatement on ParseComplete packet that DB responds to driver after validation and acceptance. Bind packet relates to Parse packet because it should specify statement name for which it sends values.
In this flow acra do next: remembers Parse packet and save it as `pendingParse`. Then handle Bind packet, loads finds `pendignParse` and link them together. 

Previously we expected that one set of packets in TCP packet contains only one packet with a query like SimpleQuery or Parse packet. And when Acra receives ParsePacket, it resets state, forgets about Bind and other kind of packets - https://github.com/cossacklabs/acra/blob/master/decryptor/postgresql/protocol.go#L121

But drivers not limited in the number of query packets. They can send several of them in one set. And they should be processed in same order. If acra got 2 Describe packets from driver to database and then receives 2 RowDescription responses from the database, it should link first RowDescription to the first Describe, second one to the second. 
So Acra should not store only last packet, but should all of them in same order.

In this PR was added new component that stores all pendingPackets and store them separately according to the type, works as a queue. And was refactored logic with working with pending packets. Now it removes item from the queue, not nilify a field.

Due to limitations of python's drivers that don't allow to compile such set of packets to write regression test, were added unit-test with dumped packets that reproduces the problem. 


## Checklist

- [ ] Change is covered by automated tests
- [ ] The [coding guidelines] are followed
- [ ] Public API has proper documentation in the [Acra documentation] site or has PR on [documentation repository] 
  with new changes
- [ ] CHANGELOG.md is updated (in case of notable or breaking changes)
- [ ] CHANGELOG_DEV.md is updated
- [ ] Benchmark results are attached (if applicable)
- [ ] [Example projects and code samples] are up-to-date (in case of API changes) 

[coding guidelines]: https://golang.org/doc/effective_go
[Example projects and code samples]: https://github.com/cossacklabs/acra-engineering-demo
[Acra documentation]: https://docs.cossacklabs.com/
[documentation repository]: https://github.com/cossacklabs/product-docs