### PR TITLE
Fix phantom search with JOIN tests

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -7324,7 +7324,7 @@ class TestSearchableTransparentEncryptionWithJOINs(BaseSearchableTransparentEncr
             ).
             join(self.encryptor_table_join, self.encryptor_table_join.c.searchable==sa.bindparam('searchable')).
             where(self.encryptor_table.c.searchable == sa.bindparam('searchable')),
-            {'searchable': get_pregenerated_random_data().encode('utf-8')})
+            {'searchable': 'invalid-search-term'.encode('utf-8')})
         self.assertEqual(len(rows), 0)
 
         rows = self.executeSelect2(


### PR DESCRIPTION
Change `search-term` to a hardcoded invalid one instead of generating random_data.

<!-- Describe your changes here -->

## Checklist

- [ ] Change is covered by automated tests
- [ ] The [coding guidelines] are followed
- [ ] Public API has proper documentation in the [Acra documentation] site or has PR on [documentation repository] 
  with new changes
- [ ] CHANGELOG.md is updated (in case of notable or breaking changes)
- [ ] CHANGELOG_DEV.md is updated
- [ ] Benchmark results are attached (if applicable)
- [ ] [Example projects and code samples] are up-to-date (in case of API changes) 

[coding guidelines]: https://golang.org/doc/effective_go
[Example projects and code samples]: https://github.com/cossacklabs/acra-engineering-demo
[Acra documentation]: https://docs.cossacklabs.com/
[documentation repository]: https://github.com/cossacklabs/product-docs