### PR TITLE
Downgrade boto3 version to 1.23.10

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -20,5 +20,5 @@ unittest-xml-reporting==3.0.4
 cryptography==3.4.7
 redis==4.0.1
 hiredis==2.0.0
-boto3==1.24.23
+boto3==1.23.10
 python-consul==1.1.0


### PR DESCRIPTION
Downgrade `boto3` version to `1.23.10` to match with Centos7/8 available versions

<!-- Describe your changes here -->

## Checklist

- [ ] Change is covered by automated tests
- [ ] The [coding guidelines] are followed
- [ ] Public API has proper documentation in the [Acra documentation] site or has PR on [documentation repository] 
  with new changes
- [ ] CHANGELOG.md is updated (in case of notable or breaking changes)
- [ ] CHANGELOG_DEV.md is updated
- [ ] Benchmark results are attached (if applicable)
- [ ] [Example projects and code samples] are up-to-date (in case of API changes) 

[coding guidelines]: https://golang.org/doc/effective_go
[Example projects and code samples]: https://github.com/cossacklabs/acra-engineering-demo
[Acra documentation]: https://docs.cossacklabs.com/
[documentation repository]: https://github.com/cossacklabs/product-docs