### PR TITLE
Fix acrarollback tests

### DIFF
--- a/network/utils_test.go
+++ b/network/utils_test.go
@@ -90,6 +90,20 @@ func TestGetDriverConnectionStringHost(t *testing.T) {
 		assert.Equal(t, "localhost", host)
 	})
 
+	t.Run("MySQL valid connection URL & login with non-schema characters", func(t *testing.T) {
+		url := "test_-test:test@tcp(localhost:3306)/test"
+		host, err := GetDriverConnectionStringHost(url, true)
+		assert.NoError(t, err)
+		assert.Equal(t, "localhost", host)
+	})
+
+	t.Run("MySQL valid connection URL without credentials and protocol", func(t *testing.T) {
+		url := "(localhost:3306)/test"
+		host, err := GetDriverConnectionStringHost(url, true)
+		assert.NoError(t, err)
+		assert.Equal(t, "localhost", host)
+	})
+
 	t.Run("MySQL invalid connection URL", func(t *testing.T) {
 		url := "test:test@tcp://localhost:3306/test"
 		_, err := GetDriverConnectionStringHost(url, true)
@@ -106,7 +120,7 @@ func TestGetDriverConnectionStringHost(t *testing.T) {
 		url := "postgresql://test:test@localhost:5432/test"
 		_, err := GetDriverConnectionStringHost(url, true)
 		assert.Error(t, err)
-		assert.Equal(t, err.Error(), "invalid MySQL connectionURL")
+		assert.Equal(t, err.Error(), "default addr for network 'localhost:5432' unknown")
 	})
 
 	t.Run("PostgreSQL valid connection URL", func(t *testing.T) {

--- a/tests/test.py
+++ b/tests/test.py
@@ -1221,7 +1221,7 @@ class TestAcraRollback(BaseTestCase):
             DB_ARGS = ['--postgresql_enable']
 
         self.default_acrarollback_args = [
-                                             '--client_id=keypair1',
+                                             '--client_id={}'.format(base.TLS_CERT_CLIENT_ID_1),
                                              '--connection_string={}'.format(connection_string),
                                              '--output_file={}'.format(self.output_filename),
                                              '--keys_dir={}'.format(base.KEYS_FOLDER.name),
@@ -1280,6 +1280,7 @@ class TestAcraRollback(BaseTestCase):
         source_data = set([i['raw_data'].encode('ascii') for i in rows])
         result = self.engine_raw.execute(acrarollback_output_table.select())
         result = result.fetchall()
+        self.assertEqual(len(result), len(rows))
         for data in result:
             self.assertIn(data[0], source_data)
 
@@ -1308,6 +1309,7 @@ class TestAcraRollback(BaseTestCase):
         source_data = set([i['raw_data'].encode('ascii') for i in rows])
         result = self.engine_raw.execute(acrarollback_output_table.select())
         result = result.fetchall()
+        self.assertEqual(len(result), len(rows))
         for data in result:
             self.assertIn(data[0], source_data)
 
@@ -1351,13 +1353,14 @@ class TestAcraRollback(BaseTestCase):
         rows = insert_random_data()
 
         # Rotate storage keys for 'keypair1'
-        create_client_keypair('keypair1', only_storage=True)
+        create_client_keypair(base.TLS_CERT_CLIENT_ID_1, only_storage=True)
 
         # Insert some more data encrypted with new key
         rows = rows + insert_random_data()
 
         # Run acra-rollback for the test table
         self.run_acrarollback([
+            '--execute=true',
             '--select=select data from {};'.format(test_table.name),
             '--insert=insert into {} values({});'.format(
                 acrarollback_output_table.name, self.placeholder)
@@ -1367,6 +1370,7 @@ class TestAcraRollback(BaseTestCase):
         source_data = set([i['raw_data'].encode('ascii') for i in rows])
         result = self.engine_raw.execute(acrarollback_output_table.select())
         result = result.fetchall()
+        self.assertEqual(len(result), len(rows))
         for data in result:
             self.assertIn(data[0], source_data)
 


### PR DESCRIPTION
1. Found, that tests for acra-rollback do nothing and don't check that last query returns anything before iteration:
```
result = self.engine_raw.execute(acrarollback_output_table.select())
        result = result.fetchall()
        for data in result:
            self.assertIn(data[0], source_data)
```
And they succeed even with errors like `key 'keypair1' not found`.
So, fixed the name of keypairs and added additional check that there are anything to iterate.

2. Found, that our `GetDriverConnectionStringHost` method incorrectly parses usernames that don't look like valid `schema` for `net.URL`. So, replaced custom parsing logic to use an appropriate function from the target driver that knows how to deal with its own custom connection string.


## Checklist

- [ ] Change is covered by automated tests
- [ ] The [coding guidelines] are followed
- [ ] Public API has proper documentation in the [Acra documentation] site or has PR on [documentation repository] 
  with new changes
- [ ] CHANGELOG.md is updated (in case of notable or breaking changes)
- [ ] CHANGELOG_DEV.md is updated
- [ ] Benchmark results are attached (if applicable)
- [ ] [Example projects and code samples] are up-to-date (in case of API changes) 

[coding guidelines]: https://golang.org/doc/effective_go
[Example projects and code samples]: https://github.com/cossacklabs/acra-engineering-demo
[Acra documentation]: https://docs.cossacklabs.com/
[documentation repository]: https://github.com/cossacklabs/product-docs