### PR TITLE
improve unicode support

### DIFF
--- a/CHANGELOG_DEV.md
+++ b/CHANGELOG_DEV.md
@@ -1,3 +1,6 @@
+# 0.96.0 - 2023-07-26
+- Improve unicode support
+
 # 0.96.0 - 2023-03-06
 - Added support of PreparedStatement from SQL for PostgreSQL;
 

--- a/encryptor/dbDataCoder.go
+++ b/encryptor/dbDataCoder.go
@@ -20,9 +20,11 @@ import (
 	"bytes"
 	"encoding/hex"
 	"errors"
+	"github.com/cossacklabs/acra/encryptor/config"
 	"github.com/cossacklabs/acra/logging"
 	"github.com/cossacklabs/acra/sqlparser"
 	"github.com/cossacklabs/acra/utils"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/sirupsen/logrus"
 	"strconv"
 	"unicode/utf8"
@@ -34,8 +36,8 @@ var hexNumPrefix = []byte{48, 120}
 
 // DBDataCoder encode/decode binary data to correct string form for specific db
 type DBDataCoder interface {
-	Decode(sqlparser.Expr) ([]byte, error)
-	Encode(sqlparser.Expr, []byte) ([]byte, error)
+	Decode(sqlparser.Expr, config.ColumnEncryptionSetting) ([]byte, error)
+	Encode(sqlparser.Expr, []byte, config.ColumnEncryptionSetting) ([]byte, error)
 }
 
 // errUnsupportedExpression unsupported type of literal to binary encode/decode
@@ -45,7 +47,7 @@ var errUnsupportedExpression = errors.New("unsupported expression")
 type MysqlDBDataCoder struct{}
 
 // Decode decode literals from string to byte slice
-func (*MysqlDBDataCoder) Decode(expr sqlparser.Expr) ([]byte, error) {
+func (*MysqlDBDataCoder) Decode(expr sqlparser.Expr, _ config.ColumnEncryptionSetting) ([]byte, error) {
 	switch val := expr.(type) {
 	case *sqlparser.SQLVal:
 		switch val.Type {
@@ -76,7 +78,7 @@ func (*MysqlDBDataCoder) Decode(expr sqlparser.Expr) ([]byte, error) {
 }
 
 // Encode data to correct literal from binary data for this expression
-func (*MysqlDBDataCoder) Encode(expr sqlparser.Expr, data []byte) ([]byte, error) {
+func (*MysqlDBDataCoder) Encode(expr sqlparser.Expr, data []byte, _ config.ColumnEncryptionSetting) ([]byte, error) {
 	encodeDataToHex := func(val *sqlparser.SQLVal, data []byte) ([]byte, error) {
 		output := make([]byte, hex.EncodedLen(len(data)))
 		hex.Encode(output, data)
@@ -140,7 +142,7 @@ type PostgresqlDBDataCoder struct{}
 // Decode hex/escaped literals to raw binary values for encryption/decryption. String values left as is because it
 // doesn't need any decoding. Historically Int values had support only for tokenization and operated over string SQL
 // literals.
-func (*PostgresqlDBDataCoder) Decode(expr sqlparser.Expr) ([]byte, error) {
+func (*PostgresqlDBDataCoder) Decode(expr sqlparser.Expr, setting config.ColumnEncryptionSetting) ([]byte, error) {
 	switch val := expr.(type) {
 	case *sqlparser.SQLVal:
 		switch val.Type {
@@ -154,7 +156,30 @@ func (*PostgresqlDBDataCoder) Decode(expr sqlparser.Expr) ([]byte, error) {
 				return nil, err
 			}
 			return binValue, err
-		case sqlparser.PgEscapeString, sqlparser.StrVal:
+		case sqlparser.PgEscapeString:
+			// try to decode hex/octal encoding
+			binValue, err := utils.DecodeEscaped(val.Val)
+			if err != nil && err != utils.ErrDecodeOctalString {
+				// return error on hex decode
+				if _, ok := err.(hex.InvalidByteError); err == hex.ErrLength || ok {
+					return nil, err
+				} else if err == utils.ErrDecodeOctalString {
+					return nil, err
+				}
+
+				logrus.WithError(err).WithField(logging.FieldKeyEventCode, logging.EventCodeErrorCodingCantDecodeSQLValue).Warningln("Can't decode value, process as unescaped string")
+				// return value as is because it may be string with printable characters that wasn't encoded on client
+				return val.Val, nil
+			}
+			return binValue, nil
+		case sqlparser.StrVal:
+			// simple strings should be handled as is
+			typeID := setting.GetDBDataTypeID()
+			if typeID != 0 && typeID != pgtype.ByteaOID {
+				return val.Val, nil
+			}
+			// bytea strings are escaped with \x hex value or with octal encoding
+
 			// try to decode hex/octal encoding
 			binValue, err := utils.DecodeEscaped(val.Val)
 			if err != nil && err != utils.ErrDecodeOctalString {
@@ -176,7 +201,7 @@ func (*PostgresqlDBDataCoder) Decode(expr sqlparser.Expr) ([]byte, error) {
 }
 
 // Encode data to correct literal from binary data for this expression
-func (*PostgresqlDBDataCoder) Encode(expr sqlparser.Expr, data []byte) ([]byte, error) {
+func (*PostgresqlDBDataCoder) Encode(expr sqlparser.Expr, data []byte, _ config.ColumnEncryptionSetting) ([]byte, error) {
 	switch val := expr.(type) {
 	case *sqlparser.SQLVal:
 		switch val.Type {
@@ -197,24 +222,12 @@ func (*PostgresqlDBDataCoder) Encode(expr sqlparser.Expr, data []byte) ([]byte, 
 			// otherwise change type and pass it below for hex encoding
 			val.Type = sqlparser.PgEscapeString
 			fallthrough
-		case sqlparser.StrVal:
-			binValue, err := utils.DecodeEscaped(data)
-			// Check is encryption/tokenization operation returned string in "binary string" format instead of UTF8 string.
-			// If we can decode it as binary value and get another value, then escape it as hex binary value.
-			if err != nil || !bytes.Equal(binValue, data) {
-				return PgEncodeToHexString(data), nil
-			}
-			// If the binValue the same to data means data is Printable, return as is
-			if bytes.Equal(binValue, data) {
-				return data, nil
-			}
-			val.Type = sqlparser.PgEscapeString
-			fallthrough
-		case sqlparser.PgEscapeString:
+		case sqlparser.StrVal, sqlparser.PgEscapeString:
 			// valid strings we pass as is without extra encoding
 			if utils.IsPrintablePostgresqlString(data) {
 				return data, nil
 			}
+			// bytea type accepts strings with hex/octal encoding, just encode
 			return PgEncodeToHexString(data), nil
 		}
 	}

--- a/encryptor/queryDataEncryptor_test.go
+++ b/encryptor/queryDataEncryptor_test.go
@@ -431,7 +431,7 @@ schemas:
 		{
 			Query:             `INSERT INTO "tablewithoutcolumnschema" ("specified_client_id", "other_column", "default_client_id") VALUES ('%s', 1, '%s')`,
 			QueryData:         []interface{}{simpleStringData, simpleStringData},
-			ExpectedQueryData: []interface{}{encryptedValue, encryptedValue},
+			ExpectedQueryData: []interface{}{PgEncodeToHexString(encryptedValue), PgEncodeToHexString(encryptedValue)},
 			Normalized:        true,
 			Changed:           true,
 			ExpectedIDS:       [][]byte{specifiedClientID, defaultClientID},
@@ -442,7 +442,7 @@ schemas:
 		{
 			Query:             `UPDATE "tablewithoutcolumnschema" as "t" set "other_column"='%s', "specified_client_id"='%s', "default_client_id"='%s'`,
 			QueryData:         []interface{}{simpleStringData, simpleStringData, simpleStringData},
-			ExpectedQueryData: []interface{}{simpleStringData, encryptedValue, encryptedValue},
+			ExpectedQueryData: []interface{}{simpleStringData, PgEncodeToHexString(encryptedValue), PgEncodeToHexString(encryptedValue)},
 			Normalized:        true,
 			Changed:           true,
 			ExpectedIDS:       [][]byte{specifiedClientID, defaultClientID},
@@ -496,7 +496,7 @@ schemas:
 		{
 			Query:             `UPDATE lowercasetable set other_column='%s', specified_client_id='%s', "DEFAULT_client_id"='%s'`,
 			QueryData:         []interface{}{simpleStringData, simpleStringData, simpleStringData},
-			ExpectedQueryData: []interface{}{simpleStringData, encryptedValue, encryptedValue},
+			ExpectedQueryData: []interface{}{simpleStringData, PgEncodeToHexString(encryptedValue), PgEncodeToHexString(encryptedValue)},
 			Normalized:        true,
 			Changed:           true,
 			ExpectedIDS:       [][]byte{specifiedClientID, defaultClientID},
@@ -507,7 +507,7 @@ schemas:
 		{
 			Query:             `UPDATE lowercasetable set other_column='%s', specified_client_id='%s', DEFAULT_client_id='%s'`,
 			QueryData:         []interface{}{simpleStringData, simpleStringData, simpleStringData},
-			ExpectedQueryData: []interface{}{simpleStringData, encryptedValue, simpleStringData},
+			ExpectedQueryData: []interface{}{simpleStringData, PgEncodeToHexString(encryptedValue), simpleStringData},
 			Normalized:        true,
 			Changed:           true,
 			ExpectedIDS:       [][]byte{specifiedClientID},
@@ -518,7 +518,7 @@ schemas:
 		{
 			Query:             `UPDATE "lowercasetable" set other_column='%s', specified_client_id='%s', "DEFAULT_client_id"='%s'`,
 			QueryData:         []interface{}{simpleStringData, simpleStringData, simpleStringData},
-			ExpectedQueryData: []interface{}{simpleStringData, encryptedValue, encryptedValue},
+			ExpectedQueryData: []interface{}{simpleStringData, PgEncodeToHexString(encryptedValue), PgEncodeToHexString(encryptedValue)},
 			Normalized:        true,
 			Changed:           true,
 			ExpectedIDS:       [][]byte{specifiedClientID, defaultClientID},
@@ -529,7 +529,7 @@ schemas:
 		{
 			Query:             `UPDATE LOWERCASETABLE set other_column='%s', specified_client_id='%s', "DEFAULT_client_id"='%s'`,
 			QueryData:         []interface{}{simpleStringData, simpleStringData, simpleStringData},
-			ExpectedQueryData: []interface{}{simpleStringData, encryptedValue, encryptedValue},
+			ExpectedQueryData: []interface{}{simpleStringData, PgEncodeToHexString(encryptedValue), PgEncodeToHexString(encryptedValue)},
 			Normalized:        true,
 			Changed:           true,
 			ExpectedIDS:       [][]byte{specifiedClientID, defaultClientID},
@@ -584,7 +584,7 @@ schemas:
 		{
 			Query:             `UPDATE "UPPERCASETABLE" set "other_column"='%s', "specified_client_id"='%s', "DEFAULT_client_id"='%s'`,
 			QueryData:         []interface{}{simpleStringData, simpleStringData, simpleStringData},
-			ExpectedQueryData: []interface{}{simpleStringData, encryptedValue, encryptedValue},
+			ExpectedQueryData: []interface{}{simpleStringData, PgEncodeToHexString(encryptedValue), PgEncodeToHexString(encryptedValue)},
 			Normalized:        true,
 			Changed:           true,
 			ExpectedIDS:       [][]byte{specifiedClientID, defaultClientID},

--- a/hmac/decryptor/hashQuery.go
+++ b/hmac/decryptor/hashQuery.go
@@ -138,7 +138,7 @@ func (encryptor *HashQuery) OnQuery(ctx context.Context, query base.OnQueryObjec
 
 		// substring(column, 1, <HMAC_size>) = 'value' ===> substring(column, 1, <HMAC_size>) = <HMAC('value')>
 		// substring(column, 1, <HMAC_size>) = $1      ===> no changes
-		err := queryEncryptor.UpdateExpressionValue(ctx, item.Expr.Right, encryptor.coder, encryptor.calculateHmac)
+		err := queryEncryptor.UpdateExpressionValue(ctx, item.Expr.Right, encryptor.coder, item.Setting, encryptor.calculateHmac)
 		if err != nil {
 			logrus.WithError(err).Debugln("Failed to update expression")
 			return query, false, err

--- a/hmac/decryptor/hashQuery_test.go
+++ b/hmac/decryptor/hashQuery_test.go
@@ -199,7 +199,7 @@ func TestSearchableWithTextFormat(t *testing.T) {
 		hmacValue, err := encryptor.calculateHmac(ctx, []byte(dataQueryPart))
 		assert.NoError(t, err)
 
-		newData, err := coder.Encode(rightVal, hmacValue)
+		newData, err := coder.Encode(rightVal, hmacValue, &config.BasicColumnEncryptionSetting{})
 		assert.NoError(t, err)
 		assert.Equal(t, len(rightVal.Val), len(newData))
 	}

--- a/pseudonymization/tokenizeQuery.go
+++ b/pseudonymization/tokenizeQuery.go
@@ -85,7 +85,7 @@ func (encryptor *TokenizeQuery) OnQuery(ctx context.Context, query base.OnQueryO
 
 		encryptor.searchableQueryFilter.ChangeSearchableOperator(item.Expr)
 
-		err = queryEncryptor.UpdateExpressionValue(ctx, item.Expr.Right, encryptor.coder, encryptor.getTokenizerDataWithSetting(item.Setting))
+		err = queryEncryptor.UpdateExpressionValue(ctx, item.Expr.Right, encryptor.coder, item.Setting, encryptor.getTokenizerDataWithSetting(item.Setting))
 		if err != nil {
 			logrus.WithError(err).Debugln("Failed to update expression")
 			return query, false, err

--- a/tests/base.py
+++ b/tests/base.py
@@ -523,7 +523,7 @@ def get_random_id():
 
 def get_pregenerated_random_data():
     data_file = random.choice(TEST_RANDOM_DATA_FILES)
-    with open(data_file, 'r') as f:
+    with open(data_file, 'r', encoding='utf-8') as f:
         return f.read()
 
 
@@ -1070,7 +1070,7 @@ class MysqlConnectorCExecutor(QueryExecutor):
         if args is None:
             args = []
         with contextlib.closing(mysql.connector.connect(
-                use_unicode=True, raw=self.connection_args.raw, charset='ascii',
+                use_unicode=True, raw=self.connection_args.raw, charset='utf8',
                 host=self.connection_args.host, port=self.connection_args.port,
                 user=self.connection_args.user,
                 password=self.connection_args.password,
@@ -1089,7 +1089,7 @@ class MysqlConnectorCExecutor(QueryExecutor):
         if args is None:
             args = []
         with contextlib.closing(mysql.connector.connect(
-                use_unicode=True, charset='ascii',
+                use_unicode=True, charset='utf8',
                 host=self.connection_args.host, port=self.connection_args.port,
                 user=self.connection_args.user,
                 password=self.connection_args.password,
@@ -1108,7 +1108,7 @@ class MysqlConnectorCExecutor(QueryExecutor):
         if args is None:
             args = []
         with contextlib.closing(mysql.connector.connect(
-                use_unicode=True, charset='ascii',
+                use_unicode=True, charset='utf8',
                 host=self.connection_args.host, port=self.connection_args.port,
                 user=self.connection_args.user,
                 password=self.connection_args.password,
@@ -1137,7 +1137,7 @@ class MysqlExecutor(QueryExecutor):
         if args is None:
             args = []
         with contextlib.closing(mysql.connector.connection.MySQLConnection(
-                use_unicode=False, raw=self.connection_args.raw, charset='ascii',
+                use_unicode=False, raw=self.connection_args.raw, charset='utf8',
                 host=self.connection_args.host, port=self.connection_args.port,
                 user=self.connection_args.user,
                 password=self.connection_args.password,
@@ -1156,7 +1156,7 @@ class MysqlExecutor(QueryExecutor):
         if args is None:
             args = []
         with contextlib.closing(mysql.connector.connection.MySQLConnection(
-                use_unicode=False, charset='ascii',
+                use_unicode=False, charset='utf8',
                 host=self.connection_args.host, port=self.connection_args.port,
                 user=self.connection_args.user,
                 password=self.connection_args.password,
@@ -1175,7 +1175,7 @@ class MysqlExecutor(QueryExecutor):
         if args is None:
             args = []
         with contextlib.closing(mysql.connector.connection.MySQLConnection(
-                use_unicode=False, charset='ascii',
+                use_unicode=False, charset='utf8',
                 host=self.connection_args.host, port=self.connection_args.port,
                 user=self.connection_args.user,
                 password=self.connection_args.password,

--- a/tests/generate_random_data.py
+++ b/tests/generate_random_data.py
@@ -2,13 +2,14 @@ import json
 import os
 import random
 import string
+from random_utils import string_set
 
 TEMP_DATA_FOLDER_VARNAME = 'TEST_RANDOM_DATA_FOLDER'
 
 
 def get_random_data(config):
     size = random.randint(config['data_min_size'], config['data_max_size'])
-    return ''.join(random.SystemRandom().choice(string.ascii_letters) for _ in range(size)).encode('ascii')
+    return ''.join(random.SystemRandom().choice(string_set) for _ in range(size)).encode('utf-8')
 
 
 if __name__ == '__main__':

--- a/tests/random_utils.py
+++ b/tests/random_utils.py
@@ -9,8 +9,35 @@ max_positive_int32 = 2 ** 31
 max_uint64 = 2 ** 64
 max_negative_int64 = -2 ** 63
 max_positive_int64 = 2 ** 63
-string_set = string.ascii_letters + string.digits
 
+# Update this to include code point ranges to be sampled
+unicode_ranges = [
+    ( 0x0021, 0x0021 ),
+    # without #$%&
+    #( 0x0023, 0x0026 ),
+    # without \:;<=>?@ due to they can make conflict with our string manipulations over SQL queries
+    # with different placeholders acceptable by different drivers/db
+
+    ( 0x0028, 0x0039 ),
+    ( 0x0041, 0x005B ),
+    ( 0x005D, 0x007E ),
+
+    ( 0x00A1, 0x00AC ),
+    ( 0x00AE, 0x00FF ),
+    ( 0x0100, 0x017F ),
+    ( 0x0180, 0x024F ),
+    ( 0x2C60, 0x2C7F ),
+    ( 0x16A0, 0x16F0 ),
+    ( 0x0370, 0x0377 ),
+    ( 0x037A, 0x037E ),
+    ( 0x0384, 0x038A ),
+    ( 0x038C, 0x038C ),
+]
+
+string_set = [
+    chr(code_point) for current_range in unicode_ranges
+    for code_point in range(current_range[0], current_range[1] + 1)
+]
 
 def random_int32():
     return randint(max_negative_int32, max_positive_int32)

--- a/tests/test.py
+++ b/tests/test.py
@@ -808,7 +808,7 @@ class TestKeyStoreMigration(BaseTestCase):
         old_master_key = os.environ[ACRA_MASTER_KEY_VAR_NAME]
         os.environ[ACRA_MASTER_KEY_VAR_NAME] = new_master_key
         acra_struct = create_acrastruct(
-            data.encode('ascii'),
+            data.encode('utf-8'),
             read_storage_public_key(
                 self.client_id,
                 self.current_key_store_path()))
@@ -857,12 +857,12 @@ class TestKeyStoreMigration(BaseTestCase):
 
             # Check that we're able to put and get data via AcraServer.
             selected = self.select_as_client(row_id_1)
-            self.assertEquals(selected['data'], data_1.encode('ascii'))
+            self.assertEquals(selected['data'], data_1.encode('utf-8'))
             self.assertEquals(selected['raw_data'], data_1)
 
             # Get encrypted data. It should really be encrypted.
             encrypted_1 = self.select_directly(row_id_1)
-            self.assertNotEquals(encrypted_1['data'], data_1.encode('ascii'))
+            self.assertNotEquals(encrypted_1['data'], data_1.encode('utf-8'))
 
         self.migrate_key_store('v2')
 
@@ -870,7 +870,7 @@ class TestKeyStoreMigration(BaseTestCase):
         with self.running_services():
             # Old data should still be there, accessible via AcraServer.
             selected = self.select_as_client(row_id_1)
-            self.assertEquals(selected['data'], data_1.encode('ascii'))
+            self.assertEquals(selected['data'], data_1.encode('utf-8'))
             self.assertEquals(selected['raw_data'], data_1)
 
             # Key migration does not change encrypted data.
@@ -881,7 +881,7 @@ class TestKeyStoreMigration(BaseTestCase):
             # We're able to put some new data into the table and get it back.
             row_id_2 = self.insert_as_client(data_2)
             selected = self.select_as_client(row_id_2)
-            self.assertEquals(selected['data'], data_2.encode('ascii'))
+            self.assertEquals(selected['data'], data_2.encode('utf-8'))
             self.assertEquals(selected['raw_data'], data_2)
 
     def test_moved_key_store(self):
@@ -893,7 +893,7 @@ class TestKeyStoreMigration(BaseTestCase):
         with self.running_services():
             row_id = self.insert_as_client(data)
             selected = self.select_as_client(row_id)
-            self.assertEquals(selected['data'], data.encode('ascii'))
+            self.assertEquals(selected['data'], data.encode('utf-8'))
 
         # Move the keystore to a different (still temporary) location.
         self.change_key_store_path()
@@ -903,7 +903,7 @@ class TestKeyStoreMigration(BaseTestCase):
         # but located at different path.
         with self.running_services():
             selected = self.select_as_client(row_id)
-            self.assertEquals(selected['data'], data.encode('ascii'))
+            self.assertEquals(selected['data'], data.encode('utf-8'))
 
 
 class TestAcraKeysWithRotatedKeys(unittest.TestCase):
@@ -1247,7 +1247,7 @@ class TestPostgreSQLParseQueryErrorSkipExit(AcraCatchLogsMixin, BaseTestCase):
         row_id = get_random_id()
         data = get_pregenerated_random_data()
         public_key = self.read_public_key()
-        acra_struct = create_acrastruct(data.encode('ascii'), public_key)
+        acra_struct = create_acrastruct(data.encode('utf-8'), public_key)
         self.engine1.execute(
             test_table.insert(),
             {'id': row_id, 'data': acra_struct, 'raw_data': data})
@@ -1396,7 +1396,7 @@ class TestAcraRollback(BaseTestCase):
             data = get_pregenerated_random_data()
             row = {
                 'raw_data': data,
-                'data': create_acrastruct(data.encode('ascii'), server_public1),
+                'data': create_acrastruct(data.encode('utf-8'), server_public1),
                 'id': get_random_id()
             }
             rows.append(row)
@@ -1413,7 +1413,7 @@ class TestAcraRollback(BaseTestCase):
             for line in f:
                 self.engine_raw.execute(line)
 
-        source_data = set([i['raw_data'].encode('ascii') for i in rows])
+        source_data = set([i['raw_data'].encode('utf-8') for i in rows])
         result = self.engine_raw.execute(acrarollback_output_table.select())
         result = result.fetchall()
         self.assertEqual(len(result), len(rows))
@@ -1428,7 +1428,7 @@ class TestAcraRollback(BaseTestCase):
             data = get_pregenerated_random_data()
             row = {
                 'raw_data': data,
-                'data': create_acrastruct(data.encode('ascii'), server_public1),
+                'data': create_acrastruct(data.encode('utf-8'), server_public1),
                 'id': get_random_id()
             }
             rows.append(row)
@@ -1442,7 +1442,7 @@ class TestAcraRollback(BaseTestCase):
         ]
         self.run_acrarollback(args)
 
-        source_data = set([i['raw_data'].encode('ascii') for i in rows])
+        source_data = set([i['raw_data'].encode('utf-8') for i in rows])
         result = self.engine_raw.execute(acrarollback_output_table.select())
         result = result.fetchall()
         self.assertEqual(len(result), len(rows))
@@ -1478,7 +1478,7 @@ class TestAcraRollback(BaseTestCase):
                 data = get_pregenerated_random_data()
                 row = {
                     'raw_data': data,
-                    'data': create_acrastruct(data.encode('ascii'), public_key),
+                    'data': create_acrastruct(data.encode('utf-8'), public_key),
                     'id': get_random_id()
                 }
                 rows.append(row)
@@ -1503,7 +1503,7 @@ class TestAcraRollback(BaseTestCase):
         ])
 
         # Rollback should successfully use previous keys to decrypt data
-        source_data = set([i['raw_data'].encode('ascii') for i in rows])
+        source_data = set([i['raw_data'].encode('utf-8') for i in rows])
         result = self.engine_raw.execute(acrarollback_output_table.select())
         result = result.fetchall()
         self.assertEqual(len(result), len(rows))
@@ -1723,11 +1723,11 @@ class BasePrepareStatementMixin:
         server_public1 = read_storage_public_key(client_id, base.KEYS_FOLDER.name)
         data = get_pregenerated_random_data()
         acra_struct = create_acrastruct(
-            data.encode('ascii'), server_public1)
+            data.encode('utf-8'), server_public1)
         row_id = get_random_id()
 
         self.log(storage_client_id=client_id,
-                 data=acra_struct, expected=data.encode('ascii'))
+                 data=acra_struct, expected=data.encode('utf-8'))
 
         self.engine1.execute(
             test_table.insert(),
@@ -1744,7 +1744,7 @@ class BasePrepareStatementMixin:
             sa.select([test_table])
             .where(test_table.c.id == row_id))
         row = result.fetchone()
-        self.assertNotEqual(row['data'].decode('ascii', errors='ignore'),
+        self.assertNotEqual(row['data'].decode('utf-8', errors='ignore'),
                             row['raw_data'])
         self.assertEqual(row['empty'], b'')
 
@@ -1752,7 +1752,7 @@ class BasePrepareStatementMixin:
             sa.select([test_table])
             .where(test_table.c.id == row_id))
         row = result.fetchone()
-        self.assertNotEqual(row['data'].decode('ascii', errors='ignore'),
+        self.assertNotEqual(row['data'].decode('utf-8', errors='ignore'),
                             row['raw_data'])
         self.assertEqual(row['empty'], b'')
 
@@ -1766,16 +1766,16 @@ class BasePrepareStatementMixin:
         suffix_data = get_pregenerated_random_data()[:10]
         fake_offset = (3 + 45 + 84) - 4
         fake_acra_struct = create_acrastruct(
-            incorrect_data.encode('ascii'), server_public1)[:fake_offset]
+            incorrect_data.encode('utf-8'), server_public1)[:fake_offset]
         inner_acra_struct = create_acrastruct(
-            correct_data.encode('ascii'), server_public1)
-        data = fake_acra_struct + inner_acra_struct + suffix_data.encode('ascii')
+            correct_data.encode('utf-8'), server_public1)
+        data = fake_acra_struct + inner_acra_struct + suffix_data.encode('utf-8')
         correct_data = correct_data + suffix_data
         row_id = get_random_id()
 
         self.log(storage_client_id=client_id,
                  data=data,
-                 expected=fake_acra_struct + correct_data.encode('ascii'))
+                 expected=fake_acra_struct + correct_data.encode('utf-8'))
 
         self.engine1.execute(
             test_table.insert(),
@@ -1800,7 +1800,7 @@ class BasePrepareStatementMixin:
             sa.select([test_table])
             .where(test_table.c.id == row_id))
         row = result.fetchone()
-        self.assertNotEqual(row['data'][fake_offset:].decode('ascii', errors='ignore'),
+        self.assertNotEqual(row['data'][fake_offset:].decode('utf-8', errors='ignore'),
                             row['raw_data'])
         self.assertEqual(row['empty'], b'')
 
@@ -1808,7 +1808,7 @@ class BasePrepareStatementMixin:
             sa.select([test_table])
             .where(test_table.c.id == row_id))
         row = result.fetchone()
-        self.assertNotEqual(row['data'][fake_offset:].decode('ascii', errors='ignore'),
+        self.assertNotEqual(row['data'][fake_offset:].decode('utf-8', errors='ignore'),
                             row['raw_data'])
         self.assertEqual(row['empty'], b'')
 
@@ -1934,7 +1934,7 @@ class TestTranslatorEnableCachedOnStartup(AcraTranslatorMixin, BaseTestCase):
         self.assertEqual(create_client_keypair_from_certificate(tls_cert=TEST_TLS_CLIENT_CERT,
                                                                 extractor=self.get_identifier_extractor_type(),
                                                                 keys_dir=self.cached_dir.name), 0)
-        data = get_pregenerated_random_data().encode('ascii')
+        data = get_pregenerated_random_data().encode('utf-8')
         client_id_private_key = read_storage_private_key(self.cached_dir.name, client_id)
         connection_string = 'tcp://127.0.0.1:{}'.format(translator_port)
         translator_kwargs = {
@@ -2027,7 +2027,7 @@ class TestAcraRotate(BaseTestCase):
             key_before_rotate = {client_id: b64encode(self.read_public_key(client_id, keys_folder))}
 
             for i in range(keys_file_count):
-                data = get_pregenerated_random_data().encode('ascii')
+                data = get_pregenerated_random_data().encode('utf-8')
                 acrastruct = create_acrastruct(data, b64decode(key_before_rotate[client_id]))
                 filename = filename_template.format(
                     dir=data_folder, id=client_id, num=i)
@@ -2119,13 +2119,13 @@ class TestAcraRotate(BaseTestCase):
 
         data = get_pregenerated_random_data()
         client_id = base.TLS_CERT_CLIENT_ID_1
-        acra_struct = create_acrastruct_with_client_id(data.encode('ascii'), client_id)
+        acra_struct = create_acrastruct_with_client_id(data.encode('utf-8'), client_id)
         row_id = get_random_id()
         data_before_rotate[row_id] = acra_struct
         self.engine_raw.execute(
             rotate_test_table.insert(),
             {'id': row_id, 'data': acra_struct, 'raw_data': data,
-             'key_id': client_id.encode('ascii')})
+             'key_id': client_id.encode('utf-8')})
 
         if rotate_storage_keys:
             create_client_keypair(client_id, only_storage=True)
@@ -2387,7 +2387,7 @@ class TestPrometheusMetrics(AcraTranslatorMixin, BaseTestCase):
         }
         translator_port = 3456
         metrics_port = translator_port + 1
-        data = get_pregenerated_random_data().encode('ascii')
+        data = get_pregenerated_random_data().encode('utf-8')
         client_id = base.TLS_CERT_CLIENT_ID_1
         encryption_key = read_storage_public_key(
             client_id, keys_dir=base.KEYS_FOLDER.name)
@@ -2725,11 +2725,11 @@ class TestTLSAuthenticationDirectlyToAcraByDistinguishedName(TLSAuthenticationDi
         server_public1 = read_storage_public_key(self.acra_writer_id, base.KEYS_FOLDER.name)
         data = get_pregenerated_random_data()
         acra_struct = create_acrastruct(
-            data.encode('ascii'), server_public1)
+            data.encode('utf-8'), server_public1)
         row_id = get_random_id()
 
         self.log(storage_client_id=self.acra_writer_id,
-                 data=acra_struct, expected=data.encode('ascii'))
+                 data=acra_struct, expected=data.encode('utf-8'))
 
         self.engine1.execute(
             test_table.insert(),
@@ -2745,7 +2745,7 @@ class TestTLSAuthenticationDirectlyToAcraByDistinguishedName(TLSAuthenticationDi
             sa.select([test_table])
             .where(test_table.c.id == row_id))
         row = result.fetchone()
-        self.assertNotEqual(row['data'].decode('ascii', errors='ignore'),
+        self.assertNotEqual(row['data'].decode('utf-8', errors='ignore'),
                             row['raw_data'])
         self.assertEqual(row['empty'], b'')
 
@@ -2753,7 +2753,7 @@ class TestTLSAuthenticationDirectlyToAcraByDistinguishedName(TLSAuthenticationDi
             sa.select([test_table])
             .where(test_table.c.id == row_id))
         row = result.fetchone()
-        self.assertNotEqual(row['data'].decode('ascii', errors='ignore'),
+        self.assertNotEqual(row['data'].decode('utf-8', errors='ignore'),
                             row['raw_data'])
         self.assertEqual(row['empty'], b'')
 
@@ -2766,16 +2766,16 @@ class TestTLSAuthenticationDirectlyToAcraByDistinguishedName(TLSAuthenticationDi
         suffix_data = get_pregenerated_random_data()[:10]
         fake_offset = (3 + 45 + 84) - 4
         fake_acra_struct = create_acrastruct(
-            incorrect_data.encode('ascii'), server_public1)[:fake_offset]
+            incorrect_data.encode('utf-8'), server_public1)[:fake_offset]
         inner_acra_struct = create_acrastruct(
-            correct_data.encode('ascii'), server_public1)
-        data = fake_acra_struct + inner_acra_struct + suffix_data.encode('ascii')
+            correct_data.encode('utf-8'), server_public1)
+        data = fake_acra_struct + inner_acra_struct + suffix_data.encode('utf-8')
         correct_data = correct_data + suffix_data
         row_id = get_random_id()
 
         self.log(storage_client_id=self.acra_writer_id,
                  data=data,
-                 expected=fake_acra_struct + correct_data.encode('ascii'))
+                 expected=fake_acra_struct + correct_data.encode('utf-8'))
 
         self.engine1.execute(
             test_table.insert(),
@@ -2798,7 +2798,7 @@ class TestTLSAuthenticationDirectlyToAcraByDistinguishedName(TLSAuthenticationDi
             sa.select([test_table])
             .where(test_table.c.id == row_id))
         row = result.fetchone()
-        self.assertNotEqual(row['data'][fake_offset:].decode('ascii', errors='ignore'),
+        self.assertNotEqual(row['data'][fake_offset:].decode('utf-8', errors='ignore'),
                             row['raw_data'])
         self.assertEqual(row['empty'], b'')
 
@@ -2806,7 +2806,7 @@ class TestTLSAuthenticationDirectlyToAcraByDistinguishedName(TLSAuthenticationDi
             sa.select([test_table])
             .where(test_table.c.id == row_id))
         row = result.fetchone()
-        self.assertNotEqual(row['data'][fake_offset:].decode('ascii', errors='ignore'),
+        self.assertNotEqual(row['data'][fake_offset:].decode('utf-8', errors='ignore'),
                             row['raw_data'])
         self.assertEqual(row['empty'], b'')
 
@@ -4319,9 +4319,9 @@ class LimitOffsetQueryTest(BaseTransparentEncryption):
 
         for i in range(data_amount):
             if i % 2 == 0:
-                row = {'id': i, 'data': searchable_data.encode('ascii'), 'raw_data': searchable_data}
+                row = {'id': i, 'data': searchable_data.encode('utf-8'), 'raw_data': searchable_data}
             else:
-                data = get_pregenerated_random_data().encode('ascii')
+                data = get_pregenerated_random_data().encode('utf-8')
                 row = {'id': i, 'data': data, 'raw_data': data}
             data_set.append(row)
             self.engine1.execute(self.encryptor_table.insert(), row)
@@ -4337,7 +4337,7 @@ class LimitOffsetQueryTest(BaseTransparentEncryption):
             for i, row in enumerate(result):
                 self.assertEqual(row['id'], expected_data_slice[i]['id'])
                 self.assertEqual(memoryview_to_bytes(row['data']),
-                                 expected_data_slice[i]['raw_data'].encode('ascii'))
+                                 expected_data_slice[i]['raw_data'].encode('utf-8'))
                 self.assertEqual(row['raw_data'], expected_data_slice[i]['raw_data'])
                 self.assertEqual(row['empty'], b'')
 
@@ -4402,9 +4402,9 @@ class LimitOffsetQueryTest(BaseTransparentEncryption):
         for i in range(10):
             data = get_pregenerated_random_data()
             acra_struct = create_acrastruct(
-                data.encode('ascii'), server_public1)
+                data.encode('utf-8'), server_public1)
             self.log(storage_client_id=client_id,
-                     data=acra_struct, expected=data.encode('ascii'))
+                     data=acra_struct, expected=data.encode('utf-8'))
             row = {'id': i, 'data': acra_struct, 'raw_data': data}
             data_set.append(row)
             self.engine1.execute(test_table.insert(), row)
@@ -4417,7 +4417,7 @@ class LimitOffsetQueryTest(BaseTransparentEncryption):
             for i, row in enumerate(result):
                 self.assertEqual(row['id'], expected_data_slice[i]['id'])
                 self.assertEqual(memoryview_to_bytes(row['data']),
-                                 expected_data_slice[i]['raw_data'].encode('ascii'))
+                                 expected_data_slice[i]['raw_data'].encode('utf-8'))
                 self.assertEqual(row['raw_data'], expected_data_slice[i]['raw_data'])
                 self.assertEqual(row['empty'], b'')
 
@@ -4429,7 +4429,7 @@ class LimitOffsetQueryTest(BaseTransparentEncryption):
             for i, row in enumerate(result):
                 self.assertEqual(row['id'], expected_data_slice[i]['id'])
                 self.assertNotEqual(
-                    memoryview_to_bytes(row['data']), expected_data_slice[i]['raw_data'].encode('ascii'))
+                    memoryview_to_bytes(row['data']), expected_data_slice[i]['raw_data'].encode('utf-8'))
                 self.assertEqual(row['raw_data'], expected_data_slice[i]['raw_data'])
                 self.assertEqual(row['empty'], b'')
 
@@ -4442,17 +4442,17 @@ class LimitOffsetQueryTest(BaseTransparentEncryption):
         incorrect_data = get_pregenerated_random_data()
         suffix_data = get_pregenerated_random_data()[:10]
         fake_acra_struct = create_acrastruct(
-            incorrect_data.encode('ascii'), server_public1)[:fake_offset]
+            incorrect_data.encode('utf-8'), server_public1)[:fake_offset]
         data_set = []
         for i in range(10):
             correct_data = get_pregenerated_random_data()
             inner_acra_struct = create_acrastruct(
-                correct_data.encode('ascii'), server_public1)
-            data = fake_acra_struct + inner_acra_struct + suffix_data.encode('ascii')
+                correct_data.encode('utf-8'), server_public1)
+            data = fake_acra_struct + inner_acra_struct + suffix_data.encode('utf-8')
             correct_data = correct_data + suffix_data
             self.log(storage_client_id=client_id,
                      data=data,
-                     expected=fake_acra_struct + correct_data.encode('ascii'))
+                     expected=fake_acra_struct + correct_data.encode('utf-8'))
             row = {'id': i, 'data': data, 'raw_data': correct_data}
             data_set.append(row)
             self.engine1.execute(test_table.insert(), row)
@@ -4476,7 +4476,7 @@ class LimitOffsetQueryTest(BaseTransparentEncryption):
             self.assertEqual(len(expected_data_slice), len(result))
             for i, row in enumerate(result):
                 self.assertNotEqual(
-                    memoryview_to_bytes(row['data'][fake_offset:]).decode('ascii', errors='ignore'),
+                    memoryview_to_bytes(row['data'][fake_offset:]).decode('utf-8', errors='ignore'),
                     row['raw_data'])
 
                 self.assertEqual(row['id'], expected_data_slice[i]['id'])
@@ -4858,15 +4858,15 @@ class TestSQLPreparedStatements(AcraCatchLogsMixin):
     def get_test_prepared_sql_statements_table_context(self):
         return {
             'id': base.get_random_id(),
-            'default_client_id': base.get_pregenerated_random_data().encode('ascii'),
+            'default_client_id': base.get_pregenerated_random_data().encode('utf-8'),
             'number': base.get_random_id(),
-            'specified_client_id': base.get_pregenerated_random_data().encode('ascii'),
-            'raw_data': base.get_pregenerated_random_data().encode('ascii'),
-            'searchable': base.get_pregenerated_random_data().encode('ascii'),
+            'specified_client_id': base.get_pregenerated_random_data().encode('utf-8'),
+            'raw_data': base.get_pregenerated_random_data().encode('utf-8'),
+            'searchable': base.get_pregenerated_random_data().encode('utf-8'),
             'empty': b'',
             'nullable': None,
-            'masking': base.get_pregenerated_random_data().encode('ascii'),
-            'token_bytes': base.get_pregenerated_random_data().encode('ascii'),
+            'masking': base.get_pregenerated_random_data().encode('utf-8'),
+            'token_bytes': base.get_pregenerated_random_data().encode('utf-8'),
             'token_email': base.get_pregenerated_random_data(),
             'token_str': base.get_pregenerated_random_data(),
             'token_i32': base.random.randint(0, 2 ** 16),

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -93,9 +93,9 @@ class KeyMakerTest(unittest.TestCase):
                 signature = os.urandom(size)
                 keys = {
                     'encryption': b64encode(encryption).decode('ascii'),
-                    'signature': b64encode(signature).decode('ascii'),
+                    'signature': b64encode(signature).decode('utf-8'),
                 }
-                value = json.dumps(keys).encode('ascii')
+                value = json.dumps(keys).encode('utf-8')
             else:
                 self.fail("keystore version not supported")
 
@@ -452,22 +452,22 @@ class BaseTestCase(PrometheusMixin, unittest.TestCase):
         log_entry = {
             'master_key': base.get_master_key(),
             'key_name': key_name(),
-            'data': b64encode(data).decode('ascii'),
-            'expected': b64encode(expected).decode('ascii'),
+            'data': b64encode(data).decode('utf-8'),
+            'expected': b64encode(expected).decode('utf-8'),
         }
 
         if storage_client_id:
             public_key = base.read_storage_public_key(storage_client_id, base.KEYS_FOLDER.name)
             private_key = base.read_storage_private_key(base.KEYS_FOLDER.name, storage_client_id)
-            log_entry['public_key'] = b64encode(public_key).decode('ascii')
-            log_entry['private_key'] = b64encode(private_key).decode('ascii')
+            log_entry['public_key'] = b64encode(public_key).decode('utf-8')
+            log_entry['private_key'] = b64encode(private_key).decode('utf-8')
 
         if poison_key:
             public_key = base.read_poison_public_key(base.KEYS_FOLDER.name)
             private_key = base.read_poison_private_key(base.KEYS_FOLDER.name)
-            log_entry['public_key'] = b64encode(public_key).decode('ascii')
-            log_entry['private_key'] = b64encode(private_key).decode('ascii')
-            log_entry['poison_record'] = b64encode(base.get_poison_record()).decode('ascii')
+            log_entry['public_key'] = b64encode(public_key).decode('utf-8')
+            log_entry['private_key'] = b64encode(private_key).decode('utf-8')
+            log_entry['poison_record'] = b64encode(base.get_poison_record()).decode('utf-8')
 
         logging.debug("test log: {}".format(json.dumps(log_entry)))
 
@@ -568,7 +568,7 @@ class AcraTranslatorMixin(object):
             stub = api_pb2_grpc.WriterStub(channel)
             try:
                 response = stub.Encrypt(api_pb2.EncryptRequest(
-                    client_id=client_id.encode('ascii'), data=data),
+                    client_id=client_id.encode('utf-8'), data=data),
                     timeout=base.SOCKET_CONNECT_TIMEOUT)
             except grpc.RpcError as exc:
                 logging.info(exc)
@@ -580,7 +580,7 @@ class AcraTranslatorMixin(object):
             stub = api_pb2_grpc.ReaderStub(channel)
             try:
                 response = stub.Decrypt(api_pb2.DecryptRequest(
-                    client_id=client_id.encode('ascii'), acrastruct=acrastruct),
+                    client_id=client_id.encode('utf-8'), acrastruct=acrastruct),
                     timeout=base.SOCKET_CONNECT_TIMEOUT)
             except grpc.RpcError as exc:
                 logging.info(exc)
@@ -1102,7 +1102,7 @@ class AcraTranslatorTest(AcraTranslatorMixin, BaseTestCase):
             self.assertEqual(base.create_client_keypair_from_certificate(tls_cert=base.TEST_TLS_CLIENT_CERT,
                                                                          extractor=self.get_identifier_extractor_type(),
                                                                          keys_dir=key_folder.name), 0)
-            data = base.get_pregenerated_random_data().encode('ascii')
+            data = base.get_pregenerated_random_data().encode('utf-8')
             client_id_private_key = base.read_storage_private_key(key_folder.name, client_id)
             connection_string = 'tcp://127.0.0.1:{}'.format(translator_port)
             translator_kwargs = {
@@ -1140,7 +1140,7 @@ class AcraTranslatorTest(AcraTranslatorMixin, BaseTestCase):
             self.assertEqual(base.create_client_keypair_from_certificate(tls_cert=base.TEST_TLS_CLIENT_CERT,
                                                                          extractor=self.get_identifier_extractor_type(),
                                                                          keys_dir=key_folder.name), 0)
-            data = base.get_pregenerated_random_data().encode('ascii')
+            data = base.get_pregenerated_random_data().encode('utf-8')
             encryption_key = base.read_storage_public_key(client_id, keys_dir=key_folder.name)
             acrastruct = base.create_acrastruct(data, encryption_key)
             connection_string = 'tcp://127.0.0.1:{}'.format(translator_port)
@@ -1167,7 +1167,7 @@ class AcraTranslatorTest(AcraTranslatorMixin, BaseTestCase):
 
     def testHTTPSApiResponses(self):
         translator_port = 3456
-        data = base.get_pregenerated_random_data().encode('ascii')
+        data = base.get_pregenerated_random_data().encode('utf-8')
         encryption_key = base.read_storage_public_key(
             base.TLS_CERT_CLIENT_ID_1, keys_dir=base.KEYS_FOLDER.name)
         acrastruct = base.create_acrastruct(data, encryption_key)
@@ -1259,11 +1259,11 @@ class HexFormatTest(BaseTestCase):
         server_public1 = base.read_storage_public_key(client_id, base.KEYS_FOLDER.name)
         data = base.get_pregenerated_random_data()
         acra_struct = base.create_acrastruct(
-            data.encode('ascii'), server_public1)
+            data.encode('utf-8'), server_public1)
         row_id = base.get_random_id()
 
         self.log(storage_client_id=client_id,
-                 data=acra_struct, expected=data.encode('ascii'))
+                 data=acra_struct, expected=data.encode('utf-8'))
 
         self.engine1.execute(
             base.test_table.insert(),
@@ -1279,7 +1279,7 @@ class HexFormatTest(BaseTestCase):
             sa.select([base.test_table])
             .where(base.test_table.c.id == row_id))
         row = result.fetchone()
-        self.assertNotEqual(row['data'].decode('ascii', errors='ignore'),
+        self.assertNotEqual(row['data'].decode('utf-8', errors='ignore'),
                             row['raw_data'])
         self.assertEqual(row['empty'], b'')
 
@@ -1287,7 +1287,7 @@ class HexFormatTest(BaseTestCase):
             sa.select([base.test_table])
             .where(base.test_table.c.id == row_id))
         row = result.fetchone()
-        self.assertNotEqual(row['data'].decode('ascii', errors='ignore'),
+        self.assertNotEqual(row['data'].decode('utf-8', errors='ignore'),
                             row['raw_data'])
         self.assertEqual(row['empty'], b'')
 
@@ -1301,16 +1301,16 @@ class HexFormatTest(BaseTestCase):
         suffix_data = base.get_pregenerated_random_data()[:10]
         fake_offset = (3 + 45 + 84) - 4
         fake_acra_struct = base.create_acrastruct(
-            incorrect_data.encode('ascii'), server_public1)[:fake_offset]
+            incorrect_data.encode('utf-8'), server_public1)[:fake_offset]
         inner_acra_struct = base.create_acrastruct(
-            correct_data.encode('ascii'), server_public1)
-        data = fake_acra_struct + inner_acra_struct + suffix_data.encode('ascii')
+            correct_data.encode('utf-8'), server_public1)
+        data = fake_acra_struct + inner_acra_struct + suffix_data.encode('utf-8')
         correct_data = correct_data + suffix_data
         row_id = base.get_random_id()
 
         self.log(storage_client_id=client_id,
                  data=data,
-                 expected=fake_acra_struct + correct_data.encode('ascii'))
+                 expected=fake_acra_struct + correct_data.encode('utf-8'))
 
         self.engine1.execute(
             base.test_table.insert(),
@@ -1333,7 +1333,7 @@ class HexFormatTest(BaseTestCase):
             sa.select([base.test_table])
             .where(base.test_table.c.id == row_id))
         row = result.fetchone()
-        self.assertNotEqual(row['data'][fake_offset:].decode('ascii', errors='ignore'),
+        self.assertNotEqual(row['data'][fake_offset:].decode('utf-8', errors='ignore'),
                             row['raw_data'])
         self.assertEqual(row['empty'], b'')
 
@@ -1341,7 +1341,7 @@ class HexFormatTest(BaseTestCase):
             sa.select([base.test_table])
             .where(base.test_table.c.id == row_id))
         row = result.fetchone()
-        self.assertNotEqual(row['data'][fake_offset:].decode('ascii', errors='ignore'),
+        self.assertNotEqual(row['data'][fake_offset:].decode('utf-8', errors='ignore'),
                             row['raw_data'])
         self.assertEqual(row['empty'], b'')
 
@@ -1384,7 +1384,7 @@ class TestKeyRotation(BaseTestCase):
             row_id = base.get_random_id()
             data = base.get_pregenerated_random_data()
             public_key = self.read_rotation_public_key()
-            acra_struct = base.create_acrastruct(data.encode('ascii'), public_key)
+            acra_struct = base.create_acrastruct(data.encode('utf-8'), public_key)
             self.engine1.execute(
                 base.test_table.insert(),
                 {'id': row_id, 'data': acra_struct, 'raw_data': data})
@@ -1453,7 +1453,7 @@ class TestTranslatorDisableCachedOnStartup(AcraTranslatorMixin, BaseTestCase):
         self.assertEqual(base.create_client_keypair_from_certificate(tls_cert=base.TEST_TLS_CLIENT_CERT,
                                                                      extractor=self.get_identifier_extractor_type(),
                                                                      keys_dir=self.cached_dir.name), 0)
-        data = base.get_pregenerated_random_data().encode('ascii')
+        data = base.get_pregenerated_random_data().encode('utf-8')
         client_id_private_key = base.read_storage_private_key(self.cached_dir.name, client_id)
         connection_string = 'tcp://127.0.0.1:{}'.format(translator_port)
         translator_kwargs = {

--- a/tests/test_searchable_transparent_encryption.py
+++ b/tests/test_searchable_transparent_encryption.py
@@ -60,10 +60,10 @@ class TestTransparentEncryption(BaseTransparentEncryption):
     def get_context_data(self):
         context = {
             'id': base.get_random_id(),
-            'default_client_id': base.get_pregenerated_random_data().encode('ascii'),
+            'default_client_id': base.get_pregenerated_random_data().encode('utf-8'),
             'number': base.get_random_id(),
-            'specified_client_id': base.get_pregenerated_random_data().encode('ascii'),
-            'raw_data': base.get_pregenerated_random_data().encode('ascii'),
+            'specified_client_id': base.get_pregenerated_random_data().encode('utf-8'),
+            'raw_data': base.get_pregenerated_random_data().encode('utf-8'),
             'empty': b'',
         }
         return context
@@ -209,8 +209,8 @@ class TestTransparentAcraBlockEncryption(TestTransparentEncryption):
         data = {'specified_client_id': specified_acrastruct,
                 'default_client_id': default_acrastruct,
                 'id': row_id,
-                'masked_prefix': base.get_pregenerated_random_data().encode('ascii'),
-                'token_bytes': base.get_pregenerated_random_data().encode('ascii'),
+                'masked_prefix': base.get_pregenerated_random_data().encode('utf-8'),
+                'token_bytes': base.get_pregenerated_random_data().encode('utf-8'),
                 'token_str': base.get_pregenerated_random_data(),
                 'token_i64': base.random.randint(0, 2 ** 32),
                 }
@@ -422,16 +422,16 @@ class BaseSearchableTransparentEncryption(TestTransparentEncryption):
     def get_context_data(self):
         context = {
             'id': base.get_random_id(),
-            'default_client_id': base.get_pregenerated_random_data().encode('ascii'),
+            'default_client_id': base.get_pregenerated_random_data().encode('utf-8'),
             'number': base.get_random_id(),
-            'specified_client_id': base.get_pregenerated_random_data().encode('ascii'),
-            'raw_data': base.get_pregenerated_random_data().encode('ascii'),
-            'searchable': base.get_pregenerated_random_data().encode('ascii'),
-            'searchable_acrablock': base.get_pregenerated_random_data().encode('ascii'),
+            'specified_client_id': base.get_pregenerated_random_data().encode('utf-8'),
+            'raw_data': base.get_pregenerated_random_data().encode('utf-8'),
+            'searchable': base.get_pregenerated_random_data().encode('utf-8'),
+            'searchable_acrablock': base.get_pregenerated_random_data().encode('utf-8'),
             'empty': b'',
             'nullable': None,
-            'masking': base.get_pregenerated_random_data().encode('ascii'),
-            'token_bytes': base.get_pregenerated_random_data().encode('ascii'),
+            'masking': base.get_pregenerated_random_data().encode('utf-8'),
+            'token_bytes': base.get_pregenerated_random_data().encode('utf-8'),
             'token_email': base.get_pregenerated_random_data(),
             'token_str': base.get_pregenerated_random_data(),
             'token_i32': base.random.randint(0, 2 ** 16),
@@ -1233,7 +1233,7 @@ class TestSearchableTransparentEncryptionWithJOINs(BaseSearchableTransparentEncr
         self.insertRow(context)
         self.insertDifferentRows(context, count=5)
 
-        search_term_join = base.get_pregenerated_random_data().encode('ascii')
+        search_term_join = base.get_pregenerated_random_data().encode('utf-8')
         context['searchable'] = search_term_join
 
         # Insert the same data into encryptor_table_join table with different search term

--- a/tests/test_tokenization.py
+++ b/tests/test_tokenization.py
@@ -1082,7 +1082,7 @@ class TestMasking(BaseMasking):
             self.assertEqual(source_data[0][i], data[i])
 
         hidden_data = hidden_data[0]
-        mask_pattern = 'xxxx'.encode('ascii')
+        mask_pattern = 'xxxx'.encode('utf8')
         # check that mask at correct place
         self.assertEqual(hidden_data['masked_prefix'][:len(mask_pattern)], mask_pattern)
         # check that len of masked value not equal to source data because acrastruct always longer than plaintext
@@ -1162,7 +1162,7 @@ class TestMasking(BaseMasking):
             self.assertEqual(source_data[0][i], data[i])
 
         hidden_data = hidden_data[0]
-        mask_pattern = 'xxxx'.encode('ascii')
+        mask_pattern = 'xxxx'.encode('utf-8')
         # check that mask at correct place
         self.assertEqual(hidden_data['masked_prefix'][:len(mask_pattern)], mask_pattern)
         # check that len of masked value not equal to source data because acrastruct always longer than plaintext


### PR DESCRIPTION
- updated `DecodeOctal` function to operate with runes instead of bytes. previously it returned error on any not printable symbol that applies to every unicode symbol
- updated PostgreSQL data coder/decoder. now it uses info from the ColumnEncryptionSetting and always encodes into hex/octal format if destination type is not specified as text. Acra expects bytea/blob type on database side and default dest type is binary. Postgresql's bytea type expects hex/octal string, it doesn't work with escaped strings `E''`
- updated integration tests to use unicode strings

## Checklist

- [x] Change is covered by automated tests
- [x] The [coding guidelines] are followed
- [x] Public API has proper documentation in the [Acra documentation] site or has PR on [documentation repository] 
  with new changes
- [x] CHANGELOG.md is updated (in case of notable or breaking changes)
- [x] CHANGELOG_DEV.md is updated
- [x] Benchmark results are attached (if applicable)
- [x] [Example projects and code samples] are up-to-date (in case of API changes) 

[coding guidelines]: https://golang.org/doc/effective_go
[Example projects and code samples]: https://github.com/cossacklabs/acra-engineering-demo
[Acra documentation]: https://docs.cossacklabs.com/
[documentation repository]: https://github.com/cossacklabs/product-docs