### PR TITLE
Adapt tests for centos7 environment

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,7 @@
 pythemis
 psycopg2==2.8.6
-psycopg==3.0.13
+# only this supported on centos 7 due to problems with version of libpq
+psycopg[binary]==3.0.13
 asyncpg==0.23.0
 SQLAlchemy==1.4.15
 PyMySQL==1.0.2

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,7 +1,7 @@
 pythemis
 psycopg2==2.8.6
 # only this supported on centos 7 due to problems with version of libpq
-psycopg[binary]==3.0.13
+psycopg[binary]==3.0.18
 asyncpg==0.23.0
 SQLAlchemy==1.4.15
 PyMySQL==1.0.2

--- a/tests/test.py
+++ b/tests/test.py
@@ -11466,7 +11466,10 @@ class TestSigHUPHandler(AcraTranslatorMixin, BaseTestCase):
 
     def copy_keystore(self):
         new_keystore = tempfile.mkdtemp()
-        return shutil.copytree(KEYS_FOLDER.name, new_keystore, dirs_exist_ok=True)
+        # we don't use shutil.copytree(..., dirs_exist_ok=True) due to unsupported in default python on centos 7, 8
+        # so we remove folder and then copy
+        shutil.rmtree(new_keystore)
+        return shutil.copytree(KEYS_FOLDER.name, new_keystore)
 
     def find_forked_pid(self, filepath):
         with open(filepath, 'r') as f:


### PR DESCRIPTION
Here are several updates to simplify running tests on centos 7/8 which uses python 3.6.8. Replaces `shutil` to simplified version and used pre-compiled psycopg2 due to problems with postgresql-devel packages on centos and building pyscopg2 from sources. For us no difference in where to get psycopg2 for tests.

## Checklist

- [ ] Change is covered by automated tests
- [ ] The [coding guidelines] are followed
- [ ] Public API has proper documentation in the [Acra documentation] site or has PR on [documentation repository] 
  with new changes
- [ ] CHANGELOG.md is updated (in case of notable or breaking changes)
- [ ] CHANGELOG_DEV.md is updated
- [ ] Benchmark results are attached (if applicable)
- [ ] [Example projects and code samples] are up-to-date (in case of API changes) 

[coding guidelines]: https://golang.org/doc/effective_go
[Example projects and code samples]: https://github.com/cossacklabs/acra-engineering-demo
[Acra documentation]: https://docs.cossacklabs.com/
[documentation repository]: https://github.com/cossacklabs/product-docs