### PR TITLE
Declare tables on object level instead of class level

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -3258,12 +3258,15 @@ class TestPostgresqlConnectWithTLSPrefer(BaseTestCase):
 
 
 class TestDbFlushingOnError(BaseTransparentEncryption):
-    encryptor_table = sa.Table(
-        'test_proper_db_flushing_on_error', sa.MetaData(),
-        sa.Column('id', sa.Integer, primary_key=True),
-        sa.Column('value_bytes', sa.LargeBinary),
-    )
     ENCRYPTOR_CONFIG = get_encryptor_config('tests/encryptor_configs/transparent_type_aware_decryption.yaml')
+
+    def get_encryptor_table(self):
+        encryptor_table = sa.Table(
+            'test_proper_db_flushing_on_error', sa.MetaData(),
+            sa.Column('id', sa.Integer, primary_key=True),
+            sa.Column('value_bytes', sa.LargeBinary),
+        )
+        return encryptor_table
 
     def checkSkip(self):
         if not TEST_WITH_TLS:
@@ -3365,13 +3368,16 @@ class TestDbFlushingOnError(BaseTransparentEncryption):
 
 
 class TestPostgresqlDbFlushingOnError(BaseTransparentEncryption):
-    encryptor_table = sa.Table(
-        'test_proper_db_flushing_on_error', sa.MetaData(),
-        sa.Column('id', sa.Integer, primary_key=True),
-        sa.Column('value_bytes', sa.LargeBinary),
-    )
     ENCRYPTOR_CONFIG = get_encryptor_config(
         'tests/encryptor_configs/transparent_type_aware_decryption.yaml')
+
+    def get_encryptor_table(self):
+        encryptor_table = sa.Table(
+            'test_proper_db_flushing_on_error', sa.MetaData(),
+            sa.Column('id', sa.Integer, primary_key=True),
+            sa.Column('value_bytes', sa.LargeBinary),
+        )
+        return encryptor_table
 
     def checkSkip(self):
         if not (TEST_POSTGRESQL and TEST_WITH_TLS):
@@ -4045,15 +4051,18 @@ class TestSigHUPHandler(AcraTranslatorMixin, BaseTestCase):
 
 
 class LimitOffsetQueryTest(BaseTransparentEncryption):
-    encryptor_table = sa.Table(
-        'test_searchable_limit_offset', metadata,
-        sa.Column('id', sa.Integer, primary_key=True, autoincrement=False),
-        sa.Column('data',
-                  sa.LargeBinary(length=COLUMN_DATA_SIZE)),
-        sa.Column('raw_data', sa.Text),
-        sa.Column('empty', sa.LargeBinary(length=COLUMN_DATA_SIZE), nullable=False, default=b''),
-    )
     ENCRYPTOR_CONFIG = get_encryptor_config('tests/encryptor_configs/ee_encryptor_config.yaml')
+
+    def get_encryptor_table(self):
+        encryptor_table = sa.Table(
+            'test_searchable_limit_offset', self.get_metadata(),
+            sa.Column('id', sa.Integer, primary_key=True, autoincrement=False),
+            sa.Column('data',
+                      sa.LargeBinary(length=COLUMN_DATA_SIZE)),
+            sa.Column('raw_data', sa.Text),
+            sa.Column('empty', sa.LargeBinary(length=COLUMN_DATA_SIZE), nullable=False, default=b''),
+        )
+        return encryptor_table
 
     def setUp(self):
         # should be before setUp and fork_acra

--- a/tests/test.py
+++ b/tests/test.py
@@ -3262,7 +3262,7 @@ class TestDbFlushingOnError(BaseTransparentEncryption):
 
     def get_encryptor_table(self):
         encryptor_table = sa.Table(
-            'test_proper_db_flushing_on_error', sa.MetaData(),
+            'test_proper_db_flushing_on_error', self.get_metadata(),
             sa.Column('id', sa.Integer, primary_key=True),
             sa.Column('value_bytes', sa.LargeBinary),
         )
@@ -3373,7 +3373,7 @@ class TestPostgresqlDbFlushingOnError(BaseTransparentEncryption):
 
     def get_encryptor_table(self):
         encryptor_table = sa.Table(
-            'test_proper_db_flushing_on_error', sa.MetaData(),
+            'test_proper_db_flushing_on_error', self.get_metadata(),
             sa.Column('id', sa.Integer, primary_key=True),
             sa.Column('value_bytes', sa.LargeBinary),
         )

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -417,6 +417,7 @@ class BaseTestCase(PrometheusMixin, unittest.TestCase):
             pass
         try:
             self.engine_raw.execute('delete from test;')
+            base.metadata.drop_all(self.engine_raw)
         except:
             pass
         for engine in getattr(self, 'engines', []):
@@ -471,7 +472,7 @@ class AcraCatchLogsMixin(object):
         with open(self.log_files[process].name, 'r', errors='replace',
                   encoding='utf-8') as f:
             log = f.read()
-            print(log.encode(encoding='utf-8', errors='replace'))
+            print(log)
             return log
 
     def fork_acra(self, popen_kwargs: dict = None, **acra_kwargs: dict):
@@ -944,6 +945,23 @@ class TLSAuthenticationDirectlyToAcraMixin:
         except:
             self.tearDown()
             raise
+
+
+class SeparateMetadataMixin:
+
+    def get_metadata(self) -> sa.MetaData:
+        if not getattr(self, 'metadata', None):
+            self.metadata = sa.MetaData()
+        return self.metadata
+
+    def setUp(self):
+        super().setUp()
+        self.get_metadata().create_all(self.engine_raw)
+
+    def tearDown(self):
+        self.get_metadata().drop_all(self.engine_raw)
+        self.metadata = None
+        super().tearDown()
 
 
 def tearDown(self):

--- a/tests/test_searchable_transparent_encryption.py
+++ b/tests/test_searchable_transparent_encryption.py
@@ -10,23 +10,27 @@ import test_common
 import test_integrations
 
 
-class BaseTransparentEncryption(test_common.BaseTestCase):
-    encryptor_table = sa.Table(
-        'test_transparent_encryption', base.metadata,
-        sa.Column('id', sa.Integer, primary_key=True),
-        sa.Column('specified_client_id',
-                  sa.LargeBinary(length=base.COLUMN_DATA_SIZE)),
-        sa.Column('default_client_id',
-                  sa.LargeBinary(length=base.COLUMN_DATA_SIZE)),
-        sa.Column('number', sa.Integer),
-        sa.Column('raw_data', sa.LargeBinary(length=base.COLUMN_DATA_SIZE)),
-        sa.Column('nullable', sa.Text, nullable=True),
-        sa.Column('empty', sa.LargeBinary(length=base.COLUMN_DATA_SIZE), nullable=False, default=b''),
-    )
+class BaseTransparentEncryption(test_common.SeparateMetadataMixin, test_common.BaseTestCase):
     ENCRYPTOR_CONFIG = base.get_encryptor_config('tests/encryptor_configs/encryptor_config.yaml')
+
+    def get_encryptor_table(self):
+        encryptor_table = sa.Table(
+            'test_transparent_encryption', self.get_metadata(),
+            sa.Column('id', sa.Integer, primary_key=True),
+            sa.Column('specified_client_id',
+                      sa.LargeBinary(length=base.COLUMN_DATA_SIZE)),
+            sa.Column('default_client_id',
+                      sa.LargeBinary(length=base.COLUMN_DATA_SIZE)),
+            sa.Column('number', sa.Integer),
+            sa.Column('raw_data', sa.LargeBinary(length=base.COLUMN_DATA_SIZE)),
+            sa.Column('nullable', sa.Text, nullable=True),
+            sa.Column('empty', sa.LargeBinary(length=base.COLUMN_DATA_SIZE), nullable=False, default=b''),
+        )
+        return encryptor_table
 
     def setUp(self):
         self.prepare_encryptor_config(client_id=base.TLS_CERT_CLIENT_ID_1)
+        self.encryptor_table = self.get_encryptor_table()
         super(BaseTransparentEncryption, self).setUp()
 
     def get_encryptor_config_path(self):
@@ -38,6 +42,7 @@ class BaseTransparentEncryption(test_common.BaseTestCase):
 
     def tearDown(self):
         self.engine_raw.execute(self.encryptor_table.delete())
+        base.metadata.remove(self.encryptor_table)
         super(BaseTransparentEncryption, self).tearDown()
         try:
             os.remove(base.get_test_encryptor_config(self.ENCRYPTOR_CONFIG))
@@ -171,26 +176,28 @@ class TestTransparentEncryption(BaseTransparentEncryption):
 
 
 class TestTransparentAcraBlockEncryption(TestTransparentEncryption):
-    WHOLECELL_MODE = False
-    encryptor_table = sa.Table('test_transparent_acrablock_encryption', base.metadata,
-                               sa.Column('id', sa.Integer, primary_key=True),
-                               sa.Column('specified_client_id',
-                                         sa.LargeBinary(length=base.COLUMN_DATA_SIZE)),
-                               sa.Column('default_client_id',
-                                         sa.LargeBinary(length=base.COLUMN_DATA_SIZE)),
-                               sa.Column('number', sa.Integer),
-                               sa.Column('raw_data', sa.LargeBinary(length=base.COLUMN_DATA_SIZE)),
-                               sa.Column('nullable', sa.Text, nullable=True),
-                               sa.Column('empty', sa.LargeBinary(length=base.COLUMN_DATA_SIZE), nullable=False,
-                                         default=b''),
-                               sa.Column('token_i64', sa.BigInteger(), nullable=False, default=1),
-                               sa.Column('token_str', sa.Text, nullable=False, default=''),
-                               sa.Column('token_bytes', sa.LargeBinary(length=base.COLUMN_DATA_SIZE), nullable=False,
-                                         default=b''),
-                               sa.Column('masked_prefix', sa.LargeBinary(length=base.COLUMN_DATA_SIZE), nullable=False,
-                                         default=b''),
-                               )
     ENCRYPTOR_CONFIG = base.get_encryptor_config('tests/encryptor_configs/ee_acrablock_config.yaml')
+    def get_encryptor_table(self):
+        encryptor_table = sa.Table(
+            'test_transparent_acrablock_encryption', self.get_metadata(),
+            sa.Column('id', sa.Integer, primary_key=True),
+            sa.Column('specified_client_id',
+                      sa.LargeBinary(length=base.COLUMN_DATA_SIZE)),
+            sa.Column('default_client_id',
+                      sa.LargeBinary(length=base.COLUMN_DATA_SIZE)),
+            sa.Column('number', sa.Integer),
+            sa.Column('raw_data', sa.LargeBinary(length=base.COLUMN_DATA_SIZE)),
+            sa.Column('nullable', sa.Text, nullable=True),
+            sa.Column('empty', sa.LargeBinary(length=base.COLUMN_DATA_SIZE), nullable=False,
+                      default=b''),
+            sa.Column('token_i64', sa.BigInteger(), nullable=False, default=1),
+            sa.Column('token_str', sa.Text, nullable=False, default=''),
+            sa.Column('token_bytes', sa.LargeBinary(length=base.COLUMN_DATA_SIZE), nullable=False,
+                      default=b''),
+            sa.Column('masked_prefix', sa.LargeBinary(length=base.COLUMN_DATA_SIZE), nullable=False,
+                      default=b''),
+            )
+        return encryptor_table
 
     def testAcraStructReEncryption(self):
         specified_id = base.TLS_CERT_CLIENT_ID_1
@@ -356,28 +363,31 @@ class TestPostgresqlTextPreparedTransparentEncryptionWithAWSKMSMasterKeyLoader(
 
 
 class BaseSearchableTransparentEncryption(TestTransparentEncryption):
-    encryptor_table = sa.Table(
-        'test_searchable_transparent_encryption', base.metadata,
-        sa.Column('id', sa.Integer, primary_key=True),
-        sa.Column('specified_client_id',
-                  sa.LargeBinary(length=base.COLUMN_DATA_SIZE)),
-        sa.Column('default_client_id',
-                  sa.LargeBinary(length=base.COLUMN_DATA_SIZE)),
-
-        sa.Column('number', sa.Integer),
-        sa.Column('raw_data', sa.LargeBinary(length=base.COLUMN_DATA_SIZE)),
-        sa.Column('nullable', sa.Text, nullable=True),
-        sa.Column('searchable', sa.LargeBinary(length=base.COLUMN_DATA_SIZE)),
-        sa.Column('searchable_acrablock', sa.LargeBinary(length=base.COLUMN_DATA_SIZE)),
-        sa.Column('empty', sa.LargeBinary(length=base.COLUMN_DATA_SIZE), nullable=False, default=b''),
-        sa.Column('token_i32', sa.Integer(), nullable=False, default=1),
-        sa.Column('token_i64', sa.BigInteger(), nullable=False, default=1),
-        sa.Column('token_str', sa.Text, nullable=False, default=''),
-        sa.Column('token_bytes', sa.LargeBinary(length=base.COLUMN_DATA_SIZE), nullable=False, default=b''),
-        sa.Column('token_email', sa.Text, nullable=False, default=''),
-        sa.Column('masking', sa.LargeBinary(length=base.COLUMN_DATA_SIZE), nullable=False, default=b''),
-    )
     ENCRYPTOR_CONFIG = base.get_encryptor_config('tests/encryptor_configs/ee_encryptor_config.yaml')
+
+    def get_encryptor_table(self):
+        encryptor_table = sa.Table(
+            'test_searchable_transparent_encryption', self.get_metadata(),
+            sa.Column('id', sa.Integer, primary_key=True),
+            sa.Column('specified_client_id',
+                      sa.LargeBinary(length=base.COLUMN_DATA_SIZE)),
+            sa.Column('default_client_id',
+                      sa.LargeBinary(length=base.COLUMN_DATA_SIZE)),
+
+            sa.Column('number', sa.Integer),
+            sa.Column('raw_data', sa.LargeBinary(length=base.COLUMN_DATA_SIZE)),
+            sa.Column('nullable', sa.Text, nullable=True),
+            sa.Column('searchable', sa.LargeBinary(length=base.COLUMN_DATA_SIZE)),
+            sa.Column('searchable_acrablock', sa.LargeBinary(length=base.COLUMN_DATA_SIZE)),
+            sa.Column('empty', sa.LargeBinary(length=base.COLUMN_DATA_SIZE), nullable=False, default=b''),
+            sa.Column('token_i32', sa.Integer(), nullable=False, default=1),
+            sa.Column('token_i64', sa.BigInteger(), nullable=False, default=1),
+            sa.Column('token_str', sa.Text, nullable=False, default=''),
+            sa.Column('token_bytes', sa.LargeBinary(length=base.COLUMN_DATA_SIZE), nullable=False, default=b''),
+            sa.Column('token_email', sa.Text, nullable=False, default=''),
+            sa.Column('masking', sa.LargeBinary(length=base.COLUMN_DATA_SIZE), nullable=False, default=b''),
+        )
+        return encryptor_table
 
     def fork_acra(self, popen_kwargs: dict = None, **acra_kwargs: dict):
         # Disable keystore cache since it can interfere with rotation tests
@@ -1102,28 +1112,28 @@ class TestSearchableTransparentEncryption(BaseSearchableTransparentEncryption):
 
 
 class TestSearchableTransparentEncryptionWithJOINs(BaseSearchableTransparentEncryption):
-    encryptor_table_join = sa.Table(
-        'test_searchable_transparent_encryption_join', base.metadata,
-        sa.Column('id', sa.Integer, primary_key=True),
-        sa.Column('specified_client_id',
-                  sa.LargeBinary(length=base.COLUMN_DATA_SIZE)),
-        sa.Column('default_client_id',
-                  sa.LargeBinary(length=base.COLUMN_DATA_SIZE)),
-
-        sa.Column('number', sa.Integer),
-        sa.Column('raw_data', sa.LargeBinary(length=base.COLUMN_DATA_SIZE)),
-        sa.Column('nullable', sa.Text, nullable=True),
-        sa.Column('searchable', sa.LargeBinary(length=base.COLUMN_DATA_SIZE)),
-        sa.Column('searchable_acrablock', sa.LargeBinary(length=base.COLUMN_DATA_SIZE)),
-        sa.Column('empty', sa.LargeBinary(length=base.COLUMN_DATA_SIZE), nullable=False, default=b''),
-        sa.Column('token_i32', sa.Integer(), nullable=False, default=1),
-        sa.Column('token_i64', sa.BigInteger(), nullable=False, default=1),
-        sa.Column('token_str', sa.Text, nullable=False, default=''),
-        sa.Column('token_bytes', sa.LargeBinary(length=base.COLUMN_DATA_SIZE), nullable=False, default=b''),
-        sa.Column('token_email', sa.Text, nullable=False, default=''),
-    )
-
     def setUp(self):
+        metadata = self.get_metadata()
+        self.encryptor_table_join = sa.Table(
+            'test_searchable_transparent_encryption_join', metadata,
+            sa.Column('id', sa.Integer, primary_key=True),
+            sa.Column('specified_client_id',
+                      sa.LargeBinary(length=base.COLUMN_DATA_SIZE)),
+            sa.Column('default_client_id',
+                      sa.LargeBinary(length=base.COLUMN_DATA_SIZE)),
+
+            sa.Column('number', sa.Integer),
+            sa.Column('raw_data', sa.LargeBinary(length=base.COLUMN_DATA_SIZE)),
+            sa.Column('nullable', sa.Text, nullable=True),
+            sa.Column('searchable', sa.LargeBinary(length=base.COLUMN_DATA_SIZE)),
+            sa.Column('searchable_acrablock', sa.LargeBinary(length=base.COLUMN_DATA_SIZE)),
+            sa.Column('empty', sa.LargeBinary(length=base.COLUMN_DATA_SIZE), nullable=False, default=b''),
+            sa.Column('token_i32', sa.Integer(), nullable=False, default=1),
+            sa.Column('token_i64', sa.BigInteger(), nullable=False, default=1),
+            sa.Column('token_str', sa.Text, nullable=False, default=''),
+            sa.Column('token_bytes', sa.LargeBinary(length=base.COLUMN_DATA_SIZE), nullable=False, default=b''),
+            sa.Column('token_email', sa.Text, nullable=False, default=''),
+        )
         super().setUp()
         self.engine1.execute(self.encryptor_table_join.delete())
 

--- a/tests/test_searchable_transparent_encryption.py
+++ b/tests/test_searchable_transparent_encryption.py
@@ -42,7 +42,6 @@ class BaseTransparentEncryption(test_common.SeparateMetadataMixin, test_common.B
 
     def tearDown(self):
         self.engine_raw.execute(self.encryptor_table.delete())
-        base.metadata.remove(self.encryptor_table)
         super(BaseTransparentEncryption, self).tearDown()
         try:
             os.remove(base.get_test_encryptor_config(self.ENCRYPTOR_CONFIG))


### PR DESCRIPTION
During synchronizing acra-ee with new changes from acra-ce I met issues with table re-declaration into the `base.metadata`. Previously all our tests were placed in the `tests/test.py` and python evaluated classes only once.
Now we have several files with test cases and `test_common.py` that have base test cases with the declaration of `encryptor_table`. In most cases, this class is evaluated only once and has all child classes in the same file, or it is imported by other classes that re-declare `encryptor_table` with `extend_existing=True` parameter for `sa.Table` statement.
If we will introduce `test_XX.py` which imports `test_type_aware.py`, which uses base test cases from `test_common.py` and some of them declare `encryptor_config` on the class level then we should add `extend_existing` in the all child classes and keep in mind it. Or we can declare into the separate metadata objects (not into the global `base.metadata`) and clean up after test cases - delete all tables to allow create new one extended without name duplication errors.

<!-- Describe your changes here -->

## Checklist

- [ ] Change is covered by automated tests
- [ ] The [coding guidelines] are followed
- [ ] Public API has proper documentation in the [Acra documentation] site or has PR on [documentation repository] 
  with new changes
- [ ] CHANGELOG.md is updated (in case of notable or breaking changes)
- [ ] CHANGELOG_DEV.md is updated
- [ ] Benchmark results are attached (if applicable)
- [ ] [Example projects and code samples] are up-to-date (in case of API changes) 

[coding guidelines]: https://golang.org/doc/effective_go
[Example projects and code samples]: https://github.com/cossacklabs/acra-engineering-demo
[Acra documentation]: https://docs.cossacklabs.com/
[documentation repository]: https://github.com/cossacklabs/product-docs