### PR TITLE
Fixed flaky SIGHUP test

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -4373,7 +4373,6 @@ class TestSigHUPHandler(AcraTranslatorMixin, BaseTestCase):
         descriptors
         '''
         acra_args = self.get_acra_cli_args({})
-        # acra_args['incoming_connection_close_timeout'] = 10
         temp_keystore = self.copy_keystore()
         config = load_yaml_config('configs/acra-server.yaml')
         config.update(acra_args)


### PR DESCRIPTION
Added explicit waiter for forked process from the logs. Sometimes, a new connection from the test comes to the parent process but not to the child, which is not expected bevaviour. It causes the connection drops by the parent process and the test fails.

## Checklist

- [ ] Change is covered by automated tests
- [ ] The [coding guidelines] are followed
- [ ] Public API has proper documentation in the [Acra documentation] site or has PR on [documentation repository] 
  with new changes
- [ ] CHANGELOG.md is updated (in case of notable or breaking changes)
- [ ] CHANGELOG_DEV.md is updated
- [ ] Benchmark results are attached (if applicable)
- [ ] [Example projects and code samples] are up-to-date (in case of API changes) 

[coding guidelines]: https://golang.org/doc/effective_go
[Example projects and code samples]: https://github.com/cossacklabs/acra-engineering-demo
[Acra documentation]: https://docs.cossacklabs.com/
[documentation repository]: https://github.com/cossacklabs/product-docs