### PR TITLE
Fixed bug with matching default table with alias

### DIFF
--- a/encryptor/queryDataEncryptor.go
+++ b/encryptor/queryDataEncryptor.go
@@ -352,7 +352,7 @@ func (encryptor *QueryDataEncryptor) OnColumn(ctx context.Context, data []byte) 
 const allColumnsName = "*"
 
 func (encryptor *QueryDataEncryptor) onSelect(ctx context.Context, statement *sqlparser.Select) (bool, error) {
-	columns, err := mapColumnsToAliases(statement)
+	columns, err := mapColumnsToAliases(statement, encryptor.schemaStore)
 	if err != nil {
 		logrus.WithError(err).Errorln("Can't extract columns from SELECT statement")
 		return false, err

--- a/encryptor/searchable_query_filter.go
+++ b/encryptor/searchable_query_filter.go
@@ -96,7 +96,7 @@ func (filter *SearchableQueryFilter) filterInterestingTables(fromExp sqlparser.T
 	var defaultTableName string
 	// if query contains table without alias we need to detect default table
 	// if no, we can ignore default table and AliasToTableMap will be used to map ColName with encryptor_config
-	if filter.hasTablesWithoutAliases(fromExp) {
+	if hasTablesWithoutAliases(fromExp) {
 		var err error
 		defaultTableName, err = getFirstTableWithoutAlias(fromExp)
 		if err != nil {
@@ -232,23 +232,6 @@ func isSupportedSQLVal(val *sqlparser.SQLVal) bool {
 		return true
 	}
 	return false
-}
-
-func (filter *SearchableQueryFilter) hasTablesWithoutAliases(stmt sqlparser.SQLNode) bool {
-	var hasTableWithoutAlias bool
-	err := sqlparser.Walk(func(node sqlparser.SQLNode) (kontinue bool, err error) {
-		if tableExpr, ok := node.(*sqlparser.AliasedTableExpr); ok {
-			if tableExpr.As.IsEmpty() {
-				hasTableWithoutAlias = true
-			}
-		}
-		return true, nil
-	}, stmt)
-	if err != nil {
-		return false
-	}
-
-	return hasTableWithoutAlias
 }
 
 // getEqualComparisonExprs return only <ColName> = <VALUE> or <ColName> != <VALUE> or <ColName> <=> <VALUE> expressions

--- a/encryptor/utils.go
+++ b/encryptor/utils.go
@@ -354,7 +354,7 @@ func findTableName(alias, columnName string, expr sqlparser.SQLNode) (columnInfo
 	return columnInfo{}, errNotFoundtable
 }
 
-func mapColumnsToAliases(selectQuery *sqlparser.Select, tableSchemaStore config.mapColumnsToAliases) ([]*columnInfo, error) {
+func mapColumnsToAliases(selectQuery *sqlparser.Select, tableSchemaStore config.TableSchemaStore) ([]*columnInfo, error) {
 	out := make([]*columnInfo, 0, len(selectQuery.SelectExprs))
 	var joinTables []string
 	var joinAliases map[string]string

--- a/encryptor/utils.go
+++ b/encryptor/utils.go
@@ -214,7 +214,7 @@ func getMatchedAliasedTable(fromExpr sqlparser.TableExprs, colName *sqlparser.Co
 			}
 
 			if alisedName != "" {
-				logrus.WithField("alias", alisedName).Infoln(errTableAlreadyMatched.Error())
+				logrus.WithField("alias", alisedName).Infoln("Ambiguous column found, several tables contain the same column")
 				return "", errTableAlreadyMatched
 			}
 

--- a/encryptor/utils_test.go
+++ b/encryptor/utils_test.go
@@ -1,7 +1,6 @@
 package encryptor
 
 import (
-	"github.com/cossacklabs/acra/sqlparser/dialect/postgresql"
 	"testing"
 
 	"github.com/cossacklabs/acra/decryptor/base/mocks"
@@ -9,6 +8,7 @@ import (
 	"github.com/cossacklabs/acra/sqlparser"
 	"github.com/cossacklabs/acra/sqlparser/dialect"
 	"github.com/cossacklabs/acra/sqlparser/dialect/mysql"
+	"github.com/cossacklabs/acra/sqlparser/dialect/postgresql"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -89,7 +89,7 @@ inner join table6 on table6.col1=t1.col1
 		if !ok {
 			t.Fatal("Test query should be Select expression")
 		}
-		columns, err := mapColumnsToAliases(selectExpr)
+		columns, err := mapColumnsToAliases(selectExpr, &config.MapTableSchemaStore{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -108,35 +108,91 @@ inner join table6 on table6.col1=t1.col1
 		}
 	})
 	t.Run("with aliased table and non-aliased colum name", func(t *testing.T) {
+		testConfig := `
+schemas:
+  - table: users
+    columns:
+      - id
+      - email
+      - mobile_number
+    encrypted:
+      - column: id
+
+  - table: users_duplicate
+    columns:
+      - id
+      - email
+      - mobile_number
+    encrypted:
+      - column: id
+
+  - table: users_temp
+    columns:
+      - id_tmp
+      - email_tmp
+      - mobile_number_tmp
+    encrypted:
+      - column: id_tmp
+`
+		schemaStore, err := config.MapTableSchemaStoreFromConfig([]byte(testConfig))
+		if err != nil {
+			t.Fatal(err)
+		}
+
 		testcases := []struct {
-			query   string
-			dialect dialect.Dialect
+			query          string
+			dialect        dialect.Dialect
+			expectedValues []*columnInfo
 		}{
 			{
-				query:   `SELECT "id", "email", "mobile_number" AS "mobileNumber" FROM "users" AS "User" where "User"."is_active"`,
-				dialect: postgresql.NewPostgreSQLDialect(),
+				query: `SELECT "id", "email", "mobile_number" AS "mobileNumber" FROM "users" AS "User" where "User"."is_active"`,
+				expectedValues: []*columnInfo{
+					{Alias: "User", Table: "users", Name: "id"},
+					{Alias: "User", Table: "users", Name: "email"},
+					{Alias: "User", Table: "users", Name: "mobile_number"},
+				},
 			},
 			{
-				query:   `SELECT id, email, mobile_number FROM table1 AS alias where alias.is_active`,
+				query: `SELECT "id", "email", "mobile_number" AS "mobileNumber" FROM "users" AS "User", "table1" as "test_table"`,
+				expectedValues: []*columnInfo{
+					{Alias: "User", Table: "users", Name: "id"},
+					{Alias: "User", Table: "users", Name: "email"},
+					{Alias: "User", Table: "users", Name: "mobile_number"},
+				},
+			},
+			{
+				query: `SELECT "id", "email", "mobile_number" AS "mobileNumber" FROM "users" AS "User", "users_duplicate" as "User2"`,
+				expectedValues: []*columnInfo{
+					nil, nil, nil,
+				},
+			},
+			{
+				query: `SELECT "id", "email", "mobile_number", "id_tmp", "email_tmp", "mobile_number_tmp"  AS "mobileNumber" FROM "users" AS "User", "users_temp" as "temp"`,
+				expectedValues: []*columnInfo{
+					{Alias: "User", Table: "users", Name: "id"},
+					{Alias: "User", Table: "users", Name: "email"},
+					{Alias: "User", Table: "users", Name: "mobile_number"},
+					{Alias: "temp", Table: "users_temp", Name: "id_tmp"},
+					{Alias: "temp", Table: "users_temp", Name: "email_tmp"},
+					{Alias: "temp", Table: "users_temp", Name: "mobile_number_tmp"},
+				},
+			},
+			{
+				query:   `SELECT id, email, mobile_number FROM users AS alias where alias.is_active`,
 				dialect: mysql.NewMySQLDialect(),
+				expectedValues: []*columnInfo{
+					{Alias: "alias", Table: "users", Name: "id"},
+					{Alias: "alias", Table: "users", Name: "email"},
+					{Alias: "alias", Table: "users", Name: "mobile_number"},
+				},
 			},
 		}
-
-		expectedValues := [][]columnInfo{
-			{
-				{Alias: "User", Table: "users", Name: "id"},
-				{Alias: "User", Table: "users", Name: "email"},
-				{Alias: "User", Table: "users", Name: "mobile_number"},
-			},
-			{
-				{Alias: "alias", Table: "table1", Name: "id"},
-				{Alias: "alias", Table: "table1", Name: "email"},
-				{Alias: "alias", Table: "table1", Name: "mobile_number"},
-			},
-		}
-
 		for i, tcase := range testcases {
-			sqlparser.SetDefaultDialect(tcase.dialect)
+			var dialect dialect.Dialect = postgresql.NewPostgreSQLDialect()
+			if tcase.dialect != nil {
+				dialect = tcase.dialect
+			}
+			sqlparser.SetDefaultDialect(dialect)
 
 			parsed, err := parser.Parse(tcase.query)
 			if err != nil {
@@ -146,21 +202,24 @@ inner join table6 on table6.col1=t1.col1
 			if !ok {
 				t.Fatal("Test query should be Select expression")
 			}
-			columns, err := mapColumnsToAliases(selectExpr)
+			columns, err := mapColumnsToAliases(selectExpr, schemaStore)
 			if err != nil {
 				t.Fatal(err)
 			}
-			if len(columns) != len(expectedValues[i]) {
+			if len(columns) != len(tcase.expectedValues) {
 				t.Fatal("Returned incorrect length of values")
 			}
 
 			for y, column := range columns {
 				if column == nil {
-					t.Fatalf("[%d] Column info not found", i)
+					if tcase.expectedValues[y] != nil {
+						t.Fatalf("[%d] expected nil column value ", i)
+					}
+					continue
 				}
 
-				if *column != expectedValues[i][y] {
-					t.Fatalf("[%d] Column info is not equal to expected - %+v, actual - %+v", i, expectedValues[i], *column)
+				if *column != *tcase.expectedValues[y] {
+					t.Fatalf("[%d] Column info is not equal to expected - %+v, actual - %+v", i, tcase.expectedValues[i], *column)
 				}
 			}
 		}
@@ -230,7 +289,7 @@ inner join table6 on table6.col1=t1.col1
 				t.Fatal("Test query should be Select expression")
 			}
 
-			columns, err := mapColumnsToAliases(selectExpr)
+			columns, err := mapColumnsToAliases(selectExpr, &config.MapTableSchemaStore{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -288,7 +347,7 @@ inner join table6 on table6.col1=t1.col1
 				t.Fatal("Test query should be Select expression")
 			}
 
-			columns, err := mapColumnsToAliases(selectExpr)
+			columns, err := mapColumnsToAliases(selectExpr, &config.MapTableSchemaStore{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -323,7 +382,7 @@ inner join table6 on table6.col1=t1.col1
 
 		expectedValue := columnInfo{Alias: "*", Table: "test_table", Name: "*"}
 
-		columns, err := mapColumnsToAliases(selectExpr)
+		columns, err := mapColumnsToAliases(selectExpr, &config.MapTableSchemaStore{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -369,7 +428,7 @@ inner join table6 on table6.col1=t1.col1
 				t.Fatal("Test query should be Select expression")
 			}
 
-			columns, err := mapColumnsToAliases(selectExpr)
+			columns, err := mapColumnsToAliases(selectExpr, &config.MapTableSchemaStore{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -407,7 +466,7 @@ inner join table6 on table6.col1=t1.col1
 			{Alias: allColumnsName, Table: "test_table", Name: allColumnsName},
 		}
 
-		columns, err := mapColumnsToAliases(selectExpr)
+		columns, err := mapColumnsToAliases(selectExpr, &config.MapTableSchemaStore{})
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Currently, Acra expects that columns in `SELECT` statement haven't been aliased if FROM has a non-aliased table or they should have proper alias. But databases allow specific alias for table but use columns without an alias.

So if the query contains Columns without aliases and the table is aliased, Acra should consider this table as default. Added checking for containing aliases in tables expressions and switch between extracting tables functions depending on queries.

## Checklist

- [ ] Change is covered by automated tests
- [ ] The [coding guidelines] are followed
- [ ] Public API has proper documentation in the [Acra documentation] site or has PR on [documentation repository] 
  with new changes
- [ ] CHANGELOG.md is updated (in case of notable or breaking changes)
- [ ] CHANGELOG_DEV.md is updated
- [ ] Benchmark results are attached (if applicable)
- [ ] [Example projects and code samples] are up-to-date (in case of API changes) 

[coding guidelines]: https://golang.org/doc/effective_go
[Example projects and code samples]: https://github.com/cossacklabs/acra-engineering-demo
[Acra documentation]: https://docs.cossacklabs.com/
[documentation repository]: https://github.com/cossacklabs/product-docs