### PR TITLE
Fix test with ocsp_flag

### DIFF
--- a/cmd/acra-tokens/tokens/token_storage_redis_tls_test.go
+++ b/cmd/acra-tokens/tokens/token_storage_redis_tls_test.go
@@ -1,6 +1,3 @@
-//go:build integration && redis && tls
-// +build integration,redis,tls
-
 package tokens
 
 import (
@@ -48,6 +45,7 @@ func TestTokensStatusWithTLSRedis(t *testing.T) {
 		"redis_tls_client_cert":           filepath.Join(workingDirectory, "tests/ssl/acra-writer/acra-writer.crt"),
 		"redis_tls_crl_client_from_cert":  "ignore",
 		"redis_tls_ocsp_client_from_cert": "ignore",
+		"redis_tls_ocsp_client_required":  "allowUnknown",
 	}
 
 	for flag, value := range flagsToSet {

--- a/cmd/acra-tokens/tokens/token_storage_redis_tls_test.go
+++ b/cmd/acra-tokens/tokens/token_storage_redis_tls_test.go
@@ -1,3 +1,6 @@
+//go:build integration && redis && tls
+// +build integration,redis,tls
+
 package tokens
 
 import (


### PR DESCRIPTION
Added the missing oscp configuration flag to the failing test.

## Checklist

- [ ] Change is covered by automated tests
- [ ] The [coding guidelines] are followed
- [ ] Public API has proper documentation in the [Acra documentation] site or has PR on [documentation repository] 
  with new changes
- [ ] CHANGELOG.md is updated (in case of notable or breaking changes)
- [ ] CHANGELOG_DEV.md is updated
- [ ] Benchmark results are attached (if applicable)
- [ ] [Example projects and code samples] are up-to-date (in case of API changes) 

[coding guidelines]: https://golang.org/doc/effective_go
[Example projects and code samples]: https://github.com/cossacklabs/acra-engineering-demo
[Acra documentation]: https://docs.cossacklabs.com/
[documentation repository]: https://github.com/cossacklabs/product-docs