### PR TITLE
Fixed example encryptor_config file

### DIFF
--- a/examples/python/encryptor_config.yaml
+++ b/examples/python/encryptor_config.yaml
@@ -50,4 +50,4 @@ schemas:
       - column: data
         data_type: bytes
         # base64 bytes value `test-data`
-        default_data_value: dGVzdC1kYXRhCg
+        default_data_value: dGVzdC1kYXRh


### PR DESCRIPTION
Fix incorrect b64 value from `examples/python/encryptor_config.yaml` file.

## Checklist

- [ ] Change is covered by automated tests
- [ ] The [coding guidelines] are followed
- [ ] Public API has proper documentation in the [Acra documentation] site or has PR on [documentation repository] 
  with new changes
- [ ] CHANGELOG.md is updated (in case of notable or breaking changes)
- [ ] CHANGELOG_DEV.md is updated
- [ ] Benchmark results are attached (if applicable)
- [ ] [Example projects and code samples] are up-to-date (in case of API changes) 

[coding guidelines]: https://golang.org/doc/effective_go
[Example projects and code samples]: https://github.com/cossacklabs/acra-engineering-demo
[Acra documentation]: https://docs.cossacklabs.com/
[documentation repository]: https://github.com/cossacklabs/product-docs