### PR TITLE
Fix search with aliased table

### DIFF
--- a/encryptor/searchable_query_filter.go
+++ b/encryptor/searchable_query_filter.go
@@ -63,65 +63,24 @@ func (filter *SearchableQueryFilter) FilterSearchableComparisons(statement sqlpa
 		return nil
 	}
 
-	defaultTable, aliasedTables := filter.filterInterestingTables(tableExps)
-	if len(aliasedTables) == 0 {
-		logrus.Debugln("No encryptable tables in search query")
+	// Walk through WHERE clauses of a SELECT statements...
+	whereExprs, err := getWhereStatements(statement)
+	if err != nil {
+		logrus.WithError(err).Debugln("Failed to extract WHERE clauses")
 		return nil
 	}
 
-	// Now take a closer look at WHERE clauses of the statement. We need only expressions
-	// which are simple equality comparisons, like "WHERE column = value".
-	exprs := filter.filterComparisonExprs(statement, defaultTable, aliasedTables)
-	if len(exprs) == 0 {
-		logrus.Debugln("No eligible comparisons in search query")
-		return nil
-	}
-	// And among those expressions, not all may refer to columns with searchable encryption
-	// enabled for them. Leave only those expressions which are searchable.
-	searchableExprs := filter.filterComparisons(exprs, defaultTable, aliasedTables)
-	if len(exprs) == 0 {
-		logrus.Debugln("No searchable comparisons in search query")
-		return nil
-	}
-	return searchableExprs
-}
-
-func (filter *SearchableQueryFilter) filterInterestingTables(fromExp sqlparser.TableExprs) (*AliasedTableName, AliasToTableMap) {
-	// Not all SELECT statements refer to tables at all.
-	tables := GetTablesWithAliases(fromExp)
-	if len(tables) == 0 {
-		return nil, nil
-	}
-
-	var defaultTable *AliasedTableName
-	var defaultTableName string
-	// if query contains table without alias we need to detect default table
-	// if no, we can ignore default table and AliasToTableMap will be used to map ColName with encryptor_config
-	if hasTablesWithoutAliases(fromExp) {
-		var err error
-		defaultTableName, err = getFirstTableWithoutAlias(fromExp)
+	var searchableExprs []SearchableExprItem
+	for _, whereExpr := range whereExprs {
+		comparisonExprs, err := filter.filterColumnEqualComparisonExprs(whereExpr, tableExps)
 		if err != nil {
-			logrus.WithError(err).Debugln("Failed to find first table without alias")
-			return nil, nil
+			logrus.WithError(err).Debugln("Failed to extract comparison expressions")
+			return nil
 		}
+		searchableExprs = append(searchableExprs, comparisonExprs...)
 	}
 
-	// And even then, we can work only with tables that we have an encryption schema for.
-	var encryptableTables []*AliasedTableName
-
-	for _, table := range tables {
-		if defaultTableName == table.TableName.Name.ValueForConfig() {
-			defaultTable = table
-		}
-
-		if v := filter.schemaStore.GetTableSchema(table.TableName.Name.ValueForConfig()); v != nil {
-			encryptableTables = append(encryptableTables, table)
-		}
-	}
-	if len(encryptableTables) == 0 {
-		return nil, nil
-	}
-	return defaultTable, NewAliasToTableMapFromTables(encryptableTables)
+	return searchableExprs
 }
 
 func (filter *SearchableQueryFilter) filterTableExpressions(statement sqlparser.Statement) (sqlparser.TableExprs, error) {
@@ -143,71 +102,14 @@ func (filter *SearchableQueryFilter) filterTableExpressions(statement sqlparser.
 	}
 }
 
-func (filter *SearchableQueryFilter) filterComparisonExprs(statement sqlparser.Statement, defaultTable *AliasedTableName, aliasedTables AliasToTableMap) []*sqlparser.ComparisonExpr {
-	// Walk through WHERE clauses of a SELECT statements...
-	whereExprs, err := getWhereStatements(statement)
-	if err != nil {
-		logrus.WithError(err).Debugln("Failed to extract WHERE clauses")
-		return nil
-	}
-	// ...and find all eligible comparison expressions in them.
-	var exprs []*sqlparser.ComparisonExpr
-	for _, whereExpr := range whereExprs {
-		comparisonExprs, err := filter.getColumnEqualComparisonExprs(whereExpr, defaultTable, aliasedTables)
-		if err != nil {
-			logrus.WithError(err).Debugln("Failed to extract comparison expressions")
-			return nil
-		}
-		exprs = append(exprs, comparisonExprs...)
-	}
-	return exprs
-}
-
-func (filter *SearchableQueryFilter) filterComparisons(exprs []*sqlparser.ComparisonExpr, defaultTable *AliasedTableName, aliasedTables AliasToTableMap) []SearchableExprItem {
-	filtered := make([]SearchableExprItem, 0, len(exprs))
-	for _, expr := range exprs {
-		// Leave out comparisons of columns which do not have a schema after alias resolution.
-		column := expr.Left.(*sqlparser.ColName)
-		schema := filter.getTableSchemaOfColumn(column, defaultTable, aliasedTables)
-		if schema == nil {
-			continue
-		}
-		// Also leave out those columns which are not searchable.
-		columnName := column.Name.String()
-		encryptionSetting := schema.GetColumnEncryptionSettings(columnName)
-
-		if encryptionSetting == nil {
-			continue
-		}
-
-		isComparableSetting := encryptionSetting.IsSearchable()
-		if filter.mode == QueryFilterModeConsistentTokenization {
-			isComparableSetting = encryptionSetting.IsConsistentTokenization()
-		}
-
-		if isComparableSetting {
-			filtered = append(filtered, SearchableExprItem{Expr: expr, Setting: encryptionSetting})
-		}
-	}
-	return filtered
-}
-
-func (filter *SearchableQueryFilter) getColumnSetting(column *sqlparser.ColName, defaultTable *AliasedTableName, aliasedTables AliasToTableMap) config.ColumnEncryptionSetting {
-	schema := filter.getTableSchemaOfColumn(column, defaultTable, aliasedTables)
+func (filter *SearchableQueryFilter) getColumnSetting(column *sqlparser.ColName, columnInfo columnInfo) config.ColumnEncryptionSetting {
+	schema := filter.schemaStore.GetTableSchema(columnInfo.Table)
 	if schema == nil {
 		return nil
 	}
 	// Also leave out those columns which are not searchable.
 	columnName := column.Name.ValueForConfig()
 	return schema.GetColumnEncryptionSettings(columnName)
-}
-
-func (filter *SearchableQueryFilter) getTableSchemaOfColumn(column *sqlparser.ColName, defaultTable *AliasedTableName, aliasedTables AliasToTableMap) config.TableSchema {
-	if column.Qualifier.Qualifier.IsEmpty() && column.Qualifier.Name.IsEmpty() {
-		return filter.schemaStore.GetTableSchema(defaultTable.TableName.Name.ValueForConfig())
-	}
-	tableName := aliasedTables[column.Qualifier.Name.ValueForConfig()]
-	return filter.schemaStore.GetTableSchema(tableName)
 }
 
 func getWhereStatements(stmt sqlparser.Statement) ([]*sqlparser.Where, error) {
@@ -235,48 +137,73 @@ func isSupportedSQLVal(val *sqlparser.SQLVal) bool {
 	return false
 }
 
-// getColumnEqualComparisonExprs return only <ColName> = <VALUE> or <ColName> != <VALUE> or <ColName> <=> <VALUE> expressions
-func (filter *SearchableQueryFilter) getColumnEqualComparisonExprs(stmt sqlparser.SQLNode, defaultTable *AliasedTableName, aliasedTables AliasToTableMap) ([]*sqlparser.ComparisonExpr, error) {
-	var exprs []*sqlparser.ComparisonExpr
+// filterColumnEqualComparisonExprs return only <ColName> = <VALUE> or <ColName> != <VALUE> or <ColName> <=> <VALUE> expressions
+func (filter *SearchableQueryFilter) filterColumnEqualComparisonExprs(stmt sqlparser.SQLNode, tableExpr sqlparser.TableExprs) ([]SearchableExprItem, error) {
+	var exprs []SearchableExprItem
+	var hasTablesWithoutAliases = hasTablesWithoutAliases(tableExpr)
+
 	err := sqlparser.Walk(func(node sqlparser.SQLNode) (kontinue bool, err error) {
-		if comparisonExpr, ok := node.(*sqlparser.ComparisonExpr); ok {
-			lColumn, ok := comparisonExpr.Left.(*sqlparser.ColName)
-			if !ok {
+		comparisonExpr, ok := node.(*sqlparser.ComparisonExpr)
+		if !ok {
+			return true, nil
+		}
+
+		lColumn, ok := comparisonExpr.Left.(*sqlparser.ColName)
+		if !ok {
+			return true, nil
+		}
+
+		columnInfo, err := findColumnInfo(tableExpr, lColumn, filter.schemaStore, hasTablesWithoutAliases)
+		if err != nil {
+			return true, nil
+		}
+
+		lColumnSetting := filter.getColumnSetting(lColumn, columnInfo)
+		if lColumnSetting == nil {
+			return true, nil
+		}
+
+		if !lColumnSetting.IsSearchable() && !lColumnSetting.IsConsistentTokenization() {
+			return true, nil
+		}
+
+		// check if left column isSearchable or consistent tokenized and right column is sqlparser.ColName
+		// we want to log the warn message that searchable tokenization/encryption can work only with <ColName> = <VALUE> statements
+		// however, there is one exception - for searchable encryption it can be the scenario where we have:  join table1 t1 on t1.surname = t2.surname
+		// and if t1 and t2 are tables from encryptor_config and t1.surname and t2.surname are searchable, we want to have: join table1 t1 on substr(t1.surname, ...) = substr(t2.surname, ...)
+		if rColumn, ok := comparisonExpr.Right.(*sqlparser.ColName); ok {
+			// get right columnSetting to check weather it is searchable too
+
+			columnInfo, err := findColumnInfo(tableExpr, rColumn, filter.schemaStore, hasTablesWithoutAliases)
+			if err != nil {
 				return true, nil
 			}
 
-			lColumnSetting := filter.getColumnSetting(lColumn, defaultTable, aliasedTables)
-			if lColumnSetting == nil {
-				return true, nil
-			}
-
-			// check if left column isSearchable or consistent tokenized and right column is sqlparser.ColName
-			// we want to log the warn message that searchable tokenization/encryption can work only with <ColName> = <VALUE> statements
-			// however, there is one exception - for searchable encryption it can be the scenario where we have:  join table1 t1 on t1.surname = t2.surname
-			// and if t1 and t2 are tables from encryptor_config and t1.surname and t2.surname are searchable, we want to have: join table1 t1 on substr(t1.surname, ...) = substr(t2.surname, ...)
-			if lColumnSetting.IsSearchable() || lColumnSetting.IsConsistentTokenization() {
-				if rColumn, ok := comparisonExpr.Right.(*sqlparser.ColName); ok {
-					// get right columnSetting to check weather it is searchable too
-					rColumnSetting := filter.getColumnSetting(rColumn, defaultTable, aliasedTables)
-					if rColumnSetting != nil {
-						if rColumnSetting.IsSearchable() {
-							exprs = append(exprs, comparisonExpr)
-							return true, nil
-						}
-					}
-
-					logrus.Infoln("Searchable encryption/tokenization support equal comparison only by SQLVal but not by ColName")
+			rColumnSetting := filter.getColumnSetting(rColumn, columnInfo)
+			if rColumnSetting != nil {
+				if rColumnSetting.IsSearchable() {
+					exprs = append(exprs, SearchableExprItem{
+						Expr:    comparisonExpr,
+						Setting: rColumnSetting,
+					})
+					return true, nil
 				}
 			}
 
-			if sqlVal, ok := comparisonExpr.Right.(*sqlparser.SQLVal); ok && isSupportedSQLVal(sqlVal) {
-				if comparisonExpr.Operator == sqlparser.EqualStr || comparisonExpr.Operator == sqlparser.NotEqualStr || comparisonExpr.Operator == sqlparser.NullSafeEqualStr {
-					if _, ok := comparisonExpr.Left.(*sqlparser.ColName); ok {
-						exprs = append(exprs, comparisonExpr)
-					}
+			logrus.Infoln("Searchable encryption/tokenization support equal comparison only by SQLVal but not by ColName")
+		}
+
+		if sqlVal, ok := comparisonExpr.Right.(*sqlparser.SQLVal); ok && isSupportedSQLVal(sqlVal) {
+			if comparisonExpr.Operator == sqlparser.EqualStr || comparisonExpr.Operator == sqlparser.NotEqualStr || comparisonExpr.Operator == sqlparser.NullSafeEqualStr {
+				if _, ok := comparisonExpr.Left.(*sqlparser.ColName); ok {
+					exprs = append(exprs, SearchableExprItem{
+						Expr:    comparisonExpr,
+						Setting: lColumnSetting,
+					})
 				}
 			}
 		}
+
 		return true, nil
 	}, stmt)
 	return exprs, err

--- a/tests/test.py
+++ b/tests/test.py
@@ -7855,7 +7855,19 @@ class TestSearchableTokenizationWithoutZone(AcraCatchLogsMixin, BaseTokenization
         self.insert_via_1(default_client_id_table.insert(), data)
         self.insert_via_1(default_client_id_table_join.insert(), data)
 
+        # with aliased column in where statement
         query = 'SELECT id, token_i32, token_i64, token_str, token_email FROM test_tokenization_default_client_id as test_table WHERE test_table.token_i64 = :token_i64'
+        parameters = {'token_i64': data['token_i64']}
+
+        source_data = self.fetch_from_1(sa.text(query), parameters, literal_binds=False)
+        for k in ('token_i32', 'token_i64', 'token_str', 'token_email'):
+            if isinstance(source_data[0][k], (bytearray, bytes)) and isinstance(data[k], str):
+                self.assertEqual(source_data[0][k], data[k].encode('utf-8'))
+            else:
+                self.assertEqual(source_data[0][k], data[k])
+
+        # with non-aliased column in where statement
+        query = 'SELECT id, token_i32, token_i64, token_str, token_email FROM test_tokenization_default_client_id as test_table WHERE token_i64 = :token_i64'
         parameters = {'token_i64': data['token_i64']}
 
         source_data = self.fetch_from_1(sa.text(query), parameters, literal_binds=False)


### PR DESCRIPTION
Bug fixing related to mapping aliased table with config during searchable encryption table filtering.

In the queries like `select ... from some_table as alias where searchable_col = value` if the `some_table` is in encryptor config and searchable_col is not aliased column, Acra panic as default table remains nil and uninitialized. So that the main filtering logic was rewritten and is now based on `findColumnInfo` method that find table name depending on aliased or non-aliased tables in FROM statement and data from encryptor config.

## Checklist

- [x] Change is covered by automated tests
- [ ] The [coding guidelines] are followed
- [ ] Public API has proper documentation in the [Acra documentation] site or has PR on [documentation repository] 
  with new changes
- [ ] CHANGELOG.md is updated (in case of notable or breaking changes)
- [ ] CHANGELOG_DEV.md is updated
- [ ] Benchmark results are attached (if applicable)
- [ ] [Example projects and code samples] are up-to-date (in case of API changes) 

[coding guidelines]: https://golang.org/doc/effective_go
[Example projects and code samples]: https://github.com/cossacklabs/acra-engineering-demo
[Acra documentation]: https://docs.cossacklabs.com/
[documentation repository]: https://github.com/cossacklabs/product-docs