### PR TITLE
Use base tls flags if side-specific weren't specified

### DIFF
--- a/CHANGELOG_DEV.md
+++ b/CHANGELOG_DEV.md
@@ -1,3 +1,6 @@
+# 0.94.5 - 2023-01-11
+- Improved TLS configuration, `tls_ocsp_*` and `tls_crl_*` applied for TLS connections without `tls_ocsp_[client|database]_*`/`tls_crl_[client|database]_*` flags.g
+
 # 0.94.0 - 2022-10-18
 - Extend SQL syntax for searchable encryption with support JOINs query. 
 

--- a/cmd/acra-keys/keys/read-keys_tls_redis_test.go
+++ b/cmd/acra-keys/keys/read-keys_tls_redis_test.go
@@ -99,6 +99,7 @@ func TestReadCMD_TLSRedis_V2(t *testing.T) {
 	flagSet := flag.NewFlagSet(CmdMigrateKeys, flag.ContinueOnError)
 	keyloader.RegisterCLIParametersWithFlagSet(flagSet, "", "")
 	cmd.RegisterRedisKeystoreParametersWithPrefix(flagSet, "", "")
+	network.RegisterTLSBaseArgs(flagSet)
 
 	options := prepareTLSRedisConfigForFlagSet(flagSet, t)
 	// remove all generated keys at the end
@@ -110,6 +111,10 @@ func TestReadCMD_TLSRedis_V2(t *testing.T) {
 
 	setFlags := map[string]string{
 		"keystore_encryption_type": keyloader.KeystoreStrategyEnvMasterKey,
+		// test certs contains specified OCSP/CRL endpoints that force our TLS verifier to check it
+		// turn on ignoring it to avoid starting extra servers for ocsp/crl responses
+		"tls_ocsp_from_cert": network.OcspFromCertIgnoreStr,
+		"tls_crl_from_cert":  network.CrlFromCertIgnoreStr,
 	}
 
 	for flag, value := range setFlags {
@@ -175,7 +180,7 @@ func TestReadCMD_TLSRedis_V1(t *testing.T) {
 
 	flagSet := flag.NewFlagSet(CmdMigrateKeys, flag.ContinueOnError)
 	keyloader.RegisterCLIParametersWithFlagSet(flagSet, "", "")
-
+	network.RegisterTLSBaseArgs(flagSet)
 	cmd.RegisterRedisKeystoreParametersWithPrefix(flagSet, "", "")
 
 	options := prepareTLSRedisConfigForFlagSet(flagSet, t)
@@ -188,6 +193,10 @@ func TestReadCMD_TLSRedis_V1(t *testing.T) {
 
 	setFlags := map[string]string{
 		"keystore_encryption_type": keyloader.KeystoreStrategyEnvMasterKey,
+		// test certs contains specified OCSP/CRL endpoints that force our TLS verifier to check it
+		// turn on ignoring it to avoid starting extra servers for ocsp/crl responses
+		"tls_ocsp_from_cert": network.OcspFromCertIgnoreStr,
+		"tls_crl_from_cert":  network.CrlFromCertIgnoreStr,
 	}
 
 	for flag, value := range setFlags {

--- a/cmd/acra-server/acra-server.go
+++ b/cmd/acra-server/acra-server.go
@@ -143,7 +143,7 @@ func realMain() error {
 	enableHTTPAPI := flag.Bool("http_api_enable", false, "Enable HTTP API. Use together with --http_api_tls_transport_enable whenever possible.")
 	httpAPIUseTLS := flag.Bool("http_api_tls_transport_enable", false, "Enable HTTPS support for the API. Use together with the --http_api_enable. TLS configuration is the same as in the Acra Proxy.")
 
-	network.RegisterTLSBaseArgs()
+	network.RegisterTLSBaseArgs(flag.CommandLine)
 	network.RegisterTLSArgsForService(flag.CommandLine, false, "", network.ClientNameConstructorFunc())
 	network.RegisterTLSArgsForService(flag.CommandLine, true, "", network.DatabaseNameConstructorFunc())
 	tlsUseClientIDFromCertificate := flag.Bool("tls_client_id_from_cert", true, "Extract clientID from TLS certificate from application connection. Can't be used with --tls_client_auth=0 or --tls_auth=0")

--- a/cmd/acra-translator/acra-translator.go
+++ b/cmd/acra-translator/acra-translator.go
@@ -137,7 +137,7 @@ func realMain() error {
 	cmd.RegisterTracingCmdParameters()
 	cmd.RegisterJaegerCmdParameters()
 	logging.RegisterCLIArgs()
-	network.RegisterTLSBaseArgs()
+	network.RegisterTLSBaseArgs(flag.CommandLine)
 
 	verbose := flag.Bool("v", false, "Log to stderr all INFO, WARNING and ERROR logs")
 	debug := flag.Bool("d", false, "Log everything to stderr")

--- a/keystore/v2/keystore/filesystem/backend/redis_tls_test.go
+++ b/keystore/v2/keystore/filesystem/backend/redis_tls_test.go
@@ -23,6 +23,7 @@ import (
 	"crypto/tls"
 	"flag"
 	"github.com/cossacklabs/acra/cmd"
+	"github.com/cossacklabs/acra/network"
 	tests2 "github.com/cossacklabs/acra/utils/tests"
 	"path/filepath"
 	"strconv"
@@ -87,6 +88,20 @@ func prepareTLSRedisConfig(t *testing.T) (*cmd.RedisOptions, *flag.FlagSet) {
 
 func TestRedis(t *testing.T) {
 	options, flagset := prepareTLSRedisConfig(t)
+	network.RegisterTLSBaseArgs(flagset)
+	setFlags := map[string]string{
+		// test certs contains specified OCSP/CRL endpoints that force our TLS verifier to check it
+		// turn on ignoring it to avoid starting extra servers for ocsp/crl responses
+		"tls_ocsp_from_cert": network.OcspFromCertIgnoreStr,
+		"tls_crl_from_cert":  network.CrlFromCertIgnoreStr,
+	}
+
+	for flag, value := range setFlags {
+		err := flagset.Set(flag, value)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
 	redisOptions, err := options.KeysOptions(flagset)
 	if err != nil {
 		t.Fatal(err)

--- a/network/cert_verifier.go
+++ b/network/cert_verifier.go
@@ -68,21 +68,21 @@ func RegisterCertVerifierArgsForService(flags *flag.FlagSet, serviceName string,
 }
 
 // RegisterCertVerifierArgs register CLI args which allow to get CertVerifier by NewCertVerifier()
-func RegisterCertVerifierArgs() {
-	flag.StringVar(&tlsOcspURL, "tls_ocsp_url", "", "OCSP service URL")
-	flag.StringVar(&tlsOcspRequired, "tls_ocsp_required", OcspRequiredDenyUnknownStr,
+func RegisterCertVerifierArgs(flags *flag.FlagSet) {
+	flags.StringVar(&tlsOcspURL, "tls_ocsp_url", "", "OCSP service URL")
+	flags.StringVar(&tlsOcspRequired, "tls_ocsp_required", OcspRequiredDenyUnknownStr,
 		fmt.Sprintf("How to treat certificates unknown to OCSP: <%s>", strings.Join(OcspRequiredValuesList, "|")))
-	flag.StringVar(&tlsOcspFromCert, "tls_ocsp_from_cert", OcspFromCertPreferStr,
+	flags.StringVar(&tlsOcspFromCert, "tls_ocsp_from_cert", OcspFromCertPreferStr,
 		fmt.Sprintf("How to treat OCSP server described in certificate itself: <%s>", strings.Join(OcspFromCertValuesList, "|")))
-	flag.BoolVar(&tlsOcspCheckOnlyLeafCertificate, "tls_ocsp_check_only_leaf_certificate", false,
+	flags.BoolVar(&tlsOcspCheckOnlyLeafCertificate, "tls_ocsp_check_only_leaf_certificate", false,
 		"Put 'true' to check only final/last certificate, or 'false' to check the whole certificate chain using OCSP")
-	flag.StringVar(&tlsCrlURL, "tls_crl_url", "", "URL of the Certificate Revocation List (CRL) to use")
-	flag.StringVar(&tlsCrlFromCert, "tls_crl_from_cert", CrlFromCertPreferStr,
+	flags.StringVar(&tlsCrlURL, "tls_crl_url", "", "URL of the Certificate Revocation List (CRL) to use")
+	flags.StringVar(&tlsCrlFromCert, "tls_crl_from_cert", CrlFromCertPreferStr,
 		fmt.Sprintf("How to treat CRL URL described in certificate itself: <%s>", strings.Join(CrlFromCertValuesList, "|")))
-	flag.BoolVar(&tlsCrlCheckOnlyLeafCertificate, "tls_crl_check_only_leaf_certificate", false,
+	flags.BoolVar(&tlsCrlCheckOnlyLeafCertificate, "tls_crl_check_only_leaf_certificate", false,
 		"Put 'true' to check only final/last certificate, or 'false' to check the whole certificate chain using CRL")
-	flag.UintVar(&tlsCrlCacheSize, "tls_crl_cache_size", CrlDefaultCacheSize, "How many CRLs to cache in memory (use 0 to disable caching)")
-	flag.UintVar(&tlsCrlCacheTime, "tls_crl_cache_time", CrlDisableCacheTime,
+	flags.UintVar(&tlsCrlCacheSize, "tls_crl_cache_size", CrlDefaultCacheSize, "How many CRLs to cache in memory (use 0 to disable caching)")
+	flags.UintVar(&tlsCrlCacheTime, "tls_crl_cache_time", CrlDisableCacheTime,
 		fmt.Sprintf("How long to keep CRLs cached, in seconds (use 0 to disable caching, maximum: %d s)", CrlCacheTimeMax))
 }
 

--- a/network/crl.go
+++ b/network/crl.go
@@ -134,33 +134,43 @@ func NewCRLConfigByName(flags *flag.FlagSet, name string, namerFunc CLIParamName
 	var crlURL, crlFromCert string
 	var crlCheckOnlyLeafCertificate bool
 	var crlCacheSize, crlCacheTime uint
-	if f := flags.Lookup(namerFunc(name, "url", "crl")); f != nil {
+
+	crlURL = tlsCrlURL
+	if isFlagSet(namerFunc(name, "url", "crl"), flags) {
+		f := flags.Lookup(namerFunc(name, "url", "crl"))
 		crlURL = f.Value.String()
-		if crlURL == "" {
-			crlURL = tlsCrlURL
-		}
 	}
-	if f := flags.Lookup(namerFunc(name, "from_cert", "crl")); f != nil {
+
+	crlFromCert = tlsCrlFromCert
+	if isFlagSet(namerFunc(name, "from_cert", "crl"), flags) {
+		f := flags.Lookup(namerFunc(name, "from_cert", "crl"))
 		crlFromCert = f.Value.String()
-		if crlFromCert == "" {
-			crlFromCert = tlsCrlFromCert
-		}
 	}
-	if f := flags.Lookup(namerFunc(name, "check_only_leaf_certificate", "crl")); f != nil {
+
+	// use common flag if named option not set
+	crlCheckOnlyLeafCertificate = tlsCrlCheckOnlyLeafCertificate
+	if isFlagSet(namerFunc(name, "check_only_leaf_certificate", "crl"), flags) {
+		f := flags.Lookup(namerFunc(name, "check_only_leaf_certificate", "crl"))
 		v, err := strconv.ParseBool(f.Value.String())
 		if err != nil {
 			log.WithField("value", f.Value.String).Fatalf("Can't cast %s to boolean value", namerFunc(name, "check_only_leaf_certificate", "crl"))
 		}
 		crlCheckOnlyLeafCertificate = v
 	}
-	if f := flags.Lookup(namerFunc(name, "cache_size", "crl")); f != nil {
+
+	crlCacheSize = tlsCrlCacheSize
+	if isFlagSet(namerFunc(name, "cache_size", "crl"), flags) {
+		f := flags.Lookup(namerFunc(name, "cache_size", "crl"))
 		size, err := strconv.ParseUint(f.Value.String(), 10, 64)
 		if err != nil {
 			log.WithField("value", f.Value.String).Fatalf("Can't cast %s to integer value", namerFunc(name, "cache_size", "crl"))
 		}
 		crlCacheSize = uint(size)
 	}
-	if f := flags.Lookup(namerFunc(name, "cache_time", "crl")); f != nil {
+
+	crlCacheTime = tlsCrlCacheTime
+	if isFlagSet(namerFunc(name, "cache_time", "crl"), flags) {
+		f := flags.Lookup(namerFunc(name, "cache_time", "crl"))
 		cacheTime, err := strconv.ParseUint(f.Value.String(), 10, 64)
 		if err != nil {
 			log.WithField("value", f.Value.String).Fatalf("Can't cast %s to integer value", namerFunc(name, "cache_time", "crl"))

--- a/network/crl_test.go
+++ b/network/crl_test.go
@@ -28,6 +28,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"strconv"
 	"testing"
 	"time"
 )
@@ -56,6 +57,9 @@ const (
 
 	// CRL that contains self-revoked root CA
 	TestCRLFilenameRootSelfRevoked = "ca/crl_with_root.pem"
+
+	// special port value force kernel to choose free port
+	freePort = 0
 )
 
 type TestCertGroup struct {
@@ -198,8 +202,8 @@ func pemToX509Cert(data []byte) (*x509.Certificate, error) {
 
 // Starts HTTP server on some random port, uses `mux` to handle requests,
 // returns created server and IP:port of listening socket
-func getTestHTTPServer(t *testing.T, mux *http.ServeMux) (*http.Server, string) {
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
+func getTestHTTPServer(t *testing.T, port int, mux *http.ServeMux) (*http.Server, string) {
+	listener, err := net.Listen("tcp", "127.0.0.1:"+strconv.Itoa(port))
 	if err != nil {
 		t.Fatalf("Cannot create TCP socket for HTTP server: %v", err)
 	}
@@ -356,7 +360,7 @@ func TestDefaultCRLClientHTTP(t *testing.T) {
 		res.Write(rawCRL)
 	})
 
-	httpServer, addr := getTestHTTPServer(t, mux)
+	httpServer, addr := getTestHTTPServer(t, freePort, mux)
 	defer httpServer.Close()
 
 	crlClient := NewDefaultCRLClient()
@@ -479,7 +483,7 @@ func testDefaultCRLVerifierWithGroupValid(t *testing.T, certGroup TestCertGroup)
 		res.Write(rawCRL)
 	})
 
-	httpServer, addr := getTestHTTPServer(t, mux)
+	httpServer, addr := getTestHTTPServer(t, freePort, mux)
 	defer httpServer.Close()
 
 	// Test with valid URL
@@ -513,7 +517,7 @@ func testDefaultCRLVerifierWithGroupRevoked(t *testing.T, certGroup TestCertGrou
 		res.Write(rawCRL)
 	})
 
-	httpServer, addr := getTestHTTPServer(t, mux)
+	httpServer, addr := getTestHTTPServer(t, freePort, mux)
 	defer httpServer.Close()
 
 	// Test with valid URL

--- a/network/ocsp.go
+++ b/network/ocsp.go
@@ -130,31 +130,35 @@ const (
 func NewOCSPConfigByName(flags *flag.FlagSet, name string, namerFunc CLIParamNameConstructorFunc) (*OCSPConfig, error) {
 	var url, required, fromCert string
 	var checkOnlyLeafCert bool
-	if f := flags.Lookup(namerFunc(name, "url", "ocsp")); f != nil {
+
+	url = tlsOcspURL
+	if isFlagSet(namerFunc(name, "url", "ocsp"), flags) {
+		f := flags.Lookup(namerFunc(name, "url", "ocsp"))
 		url = f.Value.String()
-		if url == "" {
-			url = tlsOcspURL
-		}
 	}
-	if f := flags.Lookup(namerFunc(name, "required", "ocsp")); f != nil {
+
+	required = tlsOcspRequired
+	if isFlagSet(namerFunc(name, "required", "ocsp"), flags) {
+		f := flags.Lookup(namerFunc(name, "required", "ocsp"))
 		required = f.Value.String()
-		if required == "" {
-			required = tlsOcspRequired
-		}
 	}
-	if f := flags.Lookup(namerFunc(name, "from_cert", "ocsp")); f != nil {
+
+	fromCert = tlsOcspFromCert
+	if isFlagSet(namerFunc(name, "from_cert", "ocsp"), flags) {
+		f := flags.Lookup(namerFunc(name, "from_cert", "ocsp"))
 		fromCert = f.Value.String()
-		if fromCert == "" {
-			fromCert = tlsOcspFromCert
-		}
 	}
-	if f := flags.Lookup(namerFunc(name, "check_only_leaf_certificate", "ocsp")); f != nil {
+
+	checkOnlyLeafCert = tlsOcspCheckOnlyLeafCertificate
+	if isFlagSet(namerFunc(name, "check_only_leaf_certificate", "ocsp"), flags) {
+		f := flags.Lookup(namerFunc(name, "check_only_leaf_certificate", "ocsp"))
 		v, err := strconv.ParseBool(f.Value.String())
 		if err != nil {
 			log.WithField("value", f.Value.String).Fatalf("Can't cast %s to boolean value", namerFunc(name, "check_only_leaf_certificate", "ocsp"))
 		}
 		checkOnlyLeafCert = v
 	}
+
 	return NewOCSPConfig(url, required, fromCert, checkOnlyLeafCert)
 }
 

--- a/network/ocsp_test.go
+++ b/network/ocsp_test.go
@@ -88,7 +88,7 @@ type ocspServerConfig struct {
 	respondWithWrongSerial bool
 }
 
-func getTestOCSPServer(t *testing.T, config ocspServerConfig) (*http.Server, string) {
+func getTestOCSPServer(t *testing.T, config ocspServerConfig, port int) (*http.Server, string) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", func(res http.ResponseWriter, req *http.Request) {
 		contentType, ok := req.Header["Content-Type"]
@@ -167,7 +167,7 @@ func getTestOCSPServer(t *testing.T, config ocspServerConfig) (*http.Server, str
 		// t.Logf("Wrote %d bytes OCSP response\n", n)
 	})
 
-	httpServer, addr := getTestHTTPServer(t, mux)
+	httpServer, addr := getTestHTTPServer(t, port, mux)
 
 	return httpServer, addr
 }
@@ -291,7 +291,7 @@ func testDefaultOCSPClientWithGroupValid(t *testing.T, certGroup TestCertGroup) 
 		testCases:     []*ocspTestCase{goodData},
 	}
 
-	ocspServer, addr := getTestOCSPServer(t, ocspServerConfig)
+	ocspServer, addr := getTestOCSPServer(t, ocspServerConfig, freePort)
 	defer ocspServer.Close()
 
 	ocspClient := NewDefaultOCSPClient()
@@ -333,7 +333,7 @@ func testDefaultOCSPClientWithGroupRevoked(t *testing.T, certGroup TestCertGroup
 		testCases:     []*ocspTestCase{revokedData},
 	}
 
-	ocspServer, addr := getTestOCSPServer(t, ocspServerConfig)
+	ocspServer, addr := getTestOCSPServer(t, ocspServerConfig, freePort)
 	defer ocspServer.Close()
 
 	ocspClient := NewDefaultOCSPClient()
@@ -376,7 +376,7 @@ func testDefaultOCSPClientWrongResponse(t *testing.T, certGroup TestCertGroup) {
 		respondWithWrongSerial: true,
 	}
 
-	ocspServer, addr := getTestOCSPServer(t, ocspServerConfig)
+	ocspServer, addr := getTestOCSPServer(t, ocspServerConfig, freePort)
 	defer ocspServer.Close()
 
 	ocspClient := NewDefaultOCSPClient()
@@ -478,7 +478,7 @@ func testDefaultOCSPVerifierWithGroupValid(t *testing.T, certGroup TestCertGroup
 		testCases:     []*ocspTestCase{goodData},
 	}
 
-	ocspServer, addr := getTestOCSPServer(t, ocspServerConfig)
+	ocspServer, addr := getTestOCSPServer(t, ocspServerConfig, freePort)
 	defer ocspServer.Close()
 
 	url := fmt.Sprintf("http://%s", addr)
@@ -526,7 +526,7 @@ func testDefaultOCSPVerifierWithGroupRevoked(t *testing.T, certGroup TestCertGro
 		testCases:     []*ocspTestCase{revokedData},
 	}
 
-	ocspServer, addr := getTestOCSPServer(t, ocspServerConfig)
+	ocspServer, addr := getTestOCSPServer(t, ocspServerConfig, freePort)
 	defer ocspServer.Close()
 
 	url := fmt.Sprintf("http://%s", addr)

--- a/network/tls_wrapper.go
+++ b/network/tls_wrapper.go
@@ -102,12 +102,12 @@ func DatabaseNameConstructorFunc() CLIParamNameConstructorFunc {
 }
 
 // RegisterTLSBaseArgs register CLI args tls_ca|tls_key|tls_cert|tls_auth which allow to get tls.Config by NewTLSConfigFromBaseArgs function
-func RegisterTLSBaseArgs() {
-	flag.StringVar(&tlsCA, "tls_ca", "", "Path to root certificate which will be used with system root certificates to validate peer's certificate")
-	flag.StringVar(&tlsKey, "tls_key", "", "Path to private key that will be used for TLS connections")
-	flag.StringVar(&tlsCert, "tls_cert", "", "Path to certificate")
-	flag.IntVar(&tlsAuthType, "tls_auth", int(tls.RequireAndVerifyClientCert), "Set authentication mode that will be used in TLS connection. Values in range 0-4 that set auth type (https://golang.org/pkg/crypto/tls/#ClientAuthType). Default is tls.RequireAndVerifyClientCert")
-	RegisterCertVerifierArgs()
+func RegisterTLSBaseArgs(flags *flag.FlagSet) {
+	flags.StringVar(&tlsCA, "tls_ca", "", "Path to root certificate which will be used with system root certificates to validate peer's certificate")
+	flags.StringVar(&tlsKey, "tls_key", "", "Path to private key that will be used for TLS connections")
+	flags.StringVar(&tlsCert, "tls_cert", "", "Path to certificate")
+	flags.IntVar(&tlsAuthType, "tls_auth", int(tls.RequireAndVerifyClientCert), "Set authentication mode that will be used in TLS connection. Values in range 0-4 that set auth type (https://golang.org/pkg/crypto/tls/#ClientAuthType). Default is tls.RequireAndVerifyClientCert")
+	RegisterCertVerifierArgs(flags)
 }
 
 // RegisterTLSArgsForService register CLI args tls_ca|tls_key|tls_cert|tls_auth and flags for certificate verifier

--- a/network/utils.go
+++ b/network/utils.go
@@ -17,6 +17,7 @@ limitations under the License.
 package network
 
 import (
+	"flag"
 	"fmt"
 	"net"
 	url_ "net/url"
@@ -228,4 +229,16 @@ func SplitConnectionString(connectionString string) (string, int, error) {
 		return "", 0, err
 	}
 	return url.Hostname(), port, nil
+}
+
+// IsFlagSet returns true if flag explicitly set via CLI arguments
+// Don't move it to the cmd package due to import cycle
+func isFlagSet(name string, flagset *flag.FlagSet) bool {
+	set := false
+	flagset.Visit(func(f *flag.Flag) {
+		if f.Name == name {
+			set = true
+		}
+	})
+	return set
 }


### PR DESCRIPTION
Here is we fix #615 issue when common flags for all sides of communication `tls_*` (with application and database) are not applied for ocsp and crl verifiers if weren't specified `tls_ocsp_[client|database]_*`/`tls_crl_[client|database]_*` flags. With this fix should be enough to specify tls_* flags once for both sides.

## Checklist

- [x] Change is covered by automated tests
- [x] The [coding guidelines] are followed
- [ ] Public API has proper documentation in the [Acra documentation] site or has PR on [documentation repository] 
  with new changes. **In progress**
- [x] CHANGELOG.md is updated (in case of notable or breaking changes)
- [x] CHANGELOG_DEV.md is updated
- [x] Benchmark results are attached (if applicable)
- [x] [Example projects and code samples] are up-to-date (in case of API changes) 

[coding guidelines]: https://golang.org/doc/effective_go
[Example projects and code samples]: https://github.com/cossacklabs/acra-engineering-demo
[Acra documentation]: https://docs.cossacklabs.com/
[documentation repository]: https://github.com/cossacklabs/product-docs