### PR TITLE
Fix typo of log file path

### DIFF
--- a/cmd/acra-server/acra-server.go
+++ b/cmd/acra-server/acra-server.go
@@ -151,7 +151,7 @@ func registerFlags(flagSet *flag.FlagSet) {
 	flagSet.Bool("v", false, "Log to stderr all INFO, WARNING and ERROR logs")
 	flagSet.Bool("d", false, "Log everything to stderr")
 	flagSet.Bool("log_to_console", true, "Log to stderr if true")
-	flagSet.String("log_to_file", "", "Log to file if pass not empty value")
+	flagSet.String("log_to_file", "", "Log to file if path not empty value")
 
 	network.RegisterTLSBaseArgs(flagSet)
 	network.RegisterTLSArgsForService(flagSet, false, "", network.ClientNameConstructorFunc())

--- a/configs/acra-server.yaml
+++ b/configs/acra-server.yaml
@@ -152,7 +152,7 @@ kms_type:
 # Log to stderr if true
 log_to_console: true
 
-# Log to file if pass not empty value
+# Log to file if path not empty value
 log_to_file: 
 
 # Logging format: plaintext, json or CEF

--- a/configs/acra-server.yaml
+++ b/configs/acra-server.yaml
@@ -152,7 +152,7 @@ kms_type:
 # Log to stderr if true
 log_to_console: true
 
-# Log to file if path not empty value
+# Log to file if pass not empty value
 log_to_file: 
 
 # Logging format: plaintext, json or CEF


### PR DESCRIPTION
Hey! 
I got a bit baffled by 'pass' which I believe means 'path' of the log file. Hope it helps!
