### PR TITLE
Add tests for searchable encryption with NotEqual operator

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -6829,7 +6829,8 @@ class TestSearchableTransparentEncryption(BaseSearchableTransparentEncryption):
 
         # Insert searchable data and some additional different rows
         self.insertRow(context)
-        self.insertDifferentRows(context, count=5)
+        extra_rows_count = 5
+        self.insertDifferentRows(context, count=extra_rows_count)
 
         rows = self.executeSelect2(
             sa.select([self.encryptor_table])
@@ -6840,6 +6841,17 @@ class TestSearchableTransparentEncryption(BaseSearchableTransparentEncryption):
 
         self.checkDefaultIdEncryption(**context)
         self.assertEqual(rows[0]['searchable'], search_term)
+
+        # check not equal
+        rows = self.executeSelect2(
+            sa.select([self.encryptor_table])
+            .where(self.encryptor_table.c.searchable != sa.bindparam('searchable')),
+            {'searchable': search_term},
+            )
+        self.assertEqual(len(rows), extra_rows_count)
+
+        for row in rows:
+            self.assertNotEqual(row['searchable'], search_term)
 
     def testExtendedSyntaxSearch(self):
         context = self.get_context_data()


### PR DESCRIPTION
Found that previously it wasn't supported properly and we haven't tests. After #605 were added support and here added tests.

## Checklist

- [ ] Change is covered by automated tests
- [ ] The [coding guidelines] are followed
- [ ] Public API has proper documentation in the [Acra documentation] site or has PR on [documentation repository] 
  with new changes
- [ ] CHANGELOG.md is updated (in case of notable or breaking changes)
- [ ] CHANGELOG_DEV.md is updated
- [ ] Benchmark results are attached (if applicable)
- [ ] [Example projects and code samples] are up-to-date (in case of API changes) 

[coding guidelines]: https://golang.org/doc/effective_go
[Example projects and code samples]: https://github.com/cossacklabs/acra-engineering-demo
[Acra documentation]: https://docs.cossacklabs.com/
[documentation repository]: https://github.com/cossacklabs/product-docs