### PR TITLE
Comment unsupported method of boto3 1.23.10

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -21,5 +21,7 @@ unittest-xml-reporting==3.0.4
 cryptography==3.4.7
 redis==4.0.1
 hiredis==2.0.0
+# don't upgrade until stop supporting Centos 7 with python3.6
+# this version is last supported for python3.6
 boto3==1.23.10
 python-consul==1.1.0

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -48,7 +48,13 @@ class AWSKMSClient:
         )
 
     def close(self):
-        self.kms_client.close()
+        # boto3 in version 1.23.10 doesn't have .close() method
+        # https://github.com/boto/boto3/blob/1.23.10/boto3/session.py
+        # We use old versions due to support Centos 7 that have python3.6 from the packages
+        # boto3 1.23.10 the last version which supports python3.6
+        # TODO uncomment after upgrading boto3 and deprecating centos 7 with python3.6
+        #self.kms_client.close()
+        pass
 
     def disable_key(self, keyId):
         self.kms_client.disable_key(KeyId=keyId)


### PR DESCRIPTION
This method is not supported with boto 1.23.10 but only this version supports python3.6 used for tests on centos 7.
boto3 we use in our acra-ee environment, that is why it wasn't visible in CE tests. We can re-install it on EE side, but this method in python code should be patched for that...

## Checklist

- [ ] Change is covered by automated tests
- [ ] The [coding guidelines] are followed
- [ ] Public API has proper documentation in the [Acra documentation] site or has PR on [documentation repository] 
  with new changes
- [ ] CHANGELOG.md is updated (in case of notable or breaking changes)
- [ ] CHANGELOG_DEV.md is updated
- [ ] Benchmark results are attached (if applicable)
- [ ] [Example projects and code samples] are up-to-date (in case of API changes) 

[coding guidelines]: https://golang.org/doc/effective_go
[Example projects and code samples]: https://github.com/cossacklabs/acra-engineering-demo
[Acra documentation]: https://docs.cossacklabs.com/
[documentation repository]: https://github.com/cossacklabs/product-docs