### PR TITLE
Fix handling null values for postgresql in binary mode

### DIFF
--- a/CHANGELOG_DEV.md
+++ b/CHANGELOG_DEV.md
@@ -1,3 +1,6 @@
+# 0.94.0 - 2022-10-13
+- Improve handling binary format of prepared statements for PostgreSQL with null values in Bind packets.
+
 # 0.94.0 - 2022-10-05
 - Refactored integration tests. Improved finalizing socket connections in AsyncpgExecutor. Allow to run tests with databases accessible via domain name not only localhost.
 - Added additional certificates for integration tests in buildbot runner.

--- a/decryptor/postgresql/utils.go
+++ b/decryptor/postgresql/utils.go
@@ -512,10 +512,15 @@ func writeParameterArray(buf *bytes.Buffer, parameters [][]byte) (int, error) {
 	}
 	binary.BigEndian.PutUint16(tmp[0:2], uint16(len(parameters)))
 	buf.Write(tmp[0:2])
-
 	for _, parameter := range parameters {
 		if len(parameter) > math.MaxUint32 {
 			return 0, ErrArrayTooBig
+		}
+		if parameter == nil {
+			// -1 is NULL value, 0xffffff is -1 in uint32
+			binary.BigEndian.PutUint32(tmp[0:4], math.MaxUint32)
+			buf.Write(tmp[0:4])
+			continue
 		}
 		binary.BigEndian.PutUint32(tmp[0:4], uint32(len(parameter)))
 		buf.Write(tmp[0:4])

--- a/decryptor/postgresql/utils_test.go
+++ b/decryptor/postgresql/utils_test.go
@@ -62,3 +62,59 @@ func TestParseCommand(t *testing.T) {
 		t.Fatal("parsed and marshaled data not equal")
 	}
 }
+
+func TestWriteParameterArrayEmptyString(t *testing.T) {
+	buffer := bytes.Buffer{}
+	bindValue, err := hex.DecodeString(`0000000100000001000000000000`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bindPacket, err := NewBindPacket(bindValue)
+	if err != nil {
+		t.Fatal(err)
+	}
+	length, err := writeParameterArray(&buffer, bindPacket.paramValues)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if length != 6 {
+		t.Fatal(err)
+	}
+	// 1 parameter
+	if !bytes.Equal(buffer.Bytes()[:2], []byte{0, 1}) {
+		t.Fatal("Unexpected length of parameters")
+	}
+
+	// one parameter with empty string
+	if !bytes.Equal(buffer.Bytes()[2:], []byte{0, 0, 0, 0}) {
+		t.Fatal("Empty")
+	}
+}
+
+func TestWriteParameterArrayNullValue(t *testing.T) {
+	buffer := bytes.Buffer{}
+	bindValue, err := hex.DecodeString(`0000000100000001ffffffff0000`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bindPacket, err := NewBindPacket(bindValue)
+	if err != nil {
+		t.Fatal(err)
+	}
+	length, err := writeParameterArray(&buffer, bindPacket.paramValues)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if length != 6 {
+		t.Fatal(err)
+	}
+	// 1 parameter
+	if !bytes.Equal(buffer.Bytes()[:2], []byte{0, 1}) {
+		t.Fatal("Unexpected length of parameters")
+	}
+
+	// one parameter with null value as -1 or 0xffffffff
+	if !bytes.Equal(buffer.Bytes()[2:], []byte{255, 255, 255, 255}) {
+		t.Fatal("Empty")
+	}
+}

--- a/tests/test.py
+++ b/tests/test.py
@@ -9283,6 +9283,7 @@ class TestPostgresqlTextFormatTypeAwareDecryptionWithDefaults(BaseTransparentEnc
                 continue
             if 'empty' in column:
                 self.assertEqual(row[column], '')
+                self.assertEqual(row[column], data[column])
                 continue
             self.assertNotEqual(data[column], row[column])
             if column in ('value_int32', 'value_int64'):
@@ -9443,21 +9444,18 @@ class TestPostgresqlBinaryFormatTypeAwareDecryptionWithDefaults(
             .where(self.test_table.c.id == sa.bindparam('id')), {'id': data['id']})
         row = self.executor1.execute_prepared_statement(query, args)[0]
         for column in columns:
-            if 'null' in column:
-                # asyncpg decodes None values as empty str/bytes value
-                self.assertFalse(row[column])
-                continue
             self.assertEqual(data[column], row[column])
             self.assertIsInstance(row[column], type(data[column]))
 
         row = self.executor2.execute_prepared_statement(query, args)[0]
         for column in columns:
             if 'null' in column:
-                # asyncpg decodes None values as empty str/bytes value
-                self.assertFalse(row[column])
+                self.assertIsNone(row[column])
+                self.assertIsNone(data[column])
                 continue
             if 'empty' in column:
                 self.assertEqual(data[column], row[column])
+                self.assertEqual(data[column], '')
             else:
                 self.assertNotEqual(data[column], row[column])
                 self.assertEqual(row[column], default_expected_values[column])
@@ -9465,9 +9463,13 @@ class TestPostgresqlBinaryFormatTypeAwareDecryptionWithDefaults(
 
         row = self.executor2.execute_prepared_statement(query, args)[0]
         for column in columns:
-            if 'null' in column or 'empty' in column:
-                # asyncpg decodes None values as empty str/bytes value
-                self.assertFalse(row[column])
+            if 'null' in column:
+                self.assertIsNone(row[column])
+                self.assertEqual(data[column], row[column])
+                continue
+            if 'empty' in column:
+                self.assertEqual(row[column], '')
+                self.assertEqual(row[column], data[column])
                 continue
             self.assertNotEqual(data[column], row[column])
 
@@ -9520,9 +9522,12 @@ class TestMySQLBinaryFormatTypeAwareDecryptionWithDefaults(TestMySQLTextFormatTy
 
         for column in columns:
             if 'empty' in column:
-                self.assertEqual(data[column], row[column])
+                self.assertEqual(row[column], '')
+                self.assertEqual(row[column], data[column])
+                continue
             elif 'null' in column:
                 self.assertEqual(data[column], row[column])
+                self.assertIsNone(data[column])
             else:
                 self.assertNotEqual(data[column], row[column])
                 self.assertEqual(default_expected_values[column], row[column])
@@ -9596,11 +9601,14 @@ class TestPostgresqlTextTypeAwareDecryptionWithoutDefaults(BaseTransparentEncryp
                 .where(self.test_table.c.id == data['id']))
         row = result.fetchone()
         for column in columns:
-            if 'null' in column or 'empty' in column:
-                # asyncpg decodes None values as empty str/bytes value
-                self.assertFalse(row[column])
+            if 'null' in column:
+                self.assertIsNone(row[column])
+                self.assertEqual(row[column], data[column])
                 continue
             value = utils.memoryview_to_bytes(row[column])
+            if 'empty' in column:
+                self.assertEqual(value, b'')
+                continue
             self.assertIsInstance(value, bytes, column)
             self.assertNotEqual(data[column], value, column)
 
@@ -9760,13 +9768,17 @@ class TestPostgresqlBinaryTypeAwareDecryptionWithoutDefaults(TestPostgresqlBinar
 
         row = self.raw_executor.execute_prepared_statement(query, args)[0]
         for column in columns:
-            if 'null' in column or 'empty' in column:
-                # asyncpg decodes None values as empty str/bytes value
-                self.assertFalse(row[column])
+            if 'null' in column:
+                self.assertIsNone(row[column])
+                self.assertEqual(row[column], data[column])
                 continue
             value = utils.memoryview_to_bytes(row[column])
+            if 'empty' in column:
+                self.assertEqual(value, b'')
+                continue
             self.assertIsInstance(value, bytes, column)
             self.assertNotEqual(data[column], value, column)
+
 
 class TestPostgresqlBinaryTypeAwareDecryptionWithError(TestPostgresqlBinaryFormatTypeAwareDecryptionWithDefaults):
     # test table used for queries and data mapping into python types
@@ -9838,11 +9850,14 @@ class TestPostgresqlBinaryTypeAwareDecryptionWithError(TestPostgresqlBinaryForma
 
         row = self.raw_executor.execute_prepared_statement(query, args)[0]
         for column in columns:
-            if 'null' in column or 'empty' in column:
-                # asyncpg decodes None values as empty str/bytes value
-                self.assertFalse(row[column])
+            if 'null' in column:
+                self.assertIsNone(row[column])
+                self.assertEqual(row[column], data[column])
                 continue
             value = utils.memoryview_to_bytes(row[column])
+            if 'empty' in column:
+                self.assertEqual(value, b'')
+                continue
             self.assertIsInstance(value, bytes, column)
             self.assertNotEqual(data[column], value, column)
 
@@ -9915,11 +9930,14 @@ class TestPostgresqlTextTypeAwareDecryptionWithError(BaseTransparentEncryption):
                 .where(self.test_table.c.id == data['id']))
         row = result.fetchone()
         for column in columns:
-            if 'null' in column or 'empty' in column:
-                # asyncpg decodes None values as empty str/bytes value
-                self.assertFalse(row[column])
+            if 'null' in column:
+                self.assertIsNone(row[column])
+                self.assertEqual(row[column], data[column])
                 continue
             value = utils.memoryview_to_bytes(row[column])
+            if 'empty' in column:
+                self.assertEqual(value, b'')
+                continue
             self.assertIsInstance(value, bytes, column)
             self.assertNotEqual(data[column], value, column)
 
@@ -9993,13 +10011,17 @@ class TestPostgresqlBinaryTypeAwareDecryptionWithCiphertext(TestPostgresqlBinary
 
         row = self.raw_executor.execute_prepared_statement(query, args)[0]
         for column in columns:
-            if 'null' in column or 'empty' in column:
-                # asyncpg decodes None values as empty str/bytes value
-                self.assertFalse(row[column])
+            if 'null' in column:
+                self.assertIsNone(row[column])
+                self.assertEqual(row[column], data[column])
                 continue
             value = utils.memoryview_to_bytes(row[column])
+            if 'empty' in column:
+                self.assertEqual(value, b'')
+                continue
             self.assertIsInstance(value, bytes, column)
             self.assertNotEqual(data[column], value, column)
+
 
 # `response_on_fail` is `ciphertext` if not defined. That's why the code is
 # exactly the same as inTestPostgresqlTextTypeAwareDecryptionWithoutDefaults
@@ -10069,11 +10091,14 @@ class TestPostgresqlTextTypeAwareDecryptionWithCiphertext(BaseTransparentEncrypt
                 .where(self.test_table.c.id == data['id']))
         row = result.fetchone()
         for column in columns:
-            if 'null' in column or 'empty' in column:
-                # asyncpg decodes None values as empty str/bytes value
-                self.assertFalse(row[column])
+            if 'null' in column:
+                self.assertIsNone(row[column])
+                self.assertEqual(row[column], data[column])
                 continue
             value = utils.memoryview_to_bytes(row[column])
+            if 'empty' in column:
+                self.assertEqual(value, b'')
+                continue
             self.assertIsInstance(value, bytes, column)
             self.assertNotEqual(data[column], value, column)
 


### PR DESCRIPTION
Previously we missed the logic of handling NULL values which should be encoded differently than empty strings. We encoded them as empty strings instead of placing `-1` value according to [wire protocol](https://www.postgresql.org/docs/current/protocol-message-formats.html)
This should fix #591.

## Checklist

- [+] Change is covered by automated tests
- [+] The [coding guidelines] are followed
- [+] Public API has proper documentation in the [Acra documentation] site or has PR on [documentation repository] 
  with new changes
- [+] CHANGELOG.md is updated (in case of notable or breaking changes)
- [+] CHANGELOG_DEV.md is updated
- [+] Benchmark results are attached (if applicable)
- [+] [Example projects and code samples] are up-to-date (in case of API changes) 

[coding guidelines]: https://golang.org/doc/effective_go
[Example projects and code samples]: https://github.com/cossacklabs/acra-engineering-demo
[Acra documentation]: https://docs.cossacklabs.com/
[documentation repository]: https://github.com/cossacklabs/product-docs