### PR TITLE
Apply type awareness actions on failure of hash validation

### DIFF
--- a/decryptor/base/decryptionNotification.go
+++ b/decryptor/base/decryptionNotification.go
@@ -137,9 +137,15 @@ func MarkDecryptedContext(ctx context.Context) context.Context {
 	return context.WithValue(ctx, decryptedCtxKey{}, true)
 }
 
+// MarkNotDecryptedContext save flag in context that data wasn't decrypted
+func MarkNotDecryptedContext(ctx context.Context) context.Context {
+	return context.WithValue(ctx, decryptedCtxKey{}, false)
+}
+
 // IsDecryptedFromContext return true if data was decrypted related to context
 func IsDecryptedFromContext(ctx context.Context) bool {
-	return ctx.Value(decryptedCtxKey{}) != nil
+	val := ctx.Value(decryptedCtxKey{})
+	return val != nil && val.(bool)
 }
 
 type errorConvertedDataTypeCtxKey struct{}

--- a/encryptor/config/encryptionSettings.go
+++ b/encryptor/config/encryptionSettings.go
@@ -109,8 +109,8 @@ var validSettings = map[SettingMask]struct{}{
 	SettingDefaultDataValueFlag | SettingDataTypeFlag | SettingSearchFlag | SettingAcraStructEncryptionFlag | SettingReEncryptionFlag: {},
 	SettingDefaultDataValueFlag | SettingDataTypeFlag | SettingSearchFlag | SettingAcraBlockEncryptionFlag | SettingReEncryptionFlag:  {},
 
-	SettingDefaultDataValueFlag | SettingDataTypeIDFlag | SettingSearchFlag | SettingAcraStructEncryptionFlag | SettingReEncryptionFlag: {},
-	SettingDefaultDataValueFlag | SettingDataTypeIDFlag | SettingSearchFlag | SettingAcraBlockEncryptionFlag | SettingReEncryptionFlag:  {},
+	SettingDefaultDataValueFlag | SettingOnFailFlag | SettingDataTypeIDFlag | SettingSearchFlag | SettingAcraStructEncryptionFlag | SettingReEncryptionFlag: {},
+	SettingDefaultDataValueFlag | SettingOnFailFlag | SettingDataTypeIDFlag | SettingSearchFlag | SettingAcraBlockEncryptionFlag | SettingReEncryptionFlag:  {},
 
 	// specified ClientID
 	SettingSearchFlag | SettingClientIDFlag | SettingAcraStructEncryptionFlag | SettingReEncryptionFlag: {},
@@ -123,11 +123,11 @@ var validSettings = map[SettingMask]struct{}{
 	SettingDataTypeIDFlag | SettingSearchFlag | SettingClientIDFlag | SettingAcraBlockEncryptionFlag | SettingReEncryptionFlag:  {},
 
 	// specified ClientID with data type default
-	SettingDefaultDataValueFlag | SettingDataTypeFlag | SettingSearchFlag | SettingClientIDFlag | SettingAcraStructEncryptionFlag | SettingReEncryptionFlag: {},
-	SettingDefaultDataValueFlag | SettingDataTypeFlag | SettingSearchFlag | SettingClientIDFlag | SettingAcraBlockEncryptionFlag | SettingReEncryptionFlag:  {},
+	SettingDefaultDataValueFlag | SettingDataTypeFlag | SettingSearchFlag | SettingOnFailFlag | SettingClientIDFlag | SettingAcraStructEncryptionFlag | SettingReEncryptionFlag: {},
+	SettingDefaultDataValueFlag | SettingDataTypeFlag | SettingSearchFlag | SettingOnFailFlag | SettingClientIDFlag | SettingAcraBlockEncryptionFlag | SettingReEncryptionFlag:  {},
 
-	SettingDefaultDataValueFlag | SettingDataTypeIDFlag | SettingSearchFlag | SettingClientIDFlag | SettingAcraStructEncryptionFlag | SettingReEncryptionFlag: {},
-	SettingDefaultDataValueFlag | SettingDataTypeIDFlag | SettingSearchFlag | SettingClientIDFlag | SettingAcraBlockEncryptionFlag | SettingReEncryptionFlag:  {},
+	SettingDefaultDataValueFlag | SettingDataTypeIDFlag | SettingSearchFlag | SettingOnFailFlag | SettingClientIDFlag | SettingAcraStructEncryptionFlag | SettingReEncryptionFlag: {},
+	SettingDefaultDataValueFlag | SettingDataTypeIDFlag | SettingSearchFlag | SettingOnFailFlag | SettingClientIDFlag | SettingAcraBlockEncryptionFlag | SettingReEncryptionFlag:  {},
 
 	/////////////
 	// MASKING (should be specified all 3 parameters)

--- a/encryptor/config/schemaStore_test.go
+++ b/encryptor/config/schemaStore_test.go
@@ -749,8 +749,11 @@ schemas:
       - data_bytes
       - data_int32
       - data_int64
+      - data_searchable_str
     encrypted:
       - column: data_str
+        data_type: str
+      - column: data_searchable_str
         data_type: str
       - column: data_bytes
         data_type: bytes
@@ -759,7 +762,7 @@ schemas:
       - column: data_int64
         data_type: int64`},
 
-		{"onFail is 'default_vaue' if explicitly defined",
+		{"onFail is 'default_value' if explicitly defined",
 			common2.ResponseOnFailDefault,
 			`
 schemas:
@@ -769,11 +772,18 @@ schemas:
       - data_bytes
       - data_int32
       - data_int64
+      - data_searchable_str
     encrypted:
       - column: data_str
         data_type: str
         response_on_fail: default_value
         default_data_value: string
+
+      - column: data_searchable_str
+        data_type: str
+        response_on_fail: default_value
+        default_data_value: string
+        searchable: true
 
       - column: data_bytes
         data_type: bytes
@@ -800,8 +810,13 @@ schemas:
       - data_bytes
       - data_int32
       - data_int64
+      - data_searchable_str
     encrypted:
       - column: data_str
+        data_type: str
+        response_on_fail: error
+
+      - column: data_searchable_str
         data_type: str
         response_on_fail: error
 
@@ -827,8 +842,13 @@ schemas:
       - data_bytes
       - data_int32
       - data_int64
+      - data_searchable_str
     encrypted:
     - column: data_str
+      data_type: str
+      default_data_value: string
+
+    - column: data_searchable_str
       data_type: str
       default_data_value: string
 

--- a/hmac/dataProcessor.go
+++ b/hmac/dataProcessor.go
@@ -58,7 +58,7 @@ func (p *Processor) OnColumn(ctx context.Context, data []byte) (context.Context,
 		logger := logging.GetLoggerFromContext(ctx)
 		logger.WithError(err).Debugln("Failed on HMAC processing")
 		p.hashData = nil
-		return ctx, p.rawData, nil
+		return base.MarkNotDecryptedContext(ctx), p.rawData, nil
 	}
 
 	p.matchedHash = ExtractHash(data)

--- a/tests/encryptor_configs/transparent_type_aware_decryption.yaml
+++ b/tests/encryptor_configs/transparent_type_aware_decryption.yaml
@@ -4,6 +4,7 @@ schemas:
     columns:
       - id
       - value_str
+      - value_searchable
       - value_bytes
       - value_int32
       - value_int64
@@ -12,6 +13,12 @@ schemas:
       - value_empty_str
 
     encrypted:
+      - column: value_searchable
+        data_type: "str"
+        response_on_fail: default_value
+        default_data_value: "searchable_str"
+        searchable: true
+
       - column: value_str
         data_type: "str"
         response_on_fail: default_value

--- a/tests/encryptor_configs/transparent_type_aware_decryption_postgres_with_data_type_id.yaml
+++ b/tests/encryptor_configs/transparent_type_aware_decryption_postgres_with_data_type_id.yaml
@@ -4,6 +4,7 @@ schemas:
     columns:
       - id
       - value_str
+      - value_searchable
       - value_bytes
       - value_int32
       - value_int64
@@ -16,6 +17,12 @@ schemas:
         data_type_db_identifier: 25
         response_on_fail: default_value
         default_data_value: "value_str"
+
+      - column: value_searchable
+        data_type_db_identifier: 25
+        response_on_fail: default_value
+        default_data_value: "searchable_str"
+        searchable: true
 
       - column: value_bytes
         data_type_db_identifier: 17

--- a/tests/test.py
+++ b/tests/test.py
@@ -8143,6 +8143,7 @@ class TestPostgresqlTextFormatTypeAwareDecryptionWithDefaults(BaseTransparentEnc
         'test_type_aware_decryption_with_defaults', sa.MetaData(),
         sa.Column('id', sa.Integer, primary_key=True),
         sa.Column('value_str', sa.Text),
+        sa.Column('value_searchable', sa.Text),
         sa.Column('value_bytes', sa.LargeBinary),
         sa.Column('value_int32', sa.Integer),
         sa.Column('value_int64', sa.BigInteger),
@@ -8156,6 +8157,7 @@ class TestPostgresqlTextFormatTypeAwareDecryptionWithDefaults(BaseTransparentEnc
         'test_type_aware_decryption_with_defaults', metadata,
         sa.Column('id', sa.Integer, primary_key=True),
         sa.Column('value_str', sa.LargeBinary),
+        sa.Column('value_searchable', sa.LargeBinary),
         sa.Column('value_bytes', sa.LargeBinary),
         sa.Column('value_int32', sa.LargeBinary),
         sa.Column('value_int64', sa.LargeBinary),
@@ -8182,17 +8184,19 @@ class TestPostgresqlTextFormatTypeAwareDecryptionWithDefaults(BaseTransparentEnc
             'value_int64': random_int64(),
             'value_null_str': None,
             'value_null_int32': None,
-            'value_empty_str': ''
+            'value_empty_str': '',
+            'value_searchable': random_str(),
         }
         default_expected_values = {
             'value_int32': 32,
             'value_int64': 64,
             'value_bytes': b'value_bytes',
             'value_str': 'value_str',
+            'value_searchable': 'searchable_str',
         }
 
         self.schema_table.create(bind=self.engine_raw, checkfirst=True)
-        columns = ('value_str', 'value_bytes', 'value_int32', 'value_int64', 'value_null_str', 'value_null_int32',
+        columns = ('value_str', 'value_searchable', 'value_bytes', 'value_int32', 'value_int64', 'value_null_str', 'value_null_int32',
                    'value_empty_str')
         self.engine1.execute(self.test_table.insert(), data)
         result = self.engine1.execute(
@@ -8360,17 +8364,19 @@ class TestPostgresqlBinaryFormatTypeAwareDecryptionWithDefaults(
             'value_int64': random_int64(),
             'value_null_str': None,
             'value_null_int32': None,
-            'value_empty_str': ''
+            'value_empty_str': '',
+            'value_searchable': random_str(),
         }
         default_expected_values = {
             'value_int32': 32,
             'value_int64': 64,
             'value_bytes': b'value_bytes',
             'value_str': 'value_str',
+            'value_searchable': 'searchable_str',
         }
 
         self.schema_table.create(bind=self.engine_raw, checkfirst=True)
-        columns = ('value_str', 'value_bytes', 'value_int32', 'value_int64', 'value_null_str', 'value_null_int32',
+        columns = ('value_str', 'value_searchable', 'value_bytes', 'value_int32', 'value_int64', 'value_null_str', 'value_null_int32',
                    'value_empty_str')
         query, args = self.compileQuery(self.test_table.insert(), data)
         self.executor1.execute_prepared_statement(query, args)

--- a/tests/test.py
+++ b/tests/test.py
@@ -4319,7 +4319,12 @@ class TestClientIDDecryptionWithVaultMasterKeyLoader(HashiCorpVaultMasterKeyLoad
 
 class AcraTranslatorTest(AcraTranslatorMixin, BaseTestCase):
 
+    # override BaseTestCase's methods to not start acra-server
+    def setUp(self):
+        pass
 
+    def tearDown(self):
+        pass
 
     def apiEncryptionTest(self, request_func, use_http=False, use_grpc=False):
         # one is set


### PR DESCRIPTION
I found that when acra-server validates searchable hash after decryption and it failed then it skips applying `response_on_fail` option and just returns as is. It's because our searchable encryptor decrypts data as first, marks the current context as successful decryption, and then validates hash which will fail. Due to the context was marked as successful, acra-server do nothing on encoding stage because it expects valid raw value instead of returning error or default value.
In this PR were added marking context as NotDecrypted in case of failed hash validation and tests for that.
Additionally found, that our encryptor_config validations denied searchable fields with type awareness (probably because searchable encryption was added after the first introduction of type awareness) and added missed masks.

## Checklist

- [ +] Change is covered by automated tests
- [ +] The [coding guidelines] are followed
- [+] Public API has proper documentation in the [Acra documentation] site or has PR on [documentation repository] 
  with new changes
- [ ] CHANGELOG.md is updated (in case of notable or breaking changes)
- [ ] CHANGELOG_DEV.md is updated
- [ ] Benchmark results are attached (if applicable)
- [ ] [Example projects and code samples] are up-to-date (in case of API changes) 

[coding guidelines]: https://golang.org/doc/effective_go
[Example projects and code samples]: https://github.com/cossacklabs/acra-engineering-demo
[Acra documentation]: https://docs.cossacklabs.com/
[documentation repository]: https://github.com/cossacklabs/product-docs